### PR TITLE
RefreshToken을 사용한 AccessToken 재발급 API 생성

### DIFF
--- a/src/main/java/com/dnd/moddo/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/dnd/moddo/domain/auth/controller/AuthController.java
@@ -1,7 +1,10 @@
 package com.dnd.moddo.domain.auth.controller;
 
 import com.dnd.moddo.domain.auth.service.AuthService;
+import com.dnd.moddo.domain.auth.service.RefreshTokenService;
+import com.dnd.moddo.global.jwt.dto.RefreshResponse;
 import com.dnd.moddo.global.jwt.dto.TokenResponse;
+import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -12,9 +15,15 @@ import org.springframework.web.bind.annotation.*;
 public class AuthController {
 
     private final AuthService authService;
+    private final RefreshTokenService refreshTokenService;
 
     @GetMapping("/guest/token")
     public ResponseEntity<TokenResponse> getGuestToken() {
         return ResponseEntity.ok(authService.createGuestUser());
+    }
+
+    @PutMapping("/refresh/token")
+    public RefreshResponse refreshToken(@RequestHeader(value = "Authorization") @NotBlank String refreshToken) {
+        return refreshTokenService.execute(refreshToken);
     }
 }

--- a/src/main/java/com/dnd/moddo/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/dnd/moddo/domain/auth/controller/AuthController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/user")
+@RequestMapping("/api/v1/user")
 public class AuthController {
 
     private final AuthService authService;
@@ -22,8 +22,8 @@ public class AuthController {
         return ResponseEntity.ok(authService.createGuestUser());
     }
 
-    @PutMapping("/refresh/token")
-    public RefreshResponse refreshToken(@RequestHeader(value = "Authorization") @NotBlank String refreshToken) {
+    @PutMapping("/reissue/token")
+    public RefreshResponse reissueAccessToken(@RequestHeader(value = "Authorization") @NotBlank String refreshToken) {
         return refreshTokenService.execute(refreshToken);
     }
 }

--- a/src/main/java/com/dnd/moddo/domain/auth/exception/TokenInvalidException.java
+++ b/src/main/java/com/dnd/moddo/domain/auth/exception/TokenInvalidException.java
@@ -1,0 +1,10 @@
+package com.dnd.moddo.domain.auth.exception;
+
+import com.dnd.moddo.global.exception.ModdoException;
+import org.springframework.http.HttpStatus;
+
+public class TokenInvalidException extends ModdoException {
+    public TokenInvalidException() {
+        super(HttpStatus.UNAUTHORIZED, "토큰이 유효하지 않습니다.");
+    }
+}

--- a/src/main/java/com/dnd/moddo/domain/auth/service/AuthService.java
+++ b/src/main/java/com/dnd/moddo/domain/auth/service/AuthService.java
@@ -35,6 +35,6 @@ public class AuthService {
 
         userRepository.save(guestUser);
 
-        return jwtProvider.generateGuestToken(guestUser.getId());
+        return jwtProvider.generateToken(guestUser.getId(), guestUser.getEmail(), guestUser.getAuthority().toString(), false);
     }
 }

--- a/src/main/java/com/dnd/moddo/domain/auth/service/AuthService.java
+++ b/src/main/java/com/dnd/moddo/domain/auth/service/AuthService.java
@@ -35,6 +35,6 @@ public class AuthService {
 
         userRepository.save(guestUser);
 
-        return jwtProvider.generateToken(guestUser.getId(), guestUser.getEmail(), guestUser.getAuthority().toString(), false);
+        return jwtProvider.generateToken(guestUser.getId(), guestUser.getEmail(), guestUser.getAuthority().toString(), guestUser.getIsMember());
     }
 }

