### PR TITLE
모임별 참여자 생성 및 조회 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,9 +42,6 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-    //junit
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.0'
-    testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.7.0'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -1,69 +1,72 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.4.1'
-	id 'io.spring.dependency-management' version '1.1.7'
-	id 'jacoco'
+    id 'java'
+    id 'org.springframework.boot' version '3.4.1'
+    id 'io.spring.dependency-management' version '1.1.7'
+    id 'jacoco'
 }
 
 group = 'com.dnd'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(17)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
 }
 
 test {
-	finalizedBy jacocoTestReport
+    finalizedBy jacocoTestReport
 }
 
 jacoco {
-	toolVersion = "0.8.8"
+    toolVersion = "0.8.8"
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.h2database:h2'
-	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    compileOnly 'org.projectlombok:lombok'
+    runtimeOnly 'com.h2database:h2'
+    runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    //junit
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.0'
+    testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.7.0'
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }
 
 jacocoTestReport {
-	dependsOn test
-	reports {
-		xml.required =  true
-		html.required =  true
-	}
-	afterEvaluate {
-		classDirectories.setFrom(
-				files(
-						classDirectories.files.collect {
-							fileTree(dir: it).matching {
-								include '**/service/**'
-								include '**/domain/**'
-							}
-						}
-				)
-		)
-	}
+    dependsOn test
+    reports {
+        xml.required = true
+        html.required = true
+    }
+    afterEvaluate {
+        classDirectories.setFrom(
+                files(
+                        classDirectories.files.collect {
+                            fileTree(dir: it).matching {
+                                include '**/service/**'
+                                include '**/domain/**'
+                            }
+                        }
+                )
+        )
+    }
 }

--- a/src/main/java/com/dnd/moddo/domain/groupMember/controller/GroupMemberController.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/controller/GroupMemberController.java
@@ -1,0 +1,43 @@
+package com.dnd.moddo.domain.groupMember.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.dnd.moddo.domain.groupMember.dto.request.GroupMembersSaveRequest;
+import com.dnd.moddo.domain.groupMember.dto.response.GroupMembersResponse;
+import com.dnd.moddo.domain.groupMember.service.CommandGroupMemberService;
+import com.dnd.moddo.domain.groupMember.service.QueryGroupMemberService;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/group-members")
+@RestController
+public class GroupMemberController {
+	private final QueryGroupMemberService queryGroupMemberService;
+	private final CommandGroupMemberService commandGroupMemberService;
+
+	@PostMapping
+	public ResponseEntity<GroupMembersResponse> saveGroupMembers(
+		@RequestParam("meetId") String token, //아마 토큰으로 받고 모임 Id
+		@RequestBody GroupMembersSaveRequest request
+	) {
+		Long meetId = 1L; //mock value
+		GroupMembersResponse response = commandGroupMemberService.createGroupMembers(meetId, request);
+		return ResponseEntity.ok(response);
+	}
+
+	@GetMapping
+	public ResponseEntity<GroupMembersResponse> getGroupMembers(
+		@RequestParam("meetId") String token
+	) {
+		Long meetId = 1L;
+		GroupMembersResponse response = queryGroupMemberService.findAll(meetId);
+		return ResponseEntity.ok(response);
+	}
+}

