### PR TITLE
예외처리 설정 추가

### DIFF
--- a/src/main/java/com/dnd/moddo/global/exception/ErrorResponse.java
+++ b/src/main/java/com/dnd/moddo/global/exception/ErrorResponse.java
@@ -1,0 +1,15 @@
+package com.dnd.moddo.global.exception;
+
+public record ErrorResponse(
+        int status,
+        String message
+
+) {
+    @Override
+    public String toString() {
+        return "{\n" +
+                "\t\"status\": " + status +
+                ",\n\t\"message\": \"" + message + '\"' +
+                "\n}";
+    }
+}

--- a/src/main/java/com/dnd/moddo/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/dnd/moddo/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,43 @@
+package com.dnd.moddo.global.exception;
+
+import com.dnd.moddo.global.logging.LoggingUtils;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler({ModdoException.class})
+    public ResponseEntity<ErrorResponse> handleDefineException(ModdoException exception) {
+        LoggingUtils.warn(exception);
+
+        return ResponseEntity.status(exception.getStatus())
+                .body(new ErrorResponse(exception.getStatus().value(), exception.getMessage()));
+    }
+
+    @ExceptionHandler({MethodArgumentNotValidException.class})
+    public ResponseEntity<ErrorResponse> handleDefineException(MethodArgumentNotValidException exception) {
+        LoggingUtils.warn(exception);
+
+        String message;
+
+        if (exception.getFieldError() == null) {
+            message = "";
+        } else {
+            message = exception.getFieldError().getDefaultMessage();
+        }
+
+        return ResponseEntity.status(400)
+                .body(new ErrorResponse(400, message));
+    }
+
+    @ExceptionHandler({RuntimeException.class})
+    public ResponseEntity<ErrorResponse> handleDefineException(RuntimeException exception) {
+        LoggingUtils.error(exception);
+
+        return ResponseEntity.status(500)
+                .body(new ErrorResponse(500, "서버에서 알 수 없는 에러가 발생했습니다."));
+    }
+}

--- a/src/main/java/com/dnd/moddo/global/exception/ModdoException.java
+++ b/src/main/java/com/dnd/moddo/global/exception/ModdoException.java
@@ -1,0 +1,12 @@
+package com.dnd.moddo.global.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public class ModdoException extends RuntimeException {
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/com/dnd/moddo/global/logging/LoggingUtils.java
+++ b/src/main/java/com/dnd/moddo/global/logging/LoggingUtils.java
@@ -1,0 +1,30 @@
+package com.dnd.moddo.global.logging;
+
+import com.dnd.moddo.global.exception.ModdoException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+
+@Slf4j
+public class LoggingUtils {
+    public static void warn(ModdoException exception) {
+        String message = getExceptionMessage(exception.getMessage());
+        log.warn(message + "\n \t {}", exception);
+    }
+
+    public static void warn(MethodArgumentNotValidException exception) {
+        String message = getExceptionMessage(exception.getMessage());
+        log.warn(message + "\n \t {}", exception);
+    }
+
+    private static String getExceptionMessage(String message) {
+        if (message == null || message.isBlank()) {
+            return "";
+        }
+        return message;
+    }
+
+    public static void error(RuntimeException exception) {
+        String message = getExceptionMessage(exception.getMessage());
+        log.error(message + "\n \t {}", exception);
+    }
+}


### PR DESCRIPTION
### #️⃣연관된 이슈
#19 

### 🔀반영 브랜치
feat/#19-set-moddo-exception -> develop

### 🔧변경 사항
- Global Exception Handling 추가
애플리케이션 전역에서 발생하는 예외를 일괄 처리하도록 설정했습니다.

- ErrorResponse 클래스 추가
예외 응답 표준화를 위해 ErrorResponse 레코드를 생성했습니다.

- ModdoException 커스텀 예외 클래스 생성

- LoggingUtils 추가
예외 발생 시 로깅을 통합 관리할 수 있도록 LoggingUtils 클래스를 추가했습니다.

### 💬리뷰 요구사항(선택)