--- a/src/main/java/com/dnd/moddo/domain/auth/service/RefreshTokenService.java
+++ b/src/main/java/com/dnd/moddo/domain/auth/service/RefreshTokenService.java
@@ -25,13 +25,13 @@ public class RefreshTokenService {
         String email;
 
         try {
-            email = jwtUtil.getJwt(jwtUtil.parseToken(token)).getBody().get(JwtConstants.AUTH_ID.message).toString();
+            email = jwtUtil.getJwt(jwtUtil.parseToken(token)).getBody().get(JwtConstants.EMAIL.message).toString();
         } catch (Exception e) {
             throw new TokenInvalidException();
         }
 
-        Optional<User> user = userRepository.findByEmail(email);
-        String newAccessToken = jwtProvider.generateAccessToken(user.get().getId(), user.get().getEmail(), user.get().getAuthority().toString());
+        User user = userRepository.getByEmail(email);
+        String newAccessToken = jwtProvider.generateAccessToken(user.getId(), user.getEmail(), user.getAuthority().toString());
 
         return RefreshResponse.builder()
                 .accessToken(newAccessToken)

--- a/src/main/java/com/dnd/moddo/domain/auth/service/RefreshTokenService.java
+++ b/src/main/java/com/dnd/moddo/domain/auth/service/RefreshTokenService.java
@@ -10,8 +10,6 @@ import com.dnd.moddo.global.jwt.utill.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.util.Optional;
-
 @RequiredArgsConstructor
 @Service
 public class RefreshTokenService {

--- a/src/main/java/com/dnd/moddo/domain/auth/service/RefreshTokenService.java
+++ b/src/main/java/com/dnd/moddo/domain/auth/service/RefreshTokenService.java
@@ -1,0 +1,40 @@
+package com.dnd.moddo.domain.auth.service;
+
+import com.dnd.moddo.domain.auth.exception.TokenInvalidException;
+import com.dnd.moddo.domain.user.entity.User;
+import com.dnd.moddo.domain.user.repository.UserRepository;
+import com.dnd.moddo.global.jwt.dto.RefreshResponse;
+import com.dnd.moddo.global.jwt.properties.JwtConstants;
+import com.dnd.moddo.global.jwt.utill.JwtProvider;
+import com.dnd.moddo.global.jwt.utill.JwtUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Service
+public class RefreshTokenService {
+
+    private final JwtUtil jwtUtil;
+    private final UserRepository userRepository;
+    private final JwtProvider jwtProvider;
+
+    public RefreshResponse execute(String token) {
+
+        String email;
+
+        try {
+            email = jwtUtil.getJwt(jwtUtil.parseToken(token)).getBody().get(JwtConstants.AUTH_ID.message).toString();
+        } catch (Exception e) {
+            throw new TokenInvalidException();
+        }
+
+        Optional<User> user = userRepository.findByEmail(email);
+        String newAccessToken = jwtProvider.generateAccessToken(user.get().getId(), user.get().getEmail(), user.get().getAuthority().toString());
+
+        return RefreshResponse.builder()
+                .accessToken(newAccessToken)
+                .build();
+    }
+}

--- a/src/main/java/com/dnd/moddo/global/jwt/auth/JwtAuth.java
+++ b/src/main/java/com/dnd/moddo/global/jwt/auth/JwtAuth.java
@@ -25,7 +25,7 @@ public class JwtAuth {
             throw new MissingTokenException();
         }
 
-        UserDetails userDetails = authDetailsService.loadUserByUsername(claims.get(JwtConstants.AUTH_ID.message).toString());
+        UserDetails userDetails = authDetailsService.loadUserByUsername(claims.get(JwtConstants.EMAIL.message).toString());
         return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
     }
 
@@ -35,6 +35,6 @@ public class JwtAuth {
             throw new TokenInvalidException();
         }
         String role = jwtUtil.getJwt(token).getHeader().get(JwtConstants.TYPE.message).toString();
-        return !role.equals(JwtConstants.ACCESS_KEY.message);
+        return !role.equals(JwtConstants.REFRESH_KEY.message);
     }
 }

