### PR TITLE
모임 생성 API

### DIFF
--- a/src/main/java/com/dnd/moddo/domain/group/controller/GroupController.java
+++ b/src/main/java/com/dnd/moddo/domain/group/controller/GroupController.java
@@ -1,0 +1,29 @@
+package com.dnd.moddo.domain.group.controller;
+
+import com.dnd.moddo.domain.group.dto.GroupRequest;
+import com.dnd.moddo.domain.group.dto.GroupResponse;
+import com.dnd.moddo.domain.group.service.CommandGroupService;
+import com.dnd.moddo.global.jwt.service.JwtService;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/group")
+public class GroupController {
+    private final CommandGroupService commandGroupService;
+    private final JwtService jwtService;
+
+    @PostMapping
+    public ResponseEntity<GroupResponse> saveGroup(HttpServletRequest request, @RequestBody GroupRequest groupRequest) {
+        Long userId = jwtService.getUserId(request);
+
+        GroupResponse response = commandGroupService.createGroup(groupRequest, userId);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/dnd/moddo/domain/group/dto/GroupRequest.java
+++ b/src/main/java/com/dnd/moddo/domain/group/dto/GroupRequest.java
@@ -1,0 +1,19 @@
+package com.dnd.moddo.domain.group.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+import java.time.LocalDateTime;
+
+public record GroupRequest(
+        @NotBlank(message = "모임 이름은 필수입니다.")
+        String name,
+
+        String password,
+
+        LocalDateTime expiredAt,
+
+        String bank,
+
+        String accountNumber
+) {
+}

--- a/src/main/java/com/dnd/moddo/domain/group/dto/GroupRequest.java
+++ b/src/main/java/com/dnd/moddo/domain/group/dto/GroupRequest.java
@@ -10,10 +10,6 @@ public record GroupRequest(
 
         String password,
 
-        LocalDateTime expiredAt,
-
-        String bank,
-
-        String accountNumber
+        LocalDateTime expiredAt
 ) {
 }

--- a/src/main/java/com/dnd/moddo/domain/group/dto/GroupResponse.java
+++ b/src/main/java/com/dnd/moddo/domain/group/dto/GroupResponse.java
@@ -1,0 +1,25 @@
+package com.dnd.moddo.domain.group.dto;
+
+import com.dnd.moddo.domain.group.entity.Group;
+
+import java.time.LocalDateTime;
+
+public record GroupResponse(
+        Long id,
+        Long writer,
+        LocalDateTime createdAt,
+        LocalDateTime expiredAt,
+        String bank,
+        String accountNumber
+) {
+    public static GroupResponse of(Group group) {
+        return new GroupResponse(
+                group.getId(),
+                group.getWriter(),
+                group.getCreatedAt(),
+                group.getExpiredAt(),
+                group.getBank(),
+                group.getAccountNumber()
+        );
+    }
+}

--- a/src/main/java/com/dnd/moddo/domain/group/entity/Group.java
+++ b/src/main/java/com/dnd/moddo/domain/group/entity/Group.java
@@ -1,0 +1,44 @@
+package com.dnd.moddo.domain.group.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "groups")
+public class Group {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id")
+    private Long writer;
+
+    private String name;
+
+    private String password;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime expiredAt;
+
+    private String bank;
+
+    private String accountNumber;
+
+    @Builder
+    public Group(String name, Long writer, String password, LocalDateTime createdAt, LocalDateTime expiredAt, String bank, String accountNumber) {
+        this.name = name;
+        this.writer = writer;
+        this.password = password;
+        this.createdAt = createdAt;
+        this.expiredAt = expiredAt;
+        this.bank = bank;
+        this.accountNumber = accountNumber;
+    }
+}

--- a/src/main/java/com/dnd/moddo/domain/group/repository/GroupRepository.java
+++ b/src/main/java/com/dnd/moddo/domain/group/repository/GroupRepository.java
@@ -1,0 +1,7 @@
+package com.dnd.moddo.domain.group.repository;
+
+import com.dnd.moddo.domain.group.entity.Group;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GroupRepository extends JpaRepository<Group, Long> {
+}

--- a/src/main/java/com/dnd/moddo/domain/group/service/CommandGroupService.java
+++ b/src/main/java/com/dnd/moddo/domain/group/service/CommandGroupService.java
@@ -1,0 +1,17 @@
+package com.dnd.moddo.domain.group.service;
+
+import com.dnd.moddo.domain.group.dto.GroupRequest;
+import com.dnd.moddo.domain.group.dto.GroupResponse;
+import com.dnd.moddo.domain.group.service.implementation.GroupCreater;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CommandGroupService {
+    private final GroupCreater groupCreater;
+
+    public GroupResponse createGroup(GroupRequest request, Long userId) {
+        return groupCreater.createGroup(request, userId);
+    }
+}

--- a/src/main/java/com/dnd/moddo/domain/group/service/implementation/GroupCreater.java
+++ b/src/main/java/com/dnd/moddo/domain/group/service/implementation/GroupCreater.java
@@ -1,0 +1,39 @@
+package com.dnd.moddo.domain.group.service.implementation;
+
+import com.dnd.moddo.domain.group.dto.GroupRequest;
+import com.dnd.moddo.domain.group.dto.GroupResponse;
+import com.dnd.moddo.domain.group.entity.Group;
+import com.dnd.moddo.domain.group.repository.GroupRepository;
+import com.dnd.moddo.domain.user.entity.User;
+import com.dnd.moddo.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class GroupCreater {
+
+    private final GroupRepository groupRepository;
+    private final UserRepository userRepository;
+    private final BCryptPasswordEncoder passwordEncoder;
+
+    public GroupResponse createGroup(GroupRequest request, Long userId) {
+        User user = userRepository.getById(userId);
+        String encryptedPassword = passwordEncoder.encode(request.password());
+
+        Group group = Group.builder()
+                .writer(user.getId())
+                .name(request.name())
+                .password(encryptedPassword)
+                .createdAt(LocalDateTime.now())
+                .expiredAt(LocalDateTime.now().plusMonths(1))
+                .bank(request.bank())
+                .accountNumber(request.accountNumber())
+                .build();
+
+        return GroupResponse.of(groupRepository.save(group));
+    }
+}

--- a/src/main/java/com/dnd/moddo/domain/group/service/implementation/GroupCreater.java
+++ b/src/main/java/com/dnd/moddo/domain/group/service/implementation/GroupCreater.java
@@ -30,8 +30,6 @@ public class GroupCreater {
                 .password(encryptedPassword)
                 .createdAt(LocalDateTime.now())
                 .expiredAt(LocalDateTime.now().plusMonths(1))
-                .bank(request.bank())
-                .accountNumber(request.accountNumber())
                 .build();
 
         return GroupResponse.of(groupRepository.save(group));

--- a/src/main/java/com/dnd/moddo/domain/user/exception/UserNotFoundException.java
+++ b/src/main/java/com/dnd/moddo/domain/user/exception/UserNotFoundException.java
@@ -4,9 +4,7 @@ import com.dnd.moddo.global.exception.ModdoException;
 import org.springframework.http.HttpStatus;
 
 public class UserNotFoundException extends ModdoException {
-    public UserNotFoundException(String email) {
-        super(HttpStatus.NOT_FOUND, email + "이 이메일인 유저가 없습니다.");
-    }
+    public UserNotFoundException(String email) { super(HttpStatus.NOT_FOUND, email + "이 이메일인 유저가 없습니다."); }
 
     public UserNotFoundException(Long id) {
         super(HttpStatus.NOT_FOUND, id + "인 아이디를 가진 유저가 없습니다.");

--- a/src/main/java/com/dnd/moddo/global/jwt/auth/JwtAuth.java
+++ b/src/main/java/com/dnd/moddo/global/jwt/auth/JwtAuth.java
@@ -18,10 +18,10 @@ public class JwtAuth {
     private final JwtUtil jwtUtil;
     private final AuthDetailsService authDetailsService;
 
-    public Authentication getAuthentication(String token) {
+    public Authentication getAuthentication(String token, String expectedTokenType) {
         Claims claims = jwtUtil.getJwt(token).getBody();
 
-        if (isNotAccessToken(token)) {
+        if (isNotExpectedToken(token, expectedTokenType)) {
             throw new MissingTokenException();
         }
 
@@ -29,12 +29,12 @@ public class JwtAuth {
         return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
     }
 
-    private boolean isNotAccessToken(String token) {
-
-        if (token.isEmpty()) {
+    private boolean isNotExpectedToken(String token, String expectedTokenType) {
+        if (token == null || token.isEmpty()) {
             throw new TokenInvalidException();
         }
+
         String role = jwtUtil.getJwt(token).getHeader().get(JwtConstants.TYPE.message).toString();
-        return !role.equals(JwtConstants.REFRESH_KEY.message);
+        return !role.equals(expectedTokenType);
     }
 }

--- a/src/main/java/com/dnd/moddo/global/jwt/auth/JwtFilter.java
+++ b/src/main/java/com/dnd/moddo/global/jwt/auth/JwtFilter.java
@@ -1,5 +1,6 @@
 package com.dnd.moddo.global.jwt.auth;
 
+import com.dnd.moddo.global.jwt.properties.JwtConstants;
 import com.dnd.moddo.global.jwt.utill.JwtUtil;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -27,10 +28,20 @@ public class JwtFilter extends OncePerRequestFilter {
         String token = jwtUtil.resolveToken(request);
 
         if (token != null) {
-            Authentication authentication = jwtAuth.getAuthentication(token);
+            String requestURI = request.getRequestURI();
+            String expectedTokenType = getExpectedTokenType(requestURI);
+
+            Authentication authentication = jwtAuth.getAuthentication(token, expectedTokenType);
             SecurityContextHolder.getContext().setAuthentication(authentication);
         }
 
         filterChain.doFilter(request, response);
+    }
+
+    private String getExpectedTokenType(String requestURI) {
+        if (requestURI.startsWith("/api/v1/user/reissue/token")) {
+            return JwtConstants.REFRESH_KEY.message;
+        }
+        return JwtConstants.ACCESS_KEY.message;
     }
 }

--- a/src/main/java/com/dnd/moddo/global/jwt/service/JwtService.java
+++ b/src/main/java/com/dnd/moddo/global/jwt/service/JwtService.java
@@ -1,0 +1,17 @@
+package com.dnd.moddo.global.jwt.service;
+
+import com.dnd.moddo.global.jwt.utill.JwtUtil;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class JwtService {
+    private final JwtUtil jwtUtil;
+
+    public Long getUserId(HttpServletRequest request) {
+        String token = jwtUtil.resolveToken(request);
+        return jwtUtil.getUserIdFromToken(token);
+    }
+}

--- a/src/test/java/com/dnd/moddo/domain/group/entity/GroupTest.java
+++ b/src/test/java/com/dnd/moddo/domain/group/entity/GroupTest.java
@@ -1,0 +1,48 @@
+package com.dnd.moddo.domain.group.entity;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
+class GroupTest {
+
+    @Test
+    void groupCreateTest() {
+        // given
+        String name = "groupName";
+        Long writer = 1L;
+        String password = "password";
+        LocalDateTime createdAt = LocalDateTime.now();
+        LocalDateTime expiredAt = createdAt.plusDays(1);
+        String bank = "bank";
+        String accountNumber = "1234-1234";
+
+        // when
+        Group group = Group.builder()
+                .name(name)
+                .writer(writer)
+                .password(password)
+                .createdAt(createdAt)
+                .expiredAt(expiredAt)
+                .bank(bank)
+                .accountNumber(accountNumber)
+                .build();
+
+        // then
+        assertThat(group).isNotNull();
+        assertThat(group.getName()).isEqualTo(name);
+        assertThat(group.getWriter()).isEqualTo(writer);
+        assertThat(group.getPassword()).isEqualTo(password);
+        assertThat(group.getCreatedAt()).isEqualTo(createdAt);
+        assertThat(group.getExpiredAt()).isEqualTo(expiredAt);
+        assertThat(group.getBank()).isEqualTo(bank);
+        assertThat(group.getAccountNumber()).isEqualTo(accountNumber);
+    }
+}

--- a/src/test/java/com/dnd/moddo/domain/group/entity/GroupTest.java
+++ b/src/test/java/com/dnd/moddo/domain/group/entity/GroupTest.java
@@ -1,11 +1,16 @@
 package com.dnd.moddo.domain.group.entity;
 
+import com.dnd.moddo.domain.group.repository.GroupRepository;
+import com.dnd.moddo.domain.groupMember.entity.GroupMember;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -13,36 +18,23 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SpringBootTest
 class GroupTest {
 
+    @Autowired
+    private GroupRepository groupRepository;
+
     @Test
     void groupCreateTest() {
         // given
-        String name = "groupName";
-        Long writer = 1L;
-        String password = "password";
-        LocalDateTime createdAt = LocalDateTime.now();
-        LocalDateTime expiredAt = createdAt.plusDays(1);
-        String bank = "bank";
-        String accountNumber = "1234-1234";
+        Group group1 = new Group("groupName", 1L, "password", LocalDateTime.now(), LocalDateTime.now().plusDays(1), "bank", "1234-1234");
+        Group group2 = new Group("groupName", 1L, "password", LocalDateTime.now(), LocalDateTime.now().plusDays(1), "bank", "1234-1234");
+        groupRepository.save(group1);
+        groupRepository.save(group2);
 
         // when
-        Group group = Group.builder()
-                .name(name)
-                .writer(writer)
-                .password(password)
-                .createdAt(createdAt)
-                .expiredAt(expiredAt)
-                .bank(bank)
-                .accountNumber(accountNumber)
-                .build();
+        Optional<Group> foundGroup = groupRepository.findById(1L);
 
         // then
-        assertThat(group).isNotNull();
-        assertThat(group.getName()).isEqualTo(name);
-        assertThat(group.getWriter()).isEqualTo(writer);
-        assertThat(group.getPassword()).isEqualTo(password);
-        assertThat(group.getCreatedAt()).isEqualTo(createdAt);
-        assertThat(group.getExpiredAt()).isEqualTo(expiredAt);
-        assertThat(group.getBank()).isEqualTo(bank);
-        assertThat(group.getAccountNumber()).isEqualTo(accountNumber);
+        assertThat(foundGroup).isPresent();
+        assertThat(foundGroup.get().getName()).isEqualTo("groupName");
+        assertThat(foundGroup.get().getWriter()).isEqualTo(1L);
     }
 }

--- a/src/test/java/com/dnd/moddo/domain/group/service/CommandGroupServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/group/service/CommandGroupServiceTest.java
@@ -31,7 +31,7 @@ class CommandGroupServiceTest {
 
     @BeforeEach
     void setUp() {
-        groupRequest = new GroupRequest("GroupName", "password123", LocalDateTime.now(), "bank", "1234-1234");
+        groupRequest = new GroupRequest("GroupName", "password123", LocalDateTime.now());
         groupResponse = new GroupResponse(1L, 1L, LocalDateTime.now(), LocalDateTime.now().minusDays(1), "bank", "1234-1234");
     }
 
@@ -47,7 +47,5 @@ class CommandGroupServiceTest {
         assertThat(response).isNotNull();
         assertThat(response.id()).isEqualTo(1L);
         assertThat(response.writer()).isEqualTo(1L);
-        assertThat(response.bank()).isEqualTo("bank");
-        assertThat(response.accountNumber()).isEqualTo("1234-1234");
     }
 }

--- a/src/test/java/com/dnd/moddo/domain/group/service/CommandGroupServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/group/service/CommandGroupServiceTest.java
@@ -1,0 +1,53 @@
+package com.dnd.moddo.domain.group.service;
+
+import com.dnd.moddo.domain.group.dto.GroupRequest;
+import com.dnd.moddo.domain.group.dto.GroupResponse;
+import com.dnd.moddo.domain.group.service.implementation.GroupCreater;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CommandGroupServiceTest {
+
+    @Mock
+    private GroupCreater groupCreater;
+
+    @InjectMocks
+    private CommandGroupService commandGroupService;
+
+    private GroupRequest groupRequest;
+    private GroupResponse groupResponse;
+
+    @BeforeEach
+    void setUp() {
+        groupRequest = new GroupRequest("GroupName", "password123", LocalDateTime.now(), "bank", "1234-1234");
+        groupResponse = new GroupResponse(1L, 1L, LocalDateTime.now(), LocalDateTime.now().minusDays(1), "bank", "1234-1234");
+    }
+
+    @Test
+    void createGroup() {
+        // Given
+        when(groupCreater.createGroup(any(GroupRequest.class), anyLong())).thenReturn(groupResponse);
+
+        // When
+        GroupResponse response = commandGroupService.createGroup(groupRequest, 1L);
+
+        // Then
+        assertThat(response).isNotNull();
+        assertThat(response.id()).isEqualTo(1L);
+        assertThat(response.writer()).isEqualTo(1L);
+        assertThat(response.bank()).isEqualTo("bank");
+        assertThat(response.accountNumber()).isEqualTo("1234-1234");
+    }
+}


### PR DESCRIPTION
### #️⃣연관된 이슈
#17 

### 🔀반영 브랜치
feat/#17-creat-group -> develop

### 🔧변경 사항
- 이전 코드에서, `isNotAccessToken(String token)` 메서드가 무조건 ACCESS_KEY를 검증하고 있어 발생한 아래 에러를 수정했습니다.
  - 리프레시 토큰을 활용해 액세스 토큰을 재발급할 때 → REFRESH_KEY를 검증해야 하는데 ACCESS_KEY를 체크하므로 실패함.
  - 액세스 토큰을 통해 사용자 ID를 추출할 때 → ACCESS_KEY를 검증하므로 정상 작동함.

### 💬리뷰 요구사항(선택)
- 모임 만료 시간을 임의로 생성일로부터 1달 뒤로 설정했습니다.
수정할 부분이 있다면 말해주세요!