--- a/src/main/java/com/dnd/moddo/domain/groupMember/controller/GroupMemberController.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/controller/GroupMemberController.java
@@ -13,6 +13,7 @@ import com.dnd.moddo.domain.groupMember.dto.response.GroupMembersResponse;
 import com.dnd.moddo.domain.groupMember.service.CommandGroupMemberService;
 import com.dnd.moddo.domain.groupMember.service.QueryGroupMemberService;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -25,7 +26,7 @@ public class GroupMemberController {
 	@PostMapping
 	public ResponseEntity<GroupMembersResponse> saveGroupMembers(
 		@RequestParam("meetId") String token, //아마 토큰으로 받고 모임 Id
-		@RequestBody GroupMembersSaveRequest request
+		@Valid @RequestBody GroupMembersSaveRequest request
 	) {
 		Long meetId = 1L; //mock value
 		GroupMembersResponse response = commandGroupMemberService.createGroupMembers(meetId, request);

--- a/src/main/java/com/dnd/moddo/domain/groupMember/dto/request/GroupMemberSaveRequest.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/dto/request/GroupMemberSaveRequest.java
@@ -1,0 +1,10 @@
+package com.dnd.moddo.domain.groupMember.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record GroupMemberSaveRequest(
+	@NotBlank(message = "참여자 이름으로 공백은 입력할 수 없습니다.")
+	String name
+) {
+
+}

--- a/src/main/java/com/dnd/moddo/domain/groupMember/dto/request/GroupMembersSaveRequest.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/dto/request/GroupMembersSaveRequest.java
@@ -1,0 +1,15 @@
+package com.dnd.moddo.domain.groupMember.dto.request;
+
+import java.util.List;
+
+import com.dnd.moddo.domain.groupMember.entity.GroupMember;
+
+public record GroupMembersSaveRequest(
+	List<GroupMemberSaveRequest> members
+) {
+	public List<GroupMember> toEntity(Long meetId) {
+		return members.stream()
+			.map(m -> new GroupMember(m.name(), meetId))
+			.toList();
+	}
+}

--- a/src/main/java/com/dnd/moddo/domain/groupMember/dto/response/GroupMemberResponse.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/dto/response/GroupMemberResponse.java
@@ -1,0 +1,23 @@
+package com.dnd.moddo.domain.groupMember.dto.response;
+
+import com.dnd.moddo.domain.groupMember.entity.GroupMember;
+
+public record GroupMemberResponse(
+	Long id,
+	String name,
+	String profile,
+	boolean isPaid
+) {
+
+	public static GroupMemberResponse of(GroupMember groupMember) {
+		return new GroupMemberResponse(groupMember.getId(), groupMember.getName(),
+			generateProfileUrl(groupMember.getProfileId()), groupMember.isPaid());
+	}
+
+	private static String generateProfileUrl(Integer profile) {
+		if (profile == null) {
+			return "https://example.com/profiles/default.jpg";
+		}
+		return "https://example.com/profiles/" + profile + ".jpg";
+	}
+}

--- a/src/main/java/com/dnd/moddo/domain/groupMember/dto/response/GroupMembersResponse.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/dto/response/GroupMembersResponse.java
@@ -1,0 +1,13 @@
+package com.dnd.moddo.domain.groupMember.dto.response;
+
+import java.util.List;
+
+import com.dnd.moddo.domain.groupMember.entity.GroupMember;
+
+public record GroupMembersResponse(List<GroupMemberResponse> members) {
+	public static GroupMembersResponse of(List<GroupMember> members) {
+		return new GroupMembersResponse(members.stream()
+			.map(GroupMemberResponse::of)
+			.toList());
+	}
+}

--- a/src/main/java/com/dnd/moddo/domain/groupMember/entity/GroupMember.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/entity/GroupMember.java
@@ -1,0 +1,52 @@
+package com.dnd.moddo.domain.groupMember.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Table(name = "group_members")
+@Entity
+public class GroupMember {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(name = "name", updatable = false, nullable = false)
+	private String name;
+
+	@Column(name = "profile_id")
+	private Integer profileId;
+
+	@Column(name = "meet_id", updatable = false, nullable = false)
+	private Long meetId;
+
+	@Column(name = "is_paid", nullable = false)
+	private boolean isPaid;
+
+	public GroupMember(String name, Long meetId) {
+		this(null, name, null, meetId, false);
+	}
+
+	public GroupMember(String name, Integer profileId, Long meetId) {
+		this(null, name, profileId, meetId, false);
+	}
+
+	public GroupMember(Long id, String name, Integer profileId, Long meetId, boolean isPaid) {
+		this.id = id;
+		this.name = name;
+		this.profileId = profileId;
+		this.meetId = meetId;
+		this.isPaid = isPaid;
+	}
+
+}
+

--- a/src/main/java/com/dnd/moddo/domain/groupMember/repository/GroupMemberRepository.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/repository/GroupMemberRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.dnd.moddo.domain.groupMember.entity.GroupMember;
 
-public interface GroupMemberRespository extends JpaRepository<GroupMember, Long> {
+public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> {
 
 	List<GroupMember> findByMeetId(Long meetId);
 }

--- a/src/main/java/com/dnd/moddo/domain/groupMember/repository/GroupMemberRespository.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/repository/GroupMemberRespository.java
@@ -1,0 +1,12 @@
+package com.dnd.moddo.domain.groupMember.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.dnd.moddo.domain.groupMember.entity.GroupMember;
+
+public interface GroupMemberRespository extends JpaRepository<GroupMember, Long> {
+
+	List<GroupMember> findByMeetId(Long meetId);
+}

--- a/src/main/java/com/dnd/moddo/domain/groupMember/service/CommandGroupMemberService.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/service/CommandGroupMemberService.java
@@ -1,0 +1,25 @@
+package com.dnd.moddo.domain.groupMember.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.dnd.moddo.domain.groupMember.dto.request.GroupMembersSaveRequest;
+import com.dnd.moddo.domain.groupMember.dto.response.GroupMembersResponse;
+import com.dnd.moddo.domain.groupMember.entity.GroupMember;
+import com.dnd.moddo.domain.groupMember.service.implementation.GroupMemberCreator;
+import com.dnd.moddo.domain.groupMember.service.implementation.GroupMemberUpdator;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Service
+public class CommandGroupMemberService {
+	private final GroupMemberCreator groupMemberCreator;
+	private final GroupMemberUpdator groupMemberUpdator;
+
+	public GroupMembersResponse createGroupMembers(Long meetId, GroupMembersSaveRequest request) {
+		List<GroupMember> members = groupMemberCreator.createGroupMember(meetId, request);
+		return GroupMembersResponse.of(members);
+	}
+}

--- a/src/main/java/com/dnd/moddo/domain/groupMember/service/QueryGroupMemberService.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/service/QueryGroupMemberService.java
@@ -1,0 +1,22 @@
+package com.dnd.moddo.domain.groupMember.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.dnd.moddo.domain.groupMember.dto.response.GroupMembersResponse;
+import com.dnd.moddo.domain.groupMember.entity.GroupMember;
+import com.dnd.moddo.domain.groupMember.service.implementation.GroupMemberReader;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Service
+public class QueryGroupMemberService {
+	private final GroupMemberReader groupMemberReader;
+
+	public GroupMembersResponse findAll(Long meetId) {
+		List<GroupMember> members = groupMemberReader.getAll(meetId);
+		return GroupMembersResponse.of(members);
+	}
+}

--- a/src/main/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberCreator.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberCreator.java
@@ -1,0 +1,24 @@
+package com.dnd.moddo.domain.groupMember.service.implementation;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.dnd.moddo.domain.groupMember.dto.request.GroupMembersSaveRequest;
+import com.dnd.moddo.domain.groupMember.entity.GroupMember;
+import com.dnd.moddo.domain.groupMember.repository.GroupMemberRespository;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Service
+public class GroupMemberCreator {
+	private final GroupMemberRespository groupMemberRespository;
+
+	@Transactional
+	public List<GroupMember> createGroupMember(Long meetId, GroupMembersSaveRequest request) {
+		List<GroupMember> groupMembers = request.toEntity(meetId);
+		return groupMemberRespository.saveAll(groupMembers);
+	}
+}

--- a/src/main/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberCreator.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberCreator.java
@@ -7,18 +7,18 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.dnd.moddo.domain.groupMember.dto.request.GroupMembersSaveRequest;
 import com.dnd.moddo.domain.groupMember.entity.GroupMember;
-import com.dnd.moddo.domain.groupMember.repository.GroupMemberRespository;
+import com.dnd.moddo.domain.groupMember.repository.GroupMemberRepository;
 
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @Service
 public class GroupMemberCreator {
-	private final GroupMemberRespository groupMemberRespository;
+	private final GroupMemberRepository groupMemberRepository;
 
 	@Transactional
 	public List<GroupMember> createGroupMember(Long meetId, GroupMembersSaveRequest request) {
 		List<GroupMember> groupMembers = request.toEntity(meetId);
-		return groupMemberRespository.saveAll(groupMembers);
+		return groupMemberRepository.saveAll(groupMembers);
 	}
 }

--- a/src/main/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberReader.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberReader.java
@@ -1,0 +1,23 @@
+package com.dnd.moddo.domain.groupMember.service.implementation;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.dnd.moddo.domain.groupMember.entity.GroupMember;
+import com.dnd.moddo.domain.groupMember.repository.GroupMemberRespository;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Service
+@Transactional(readOnly = true)
+public class GroupMemberReader {
+	private final GroupMemberRespository groupMemberRespository;
+
+	public List<GroupMember> getAll(Long meetId) {
+		return groupMemberRespository.findByMeetId(meetId);
+	}
+
+}

--- a/src/main/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberReader.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberReader.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.dnd.moddo.domain.groupMember.entity.GroupMember;
-import com.dnd.moddo.domain.groupMember.repository.GroupMemberRespository;
+import com.dnd.moddo.domain.groupMember.repository.GroupMemberRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -14,10 +14,10 @@ import lombok.RequiredArgsConstructor;
 @Service
 @Transactional(readOnly = true)
 public class GroupMemberReader {
-	private final GroupMemberRespository groupMemberRespository;
+	private final GroupMemberRepository groupMemberRepository;
 
 	public List<GroupMember> getAll(Long meetId) {
-		return groupMemberRespository.findByMeetId(meetId);
+		return groupMemberRepository.findByMeetId(meetId);
 	}
 
 }

--- a/src/main/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberUpdator.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberUpdator.java
@@ -1,0 +1,16 @@
+package com.dnd.moddo.domain.groupMember.service.implementation;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.dnd.moddo.domain.groupMember.repository.GroupMemberRespository;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Service
+@Transactional
+public class GroupMemberUpdator {
+	private final GroupMemberRespository groupMemberRespository;
+	
+}

--- a/src/main/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberUpdator.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberUpdator.java
@@ -3,7 +3,7 @@ package com.dnd.moddo.domain.groupMember.service.implementation;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.dnd.moddo.domain.groupMember.repository.GroupMemberRespository;
+import com.dnd.moddo.domain.groupMember.repository.GroupMemberRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -11,6 +11,6 @@ import lombok.RequiredArgsConstructor;
 @Service
 @Transactional
 public class GroupMemberUpdator {
-	private final GroupMemberRespository groupMemberRespository;
-	
+	private final GroupMemberRepository groupMemberRepository;
+
 }

--- a/src/test/java/com/dnd/moddo/domain/groupMember/entity/GroupMemberTest.java
+++ b/src/test/java/com/dnd/moddo/domain/groupMember/entity/GroupMemberTest.java
@@ -1,0 +1,41 @@
+package com.dnd.moddo.domain.groupMember.entity;
+
+import static org.junit.Assert.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import com.dnd.moddo.domain.groupMember.repository.GroupMemberRepository;
+
+@RunWith(SpringRunner.class)
+@DataJpaTest
+class GroupMemberTest {
+
+	@Autowired
+	private GroupMemberRepository groupMemberRepository;
+
+	@DisplayName("모임로 참여자를 조회할 수 있다.")
+	@Test
+	public void findByMeetId() {
+		// Given
+		GroupMember groupMember1 = new GroupMember("김완숙", 1, 1L);
+		GroupMember groupMember2 = new GroupMember("정에그", 2, 1L);
+		groupMemberRepository.save(groupMember1);
+		groupMemberRepository.save(groupMember2);
+
+		// When
+		List<GroupMember> groupMembers = groupMemberRepository.findByMeetId(1L);
+
+		// Then
+		assertEquals(2, groupMembers.size());  // meetId가 1인 멤버가 2명 있는지 확인
+		assertTrue(groupMembers.stream().anyMatch(member -> "김완숙".equals(member.getName())));
+		assertTrue(groupMembers.stream().anyMatch(member -> "정에그".equals(member.getName())));
+	}
+
+}

--- a/src/test/java/com/dnd/moddo/domain/groupMember/entity/GroupMemberTest.java
+++ b/src/test/java/com/dnd/moddo/domain/groupMember/entity/GroupMemberTest.java
@@ -1,20 +1,20 @@
 package com.dnd.moddo.domain.groupMember.entity;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.AssertionsForClassTypes.*;
 
 import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import com.dnd.moddo.domain.groupMember.repository.GroupMemberRepository;
 
-@RunWith(SpringRunner.class)
-@DataJpaTest
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
 class GroupMemberTest {
 
 	@Autowired
@@ -33,9 +33,9 @@ class GroupMemberTest {
 		List<GroupMember> groupMembers = groupMemberRepository.findByMeetId(1L);
 
 		// Then
-		assertEquals(2, groupMembers.size());  // meetId가 1인 멤버가 2명 있는지 확인
-		assertTrue(groupMembers.stream().anyMatch(member -> "김완숙".equals(member.getName())));
-		assertTrue(groupMembers.stream().anyMatch(member -> "정에그".equals(member.getName())));
+		assertThat(groupMembers.size()).isEqualTo(2);  // meetId가 1인 멤버가 2명 있는지 확인
+		assertThat(groupMembers.stream().anyMatch(member -> "김완숙".equals(member.getName()))).isTrue();
+		assertThat(groupMembers.stream().anyMatch(member -> "정에그".equals(member.getName()))).isTrue();
 	}
 
 }

--- a/src/test/java/com/dnd/moddo/domain/groupMember/service/CommandGroupMemberServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/groupMember/service/CommandGroupMemberServiceTest.java
@@ -1,0 +1,48 @@
+package com.dnd.moddo.domain.groupMember.service;
+
+import static org.assertj.core.api.BDDAssertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.dnd.moddo.domain.groupMember.dto.request.GroupMembersSaveRequest;
+import com.dnd.moddo.domain.groupMember.dto.response.GroupMembersResponse;
+import com.dnd.moddo.domain.groupMember.entity.GroupMember;
+import com.dnd.moddo.domain.groupMember.service.implementation.GroupMemberCreator;
+import com.dnd.moddo.domain.groupMember.service.implementation.GroupMemberUpdator;
+
+@ExtendWith(MockitoExtension.class)
+public class CommandGroupMemberServiceTest {
+	@Mock
+	private GroupMemberCreator groupMemberCreator;
+	@Mock
+	private GroupMemberUpdator groupMemberUpdator;
+	@InjectMocks
+	private CommandGroupMemberService commandGroupMemberService;
+
+	@Test
+	public void createGroupMembers() {
+		//given
+		Long meetId = 1L;
+		GroupMembersSaveRequest request = new GroupMembersSaveRequest(new ArrayList<>());
+		List<GroupMember> mockMembers = List.of(new GroupMember("김반숙", 1, meetId));
+
+		when(groupMemberCreator.createGroupMember(eq(meetId), eq(request))).thenReturn(mockMembers);
+
+		// when
+		GroupMembersResponse response = commandGroupMemberService.createGroupMembers(meetId, request);
+
+		//then
+		assertThat(response).isNotNull();
+		assertThat(response.members().size()).isEqualTo(1);
+		assertThat(response.members().get(0).name()).isEqualTo("김반숙");
+		verify(groupMemberCreator, times(1)).createGroupMember(eq(meetId), eq(request));
+	}
+}

--- a/src/test/java/com/dnd/moddo/domain/groupMember/service/QueryGroupMemberServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/groupMember/service/QueryGroupMemberServiceTest.java
@@ -1,0 +1,42 @@
+package com.dnd.moddo.domain.groupMember.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.dnd.moddo.domain.groupMember.dto.response.GroupMembersResponse;
+import com.dnd.moddo.domain.groupMember.entity.GroupMember;
+import com.dnd.moddo.domain.groupMember.service.implementation.GroupMemberReader;
+
+@ExtendWith(MockitoExtension.class)
+public class QueryGroupMemberServiceTest {
+
+	@Mock
+	private GroupMemberReader groupMemberReader;
+	@InjectMocks
+	private QueryGroupMemberService queryGroupMemberService;
+
+	@Test
+	public void findAll() {
+		//given
+		Long meetId = 1L;
+		List<GroupMember> mockMembers = List.of(new GroupMember("김반숙", 1, meetId));
+
+		when(groupMemberReader.getAll(eq(meetId))).thenReturn(mockMembers);
+		//when
+		GroupMembersResponse response = queryGroupMemberService.findAll(meetId);
+
+		//then
+		assertThat(response).isNotNull();
+		assertThat(response.members().size()).isEqualTo(1);
+		assertThat(response.members().get(0).name()).isEqualTo("김반숙");
+		verify(groupMemberReader, times(1)).getAll(eq(meetId));
+	}
+}

--- a/src/test/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberCreatorTest.java
+++ b/src/test/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberCreatorTest.java
@@ -1,0 +1,48 @@
+package com.dnd.moddo.domain.groupMember.service.implementation;
+
+import static org.assertj.core.api.BDDAssertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.dnd.moddo.domain.groupMember.dto.request.GroupMembersSaveRequest;
+import com.dnd.moddo.domain.groupMember.entity.GroupMember;
+import com.dnd.moddo.domain.groupMember.repository.GroupMemberRepository;
+
+@ExtendWith(MockitoExtension.class)
+public class GroupMemberCreatorTest {
+	@Mock
+	private GroupMemberRepository groupMemberRepository;
+
+	@InjectMocks
+	private GroupMemberCreator groupMemberCreator;
+
+	@Test
+	public void createGroupMember() {
+		//given
+		Long meetId = 1L;
+		GroupMembersSaveRequest request = new GroupMembersSaveRequest(new ArrayList<>());
+
+		List<GroupMember> expectedMembers = List.of(new GroupMember("김반숙", 1, meetId));
+
+		when(groupMemberRepository.saveAll(anyList())).thenReturn(expectedMembers);
+
+		//when
+		List<GroupMember> savedMembers = groupMemberCreator.createGroupMember(meetId, request);
+
+		//then
+		assertThat(savedMembers).isNotNull();
+		assertThat(savedMembers.size()).isEqualTo(1);
+		assertThat(savedMembers.get(0).getName()).isEqualTo("김반숙");
+		verify(groupMemberRepository, times(1)).saveAll(anyList());
+
+	}
+}

--- a/src/test/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberReaderTest.java
+++ b/src/test/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberReaderTest.java
@@ -1,0 +1,42 @@
+package com.dnd.moddo.domain.groupMember.service.implementation;
+
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.dnd.moddo.domain.groupMember.entity.GroupMember;
+import com.dnd.moddo.domain.groupMember.repository.GroupMemberRepository;
+
+@ExtendWith(MockitoExtension.class)
+public class GroupMemberReaderTest {
+	@Mock
+	private GroupMemberRepository groupMemberRepository;
+	@InjectMocks
+	private GroupMemberReader groupMemberReader;
+
+	@Test
+	public void getAll() {
+		//given
+		Long meetId = 1L;
+		List<GroupMember> expectedMembers = List.of(new GroupMember("김반숙", 1, meetId));
+
+		when(groupMemberRepository.findByMeetId(meetId)).thenReturn(expectedMembers);
+
+		//when
+		List<GroupMember> groupMembers = groupMemberReader.getAll(meetId);
+
+		//then
+		assertThat(groupMembers).isNotNull();
+		assertThat(groupMembers.size()).isEqualTo(1);
+		assertThat(groupMembers.get(0).getName()).isEqualTo("김반숙");
+		verify(groupMemberRepository, times(1)).findByMeetId(meetId);
+	}
+
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,18 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    driverClassName: org.h2.Driver
+    username: sa
+    password:
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
+    show-sql: true
+    generate-ddl: true


### PR DESCRIPTION
### #️⃣연관된 이슈
#15 

### 🔀반영 브랜치
feat/#15-groupmember

### 🔧변경 사항
- 참여자 엔티티를 추가하였습니다.
- 참여자 Creator, Reader, Updator 클래스를 추가하였습니다.
- 참여자 생성 및 조회에 대한 기능을 추가하였습니다.
- 참여자 생성 및 조회에 대한 api를 추가하였습니다.

### 💬리뷰 요구사항(선택)
- 모임Id를 controller에 요청을 보낼때 토큰형식으로 받아와서 모임 Id를 확인할 수 있는 형식으로 두었는데 괜찮을까요? 일단 mock value를 넣어놓긴 하였습니다.
- profile같은 경우 정산자에도 들어가고 참여자일때도 필요할 것 같은데 아무래도 정해진 프로필을 사용하다보니 path를 저장하기 보다는 profile의 번호를 저장하는게 메모리 측면에서 좋을 것이라고 생각했습니다. 근데 오늘 회의를 진행하며 회원은 도감 캐릭터도 되게 하자는 말씀이 있으셔서.. 아예 정산담당자 profile이든 참여자 profile이든 path를 저장하도록 할지.. 아니면 정산담당자는 path를 저장하고 참여자는 번호로 저장할지 고민입니다.


