### PR TITLE
테스트 및 커버리지 측정 자동화

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -64,22 +64,17 @@ jobs:
         id: check_coverage
         run: |
           FILE_PATH="${{ github.workspace }}/build/reports/jacoco/test/jacocoTestReport.xml"
-          if [ -f "$FILE_PATH" ]; then #파일 존재 여부
-            if [ -s "$FILE_PATH" ]; then #파일 내부존재 여부
-              echo "Coverage report exists and is not empty."
-              echo "::set-output name=exists::true"
-            else
-              echo "Coverage report is empty."
-              echo "::set-output name=exists::false"
-            fi
+          if [ -s "$FILE_PATH" ] && grep -q "<counter type=\"LINE\" missed=\"0\"" "$FILE_PATH"; then
+            echo "Coverage report exists and is not empty with coverage."
+            echo "::set-output name=exists::true"
           else
-            echo "Coverage report does not exist."
+            echo "Coverage report exists but has no coverage or is empty."
             echo "::set-output name=exists::false"
           fi
             
       #테스트 커버리지 리포트 출력
       - name: Add coverage to PR
-        if: env.exists == 'true'
+        if: steps.check_coverage.outputs.exists == 'true'
         id: jacoco
         uses: madrapps/jacoco-report@v1.2
         with:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
 
     steps:
       - name: Checkout
@@ -53,3 +55,13 @@ jobs:
         with:
           report_paths: '**/build/test-results/test/TEST-*.xml'
           token: ${{ github.token }}
+
+      - name: Add coverage to PR
+        id: jacoco
+        uses: madrapps/jacoco-report@v1.2
+        with:
+          title: 📝 테스트 커버리지 리포트입니다
+          paths: ${{ github.workspace }}/backend/build/reports/jacoco/test/jacocoTestReport.xml
+          token: ${{ secrets.TEST_TOKEN }}
+          min-coverage-overall: 50
+          min-coverage-changed-files: 50

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -43,14 +43,6 @@ jobs:
       - name: Build and Test with Gradle
         run: ./gradlew clean build test jacocoTestReport
 
-      #테스트 결과 출력
-      - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
-        if: always()
-        with:
-          files: '**/build/test-results/test/TEST-*.xml'
-          token: ${{ secrets.GITHUB_TOKEN }}
-
       #실패시 실패 코드에 코멘트
       - name: If the test fails, register a check comment in the failed code line
         uses: mikepenz/action-junit-report@v3

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+      contents: write
+      checks: write
 
     steps:
       - name: Checkout

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -61,14 +61,17 @@ jobs:
           
       #테스트 커버리지 리포트 생성 확인
       - name: Check if coverage report exists
+        id: check_coverage
         run: |
-          if [ ! -f ${{ github.workspace }}/build/reports/jacoco/test/jacocoTestReport.xml ]; then
-            echo "Jacoco 테스트 커버리지 리포트가 없습니다. 빌드를 종료합니다."
-            exit 1
+          if [ -f "${{ github.workspace }}/build/reports/jacoco/test/jacocoTestReport.xml" ]; then
+            echo "exists=true" >> $GITHUB_ENV
+          else
+            echo "exists=false" >> $GITHUB_ENV
           fi
             
       #테스트 커버리지 리포트 출력
       - name: Add coverage to PR
+        if: env.exists == 'true'
         id: jacoco
         uses: madrapps/jacoco-report@v1.2
         with:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -60,13 +60,21 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           
       #테스트 커버리지 리포트 생성 확인
-      - name: Check if coverage report exists
+      - name: Check if coverage report exists and is valid
         id: check_coverage
         run: |
-          if [ -f "${{ github.workspace }}/build/reports/jacoco/test/jacocoTestReport.xml" ]; then
-            echo "exists=true" >> $GITHUB_ENV
+          FILE_PATH="${{ github.workspace }}/build/reports/jacoco/test/jacocoTestReport.xml"
+          if [ -f "$FILE_PATH" ]; then #파일 존재 여부
+            if [ -s "$FILE_PATH" ]; then #파일 내부존재 여부
+              echo "Coverage report exists and is not empty."
+              echo "::set-output name=exists::true"
+            else
+              echo "Coverage report is empty."
+              echo "::set-output name=exists::false"
+            fi
           else
-            echo "exists=false" >> $GITHUB_ENV
+            echo "Coverage report does not exist."
+            echo "::set-output name=exists::false"
           fi
             
       #테스트 커버리지 리포트 출력

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -58,7 +58,16 @@ jobs:
         with:
           report_paths: '**/build/test-results/test/TEST-*.xml'
           token: ${{ secrets.GITHUB_TOKEN }}
-
+          
+      #테스트 커버리지 리포트 생성 확인
+      - name: Check if coverage report exists
+        run: |
+          if [ ! -f ${{ github.workspace }}/build/reports/jacoco/test/jacocoTestReport.xml ]; then
+            echo "Jacoco 테스트 커버리지 리포트가 없습니다. 빌드를 종료합니다."
+            exit 1
+          fi
+            
+      #테스트 커버리지 리포트 출력
       - name: Add coverage to PR
         id: jacoco
         uses: madrapps/jacoco-report@v1.2

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -63,8 +63,8 @@ jobs:
         id: jacoco
         uses: madrapps/jacoco-report@v1.2
         with:
-          title: 📝 테스트 커버리지 리포트입니다
-          paths: ${{ github.workspace }}/backend/build/reports/jacoco/test/jacocoTestReport.xml
+          title: 📝 테스트 커버리지 리포트입니다!
+          paths: ${{ github.workspace }}/build/reports/jacoco/test/jacocoTestReport.xml
           token: ${{ secrets.GITHUB_TOKEN }}
           min-coverage-overall: 50
           min-coverage-changed-files: 50

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,8 +1,6 @@
-name: Backend CI Test Automation
+name: Build and Test with Coverage
+
 on:
-  push:
-    branches:
-      - develop
   pull_request:
     branches:
       - main
@@ -11,6 +9,7 @@ on:
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -27,16 +26,28 @@ jobs:
       - name: Make gradlew executable
         run: chmod +x gradlew
 
-      - name: Test with Gradle Wrapper
-        run: ./gradlew clean build
+      #라이브러리 캐싱
+      - name: Cache Gradle dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
 
-      - name: Publish Unit Test Results #성공시 테스트 결과 출력
+      #Gradle 빌드 및 테스트
+      - name: Build and Test with Gradle
+        run: ./gradlew clean build test jacocoTestReport
+
+      #테스트 결과 출력
+      - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()
         with:
           files: '**/build/test-results/test/TEST-*.xml'
 
-      - name: If the test fails, register a check comment in the failed code line #실패시 실패 코드에 코멘트
+      #실패시 실패 코드에 코멘트
+      - name: If the test fails, register a check comment in the failed code line
         uses: mikepenz/action-junit-report@v3
         if: always()
         with:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -47,6 +47,7 @@ jobs:
         if: always()
         with:
           files: '**/build/test-results/test/TEST-*.xml'
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       #실패시 실패 코드에 코멘트
       - name: If the test fails, register a check comment in the failed code line
@@ -54,7 +55,7 @@ jobs:
         if: always()
         with:
           report_paths: '**/build/test-results/test/TEST-*.xml'
-          token: ${{ github.token }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Add coverage to PR
         id: jacoco
@@ -62,6 +63,6 @@ jobs:
         with:
           title: 📝 테스트 커버리지 리포트입니다
           paths: ${{ github.workspace }}/backend/build/reports/jacoco/test/jacocoTestReport.xml
-          token: ${{ secrets.TEST_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           min-coverage-overall: 50
           min-coverage-changed-files: 50

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,44 @@
+name: Backend CI Test Automation
+on:
+  push:
+    branches:
+      - develop
+  pull_request:
+    branches:
+      - main
+      - develop
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          token: ${{secrets.CONFIG_SUBMODULE_TOKEN}}
+          submodules: true
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Make gradlew executable
+        run: chmod +x gradlew
+
+      - name: Test with Gradle Wrapper
+        run: ./gradlew clean build
+
+      - name: Publish Unit Test Results #성공시 테스트 결과 출력
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: always()
+        with:
+          files: '**/build/test-results/test/TEST-*.xml'
+
+      - name: If the test fails, register a check comment in the failed code line #실패시 실패 코드에 코멘트
+        uses: mikepenz/action-junit-report@v3
+        if: always()
+        with:
+          report_paths: '**/build/test-results/test/TEST-*.xml'
+          token: ${{ github.token }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           token: ${{secrets.CONFIG_SUBMODULE_TOKEN}}
-          submodules: true
+          submodules: recursive
 
       - name: Set up JDK 17
         uses: actions/setup-java@v3

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.4.1'
 	id 'io.spring.dependency-management' version '1.1.7'
+	id 'jacoco'
 }
 
 group = 'com.dnd'
@@ -11,6 +12,14 @@ java {
 	toolchain {
 		languageVersion = JavaLanguageVersion.of(17)
 	}
+}
+
+test {
+	finalizedBy jacocoTestReport
+}
+
+jacoco {
+	toolVersion = "0.8.8"
 }
 
 configurations {
@@ -37,4 +46,12 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+jacocoTestReport {
+	dependsOn test
+	reports {
+		xml.enabled true
+		html.enabled true
+	}
 }

--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,19 @@ tasks.named('test') {
 jacocoTestReport {
 	dependsOn test
 	reports {
-		xml.enabled true
-		html.enabled true
+		xml.required =  true
+		html.required =  true
+	}
+	afterEvaluate {
+		classDirectories.setFrom(
+				files(
+						classDirectories.files.collect {
+							fileTree(dir: it).matching {
+								include '**/service/**'
+								include '**/domain/**'
+							}
+						}
+				)
+		)
 	}
 }


### PR DESCRIPTION
### #️⃣연관된 이슈
#7 
### 🔀반영 브랜치
ci/#7-test-runner-with-coverage -> develop

### 🔧변경 사항
- main과 develop branch에 PR을 날릴때 해당 워크플로우가 동작합니다.
- 테스트 결과를 코멘트로 아래와 같이 볼 수 있습니다.
<img src = "https://github.com/user-attachments/assets/d150b1c1-b13b-4c3a-ba9a-8e61055e8512" alt ="test result" width = "70%" />

- 테스트 실패시 실패한 코드에 코멘트를 남겨 어디서 실패했는지 확인할 수 있습니다.
- Jacoco를 활용하여 서비스 클래스와 엔티티 클래스의 커버리지 측정하고 아래와 같이 보여줄 수 있습니다. 
<img src = "https://github.com/user-attachments/assets/4651edd0-b50a-4bc2-9f25-506983c3b249" alt = "example" width = "70%" />

### 💬리뷰 요구사항(선택)
- 테스트 결과랑 커버리지를 모두 코멘트로 뜨게 될 것 같은데 그러면 보여주는 정보가 많아서 테스트 결과는 테스트 실패시만 보여줘야할까 고민중인데 어떻게 생각하시나요..!
- 현재 실패한 상태인데 JaCoco를 통해 측정할 테스트 커버리지가 없다보니 테스트 레포트가 비어있어서 발생하는 현상입니다.