--- a/src/main/java/com/dnd/moddo/global/jwt/auth/JwtFilter.java
+++ b/src/main/java/com/dnd/moddo/global/jwt/auth/JwtFilter.java
@@ -25,8 +25,9 @@ public class JwtFilter extends OncePerRequestFilter {
             throws ServletException, IOException {
 
         String token = jwtUtil.resolveToken(request);
+        System.out.println("token: " + token);
 
-        if (token != null) {
+        if (token != null && !jwtUtil.isRefreshToken(token)) {
             Authentication authentication = jwtAuth.getAuthentication(token);
             SecurityContextHolder.getContext().setAuthentication(authentication);
         }

--- a/src/main/java/com/dnd/moddo/global/jwt/auth/JwtFilter.java
+++ b/src/main/java/com/dnd/moddo/global/jwt/auth/JwtFilter.java
@@ -25,9 +25,8 @@ public class JwtFilter extends OncePerRequestFilter {
             throws ServletException, IOException {
 
         String token = jwtUtil.resolveToken(request);
-        System.out.println("token: " + token);
 
-        if (token != null && !jwtUtil.isRefreshToken(token)) {
+        if (token != null) {
             Authentication authentication = jwtAuth.getAuthentication(token);
             SecurityContextHolder.getContext().setAuthentication(authentication);
         }

--- a/src/main/java/com/dnd/moddo/global/jwt/dto/TokenResponse.java
+++ b/src/main/java/com/dnd/moddo/global/jwt/dto/TokenResponse.java
@@ -9,6 +9,6 @@ public record TokenResponse(
         String refreshToken,
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
         ZonedDateTime expiredAt,
-        Boolean isFirst
+        Boolean isMember
 ) {
 }

--- a/src/main/java/com/dnd/moddo/global/jwt/properties/JwtConstants.java
+++ b/src/main/java/com/dnd/moddo/global/jwt/properties/JwtConstants.java
@@ -7,7 +7,8 @@ import lombok.Getter;
 @Getter
 public enum JwtConstants {
 
-    AUTH_ID("auth_id"),
+    AUTH_ID("userId"),
+    EMAIL("email"),
     TYPE("type"),
     EMPTY(" "),
     PREFIX("prefix"),

--- a/src/main/java/com/dnd/moddo/global/jwt/utill/JwtProvider.java
+++ b/src/main/java/com/dnd/moddo/global/jwt/utill/JwtProvider.java
@@ -18,20 +18,28 @@ public class JwtProvider {
 
     private final JwtProperties jwtProperties;
 
-    public TokenResponse generateGuestToken(Long id) {
-        String accessToken = generateToken(id, "GUEST", ACCESS_KEY.getMessage(), jwtProperties.getAccessExpiration());
-        String refreshToken = generateToken(id, "GUEST", REFRESH_KEY.getMessage(), jwtProperties.getRefreshExpiration());
-
-        return new TokenResponse(accessToken, refreshToken, getExpiredTime(), true);
+    public String generateAccessToken(Long id, String authId, String role) {
+        return generateToken(id, authId, role, ACCESS_KEY.getMessage(), jwtProperties.getAccessExpiration());
     }
 
-    private String generateToken(Long id, String role, String type, Long exp) {
+    public TokenResponse generateToken(Long id, String authId, String role, Boolean isMember) {
+        String accessToken = generateToken(id, authId, role, ACCESS_KEY.getMessage(), jwtProperties.getAccessExpiration());
+        String refreshToken = generateToken(id, authId, role, REFRESH_KEY.getMessage(), jwtProperties.getRefreshExpiration());
+
+        return new TokenResponse(accessToken, refreshToken, getExpiredTime(), isMember);
+    }
+
+
+    private String generateToken(Long id, String authId, String role, String type, Long exp) {
         return Jwts.builder()
                 .claim("userId", id)
-                .setHeaderParam("type", type)
-                .claim("role", role)
+                .setHeaderParam(TYPE.message, type)
+                .claim(ROLE.getMessage(), role)
+                .claim(AUTH_ID.getMessage(), authId)
                 .signWith(jwtProperties.getSecretKey(), SignatureAlgorithm.HS256)
-                .setExpiration(new Date(System.currentTimeMillis() + exp * 1000))
+                .setExpiration(
+                        new Date(System.currentTimeMillis() + exp * 1000)
+                )
                 .compact();
     }
 

--- a/src/main/java/com/dnd/moddo/global/jwt/utill/JwtProvider.java
+++ b/src/main/java/com/dnd/moddo/global/jwt/utill/JwtProvider.java
@@ -18,24 +18,24 @@ public class JwtProvider {
 
     private final JwtProperties jwtProperties;
 
-    public String generateAccessToken(Long id, String authId, String role) {
-        return generateToken(id, authId, role, ACCESS_KEY.getMessage(), jwtProperties.getAccessExpiration());
+    public String generateAccessToken(Long id, String email, String role) {
+        return generateToken(id, email, role, ACCESS_KEY.getMessage(), jwtProperties.getAccessExpiration());
     }
 
-    public TokenResponse generateToken(Long id, String authId, String role, Boolean isMember) {
-        String accessToken = generateToken(id, authId, role, ACCESS_KEY.getMessage(), jwtProperties.getAccessExpiration());
-        String refreshToken = generateToken(id, authId, role, REFRESH_KEY.getMessage(), jwtProperties.getRefreshExpiration());
+    public TokenResponse generateToken(Long id, String email, String role, Boolean isMember) {
+        String accessToken = generateToken(id, email, role, ACCESS_KEY.getMessage(), jwtProperties.getAccessExpiration());
+        String refreshToken = generateToken(id, email, role, REFRESH_KEY.getMessage(), jwtProperties.getRefreshExpiration());
 
         return new TokenResponse(accessToken, refreshToken, getExpiredTime(), isMember);
     }
 
 
-    private String generateToken(Long id, String authId, String role, String type, Long exp) {
+    private String generateToken(Long id, String email, String role, String type, Long exp) {
         return Jwts.builder()
-                .claim("userId", id)
+                .claim(AUTH_ID.getMessage(), id)
+                .claim(EMAIL.getMessage(), email)
                 .setHeaderParam(TYPE.message, type)
                 .claim(ROLE.getMessage(), role)
-                .claim(AUTH_ID.getMessage(), authId)
                 .signWith(jwtProperties.getSecretKey(), SignatureAlgorithm.HS256)
                 .setExpiration(
                         new Date(System.currentTimeMillis() + exp * 1000)

--- a/src/main/java/com/dnd/moddo/global/jwt/utill/JwtUtil.java
+++ b/src/main/java/com/dnd/moddo/global/jwt/utill/JwtUtil.java
@@ -1,7 +1,6 @@
 package com.dnd.moddo.global.jwt.utill;
 
 import com.dnd.moddo.global.jwt.exception.TokenInvalidException;
-import com.dnd.moddo.global.jwt.properties.JwtConstants;
 import com.dnd.moddo.global.jwt.properties.JwtProperties;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;

--- a/src/main/java/com/dnd/moddo/global/jwt/utill/JwtUtil.java
+++ b/src/main/java/com/dnd/moddo/global/jwt/utill/JwtUtil.java
@@ -1,5 +1,6 @@
 package com.dnd.moddo.global.jwt.utill;
 
+import com.dnd.moddo.global.jwt.exception.TokenInvalidException;
 import com.dnd.moddo.global.jwt.properties.JwtConstants;
 import com.dnd.moddo.global.jwt.properties.JwtProperties;
 import io.jsonwebtoken.Claims;
@@ -29,12 +30,18 @@ public class JwtUtil {
     }
 
     public Jws<Claims> getJwt(String token) {
+        if (token == null) {
+            throw new TokenInvalidException();
+        }
+
         return Jwts.parserBuilder().setSigningKey(jwtProperties.getSecretKey()).build().parseClaimsJws(token);
     }
 
-    public boolean isRefreshToken(String token) {
-        return token != null && getJwt(token).getHeader().get(JwtConstants.TYPE.message).toString()
-                .equals(JwtConstants.REFRESH_KEY.message);
+    public Long getUserIdFromToken(String token) {
+        if (token == null) {
+            return null;
+        }
+        Claims claims = getJwt(token).getBody();
+        return claims.get("userId", Long.class);
     }
-
 }

--- a/src/main/java/com/dnd/moddo/global/jwt/utill/JwtUtil.java
+++ b/src/main/java/com/dnd/moddo/global/jwt/utill/JwtUtil.java
@@ -1,5 +1,6 @@
 package com.dnd.moddo.global.jwt.utill;
 
+import com.dnd.moddo.global.jwt.properties.JwtConstants;
 import com.dnd.moddo.global.jwt.properties.JwtProperties;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
@@ -30,4 +31,10 @@ public class JwtUtil {
     public Jws<Claims> getJwt(String token) {
         return Jwts.parserBuilder().setSigningKey(jwtProperties.getSecretKey()).build().parseClaimsJws(token);
     }
+
+    public boolean isRefreshToken(String token) {
+        return token != null && getJwt(token).getHeader().get(JwtConstants.TYPE.message).toString()
+                .equals(JwtConstants.REFRESH_KEY.message);
+    }
+
 }

--- a/src/main/java/com/dnd/moddo/global/security/auth/AuthDetailsService.java
+++ b/src/main/java/com/dnd/moddo/global/security/auth/AuthDetailsService.java
@@ -1,5 +1,6 @@
 package com.dnd.moddo.global.security.auth;
 
+import com.dnd.moddo.domain.user.exception.UserNotFoundException;
 import com.dnd.moddo.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -19,6 +20,6 @@ public class AuthDetailsService implements UserDetailsService {
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
         return userRepository.findByEmail(email)
                 .map(AuthDetails::new)
-                .orElseThrow(() -> new IllegalStateException("유저를 찾을 수 없습니다."));
+                .orElseThrow(() -> new UserNotFoundException(email));
     }
 }

--- a/src/test/java/com/dnd/moddo/domain/auth/service/RefreshTokenServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/auth/service/RefreshTokenServiceTest.java
@@ -1,0 +1,75 @@
+package com.dnd.moddo.domain.auth.service;
+
+import static org.assertj.core.api.BDDAssertions.*;
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.dnd.moddo.domain.user.entity.User;
+import com.dnd.moddo.domain.user.entity.type.Authority;
+import com.dnd.moddo.domain.user.repository.UserRepository;
+import com.dnd.moddo.global.jwt.dto.RefreshResponse;
+import com.dnd.moddo.global.jwt.properties.JwtConstants;
+import com.dnd.moddo.global.jwt.utill.JwtProvider;
+import com.dnd.moddo.global.jwt.utill.JwtUtil;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+
+@ExtendWith(MockitoExtension.class)
+public class RefreshTokenServiceTest {
+
+    @Mock
+    private JwtUtil jwtUtil;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private JwtProvider jwtProvider;
+
+    @InjectMocks
+    private RefreshTokenService refreshTokenService;
+
+    @Test
+    public void executeNewAccessToken() {
+        // given
+        String refreshToken = "RefreshToken";
+        String email = "test@example.com";
+        LocalDateTime time = LocalDateTime.now();
+        User user = new User(1L, "김철수", email, "profile.png", true, time, time.plusMonths(1), Authority.USER);
+
+        Claims mockClaims = mock(Claims.class);
+        Jws<Claims> mockJws = mock(Jws.class);
+
+        when(mockClaims.get(JwtConstants.AUTH_ID.message)).thenReturn(email);
+        when(mockJws.getBody()).thenReturn(mockClaims);
+
+        when(jwtUtil.parseToken(refreshToken)).thenReturn(refreshToken);
+        when(jwtUtil.getJwt(refreshToken)).thenReturn(mockJws);
+
+        when(userRepository.findByEmail(email)).thenReturn(Optional.of(user));
+
+        String newAccessToken = "newAccessToken";
+        when(jwtProvider.generateAccessToken(anyLong(), anyString(), anyString())).thenReturn(newAccessToken);
+
+        // when
+        RefreshResponse response = refreshTokenService.execute(refreshToken);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.getAccessToken()).isEqualTo(newAccessToken);
+
+        verify(jwtUtil, times(1)).parseToken(refreshToken);
+        verify(jwtUtil, times(1)).getJwt(refreshToken);
+        verify(userRepository, times(1)).findByEmail(email);
+        verify(jwtProvider, times(1)).generateAccessToken(anyLong(), anyString(), anyString());
+    }
+}


### PR DESCRIPTION
### #️⃣연관된 이슈
#24 

### 🔀반영 브랜치
feat/#24-accesstoken-reissue -> develop

### 🔧변경 사항
- JwtProvider에서 토큰 발급에 대한 회원/비회원 로직을 공통되게 변경했습니다.
- generateGuestToken -> generateToken 메서드명을 변경했습니다.

### 💬리뷰 요구사항(선택)
- `getAuthentication` 메서드에서 토큰을 확인하는 과정에서, refreshToken의 헤더 값이 `ACCESS_KEY`가 아닌 `REFRESH_KEY`로 `isNotAccessToken()`이 `true`로 반환돼 "토큰이 없습니다." 예외가 발생했습니다. 이를 해결하기 위해 JwtFilter에서 refreshToken을 필터링에서 제외하도록 구현했는데, 더 나은 방법이 있을까요?