### PR TITLE
참여자 역할 추가 및 유효성 검사 추가

### DIFF
--- a/src/main/java/com/dnd/moddo/domain/groupMember/controller/GroupMemberController.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/controller/GroupMemberController.java
@@ -1,7 +1,9 @@
 package com.dnd.moddo.domain.groupMember.controller;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -50,6 +52,15 @@ public class GroupMemberController {
 	) {
 		GroupMemberResponse response = commandGroupMemberService.addGroupMember(groupId, request);
 		return ResponseEntity.ok(response);
+	}
+
+	@DeleteMapping("/{groupMemberId}")
+	public ResponseEntity<Void> deleteGroupMember(
+		@RequestParam("groupId") Long groupId,
+		@PathVariable("groupMemberId") Long groupMemberId
+	) {
+		commandGroupMemberService.delete(groupMemberId);
+		return ResponseEntity.noContent().build();
 	}
 
 }

--- a/src/main/java/com/dnd/moddo/domain/groupMember/dto/request/GroupMemberSaveRequest.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/dto/request/GroupMemberSaveRequest.java
@@ -2,14 +2,16 @@ package com.dnd.moddo.domain.groupMember.dto.request;
 
 import com.dnd.moddo.domain.group.entity.Group;
 import com.dnd.moddo.domain.groupMember.entity.GroupMember;
+import com.dnd.moddo.domain.groupMember.entity.type.ExpenseRole;
 
 import jakarta.validation.constraints.NotBlank;
 
 public record GroupMemberSaveRequest(
 	@NotBlank(message = "참여자 이름으로 공백은 입력할 수 없습니다.")
-	String name
+	String name,
+	String role
 ) {
-	public GroupMember toEntity(Group group) {
-		return new GroupMember(name(), group);
+	public GroupMember toEntity(Group group, ExpenseRole role) {
+		return new GroupMember(name(), group, role);
 	}
 }

--- a/src/main/java/com/dnd/moddo/domain/groupMember/dto/request/GroupMembersSaveRequest.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/dto/request/GroupMembersSaveRequest.java
@@ -1,5 +1,7 @@
 package com.dnd.moddo.domain.groupMember.dto.request;
 
+import static com.dnd.moddo.domain.groupMember.entity.type.ExpenseRole.*;
+
 import java.util.List;
 
 import com.dnd.moddo.domain.group.entity.Group;
@@ -10,7 +12,7 @@ public record GroupMembersSaveRequest(
 ) {
 	public List<GroupMember> toEntity(Group group) {
 		return members.stream()
-			.map(m -> m.toEntity(group))
+			.map(m -> m.toEntity(group, getRoleByString(m.role())))
 			.toList();
 	}
 }

--- a/src/main/java/com/dnd/moddo/domain/groupMember/dto/response/GroupMemberResponse.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/dto/response/GroupMemberResponse.java
@@ -1,16 +1,18 @@
 package com.dnd.moddo.domain.groupMember.dto.response;
 
 import com.dnd.moddo.domain.groupMember.entity.GroupMember;
+import com.dnd.moddo.domain.groupMember.entity.type.ExpenseRole;
 
 public record GroupMemberResponse(
 	Long id,
+	ExpenseRole role,
 	String name,
 	String profile,
 	boolean isPaid
 ) {
 
 	public static GroupMemberResponse of(GroupMember groupMember) {
-		return new GroupMemberResponse(groupMember.getId(), groupMember.getName(),
+		return new GroupMemberResponse(groupMember.getId(), groupMember.getRole(), groupMember.getName(),
 			generateProfileUrl(groupMember.getProfileId()), groupMember.isPaid());
 	}
 

--- a/src/main/java/com/dnd/moddo/domain/groupMember/entity/GroupMember.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/entity/GroupMember.java
@@ -1,9 +1,12 @@
 package com.dnd.moddo.domain.groupMember.entity;
 
 import com.dnd.moddo.domain.group.entity.Group;
+import com.dnd.moddo.domain.groupMember.entity.type.ExpenseRole;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -38,20 +41,24 @@ public class GroupMember {
 	@Column(name = "is_paid", nullable = false)
 	private boolean isPaid;
 
-	public GroupMember(String name, Group group) {
-		this(null, name, null, group, false);
+	@Enumerated(EnumType.STRING)
+	private ExpenseRole role;
+
+	public GroupMember(String name, Group group, ExpenseRole role) {
+		this(null, name, null, group, false, role);
 	}
 
-	public GroupMember(String name, Integer profileId, Group group) {
-		this(null, name, profileId, group, false);
+	public GroupMember(String name, Integer profileId, Group group, ExpenseRole role) {
+		this(null, name, profileId, group, false, role);
 	}
 
-	public GroupMember(Long id, String name, Integer profileId, Group group, boolean isPaid) {
+	public GroupMember(Long id, String name, Integer profileId, Group group, boolean isPaid, ExpenseRole role) {
 		this.id = id;
 		this.name = name;
 		this.profileId = profileId;
 		this.group = group;
 		this.isPaid = isPaid;
+		this.role = role;
 	}
 
 }

--- a/src/main/java/com/dnd/moddo/domain/groupMember/entity/GroupMember.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/entity/GroupMember.java
@@ -61,5 +61,8 @@ public class GroupMember {
 		this.role = role;
 	}
 
+	public boolean isManager() {
+		return ExpenseRole.MANAGER.equals(role);
+	}
 }
 

--- a/src/main/java/com/dnd/moddo/domain/groupMember/entity/type/ExpenseRole.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/entity/type/ExpenseRole.java
@@ -1,0 +1,15 @@
+package com.dnd.moddo.domain.groupMember.entity.type;
+
+import com.dnd.moddo.domain.groupMember.exception.ExpenseRoleNotFoundException;
+
+public enum ExpenseRole {
+	MANAGER, PARTICIPANT;
+
+	public static ExpenseRole getRoleByString(String role) {
+		try {
+			return ExpenseRole.valueOf(role);
+		} catch (IllegalArgumentException e) {
+			throw new ExpenseRoleNotFoundException(role);
+		}
+	}
+}

--- a/src/main/java/com/dnd/moddo/domain/groupMember/exception/ExpenseRoleNotFoundException.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/exception/ExpenseRoleNotFoundException.java
@@ -1,0 +1,11 @@
+package com.dnd.moddo.domain.groupMember.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.dnd.moddo.global.exception.ModdoException;
+
+public class ExpenseRoleNotFoundException extends ModdoException {
+	public ExpenseRoleNotFoundException(String role) {
+		super(HttpStatus.NOT_FOUND, "해당 역할은 존재하지 않습니다. (Role: " + role + ")");
+	}
+}

--- a/src/main/java/com/dnd/moddo/domain/groupMember/exception/InvalidExpenseParticipantsException.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/exception/InvalidExpenseParticipantsException.java
@@ -1,0 +1,11 @@
+package com.dnd.moddo.domain.groupMember.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.dnd.moddo.global.exception.ModdoException;
+
+public class InvalidExpenseParticipantsException extends ModdoException {
+	public InvalidExpenseParticipantsException() {
+		super(HttpStatus.BAD_REQUEST, "총무(MANAGER)는 한 명 있어야 합니다.");
+	}
+}

--- a/src/main/java/com/dnd/moddo/domain/groupMember/exception/ManagerCannotDeleteException.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/exception/ManagerCannotDeleteException.java
@@ -1,0 +1,11 @@
+package com.dnd.moddo.domain.groupMember.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.dnd.moddo.global.exception.ModdoException;
+
+public class ManagerCannotDeleteException extends ModdoException {
+	public ManagerCannotDeleteException(Long groupMemberId) {
+		super(HttpStatus.BAD_REQUEST, "총무(MANAGER)는 삭제할 수 없습니다. (Member ID: " + groupMemberId + ")");
+	}
+}

--- a/src/main/java/com/dnd/moddo/domain/groupMember/service/CommandGroupMemberService.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/service/CommandGroupMemberService.java
@@ -10,6 +10,7 @@ import com.dnd.moddo.domain.groupMember.dto.response.GroupMemberResponse;
 import com.dnd.moddo.domain.groupMember.dto.response.GroupMembersResponse;
 import com.dnd.moddo.domain.groupMember.entity.GroupMember;
 import com.dnd.moddo.domain.groupMember.service.implementation.GroupMemberCreator;
+import com.dnd.moddo.domain.groupMember.service.implementation.GroupMemberDeleter;
 import com.dnd.moddo.domain.groupMember.service.implementation.GroupMemberUpdater;
 
 import lombok.RequiredArgsConstructor;
@@ -19,6 +20,7 @@ import lombok.RequiredArgsConstructor;
 public class CommandGroupMemberService {
 	private final GroupMemberCreator groupMemberCreator;
 	private final GroupMemberUpdater groupMemberUpdater;
+	private final GroupMemberDeleter groupMemberDeleter;
 
 	public GroupMembersResponse create(Long groupId, GroupMembersSaveRequest request) {
 		List<GroupMember> members = groupMemberCreator.create(groupId, request);
@@ -28,6 +30,10 @@ public class CommandGroupMemberService {
 	public GroupMemberResponse addGroupMember(Long groupId, GroupMemberSaveRequest request) {
 		GroupMember groupMember = groupMemberUpdater.addToGroup(groupId, request);
 		return GroupMemberResponse.of(groupMember);
+	}
+
+	public void delete(Long groupMemberId) {
+		groupMemberDeleter.delete(groupMemberId);
 	}
 
 }

--- a/src/main/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberCreator.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberCreator.java
@@ -20,17 +20,17 @@ import lombok.RequiredArgsConstructor;
 public class GroupMemberCreator {
 	private final GroupMemberRepository groupMemberRepository;
 	private final GroupMemberValidator groupMemberValidator;
-	private final GroupRepository groupRepository; //추후 grouopReader나 다른것으로 수정할 예정
+	private final GroupRepository groupRepository; //추후 groupReader나 다른것으로 수정할 예정
 
 	public List<GroupMember> create(Long groupId, GroupMembersSaveRequest request) {
 		Group group = groupRepository.getById(groupId);
 
 		List<String> requestNames = request.members().stream().map(GroupMemberSaveRequest::name).toList();
 
+		groupMemberValidator.validateManagerExists(request.members());
 		groupMemberValidator.validateMemberNamesNotDuplicate(requestNames);
 
 		List<GroupMember> newMembers = request.toEntity(group);
 		return groupMemberRepository.saveAll(newMembers);
 	}
-
 }

--- a/src/main/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberDeleter.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberDeleter.java
@@ -1,0 +1,26 @@
+package com.dnd.moddo.domain.groupMember.service.implementation;
+
+import org.springframework.stereotype.Service;
+
+import com.dnd.moddo.domain.groupMember.entity.GroupMember;
+import com.dnd.moddo.domain.groupMember.exception.ManagerCannotDeleteException;
+import com.dnd.moddo.domain.groupMember.repository.GroupMemberRepository;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class GroupMemberDeleter {
+	private final GroupMemberRepository groupMemberRepository;
+	private final GroupMemberReader groupMemberReader;
+
+	public void delete(Long groupMemberId) {
+		GroupMember groupMember = groupMemberReader.findByGroupMemberId(groupMemberId);
+		if (groupMember.isManager()) {
+			throw new ManagerCannotDeleteException(groupMemberId);
+		}
+		groupMemberRepository.delete(groupMember);
+	}
+}

--- a/src/main/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberUpdater.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberUpdater.java
@@ -10,13 +10,14 @@ import com.dnd.moddo.domain.group.entity.Group;
 import com.dnd.moddo.domain.group.repository.GroupRepository;
 import com.dnd.moddo.domain.groupMember.dto.request.GroupMemberSaveRequest;
 import com.dnd.moddo.domain.groupMember.entity.GroupMember;
+import com.dnd.moddo.domain.groupMember.entity.type.ExpenseRole;
 import com.dnd.moddo.domain.groupMember.repository.GroupMemberRepository;
 
 import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
+@Transactional
 public class GroupMemberUpdater {
 	private final GroupMemberRepository groupMemberRepository;
 	private final GroupMemberReader groupMemberReader;
@@ -32,6 +33,6 @@ public class GroupMemberUpdater {
 
 		groupMemberValidator.validateMemberNamesNotDuplicate(existingNames);
 
-		return groupMemberRepository.save(request.toEntity(group));
+		return groupMemberRepository.save(request.toEntity(group, ExpenseRole.PARTICIPANT));
 	}
 }

--- a/src/main/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberValidator.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberValidator.java
@@ -6,7 +6,10 @@ import java.util.Set;
 
 import org.springframework.stereotype.Service;
 
+import com.dnd.moddo.domain.groupMember.dto.request.GroupMemberSaveRequest;
+import com.dnd.moddo.domain.groupMember.entity.type.ExpenseRole;
 import com.dnd.moddo.domain.groupMember.exception.GroupMemberDuplicateNameException;
+import com.dnd.moddo.domain.groupMember.exception.InvalidExpenseParticipantsException;
 
 import lombok.RequiredArgsConstructor;
 
@@ -23,5 +26,14 @@ public class GroupMemberValidator {
 	private boolean hasDuplicateMemberName(List<String> names) {
 		Set<String> uniqueNames = new HashSet<>(names);
 		return uniqueNames.size() != names.size();
+	}
+
+	public void validateManagerExists(List<GroupMemberSaveRequest> members) {
+		boolean hasManager = members.stream()
+			.anyMatch(member -> ExpenseRole.getRoleByString(member.role()).equals(ExpenseRole.MANAGER));
+
+		if (!hasManager) {
+			throw new InvalidExpenseParticipantsException();
+		}
 	}
 }

--- a/src/main/java/com/dnd/moddo/domain/memberExpense/dto/response/MemberExpenseResponse.java
+++ b/src/main/java/com/dnd/moddo/domain/memberExpense/dto/response/MemberExpenseResponse.java
@@ -1,12 +1,19 @@
 package com.dnd.moddo.domain.memberExpense.dto.response;
 
+import com.dnd.moddo.domain.groupMember.entity.type.ExpenseRole;
 import com.dnd.moddo.domain.memberExpense.entity.MemberExpense;
 
 public record MemberExpenseResponse(
+	Long id,
+	ExpenseRole role,
 	String name,
 	Long amount
 ) {
 	public static MemberExpenseResponse of(MemberExpense memberExpense) {
-		return new MemberExpenseResponse(memberExpense.getGroupMember().getName(), memberExpense.getAmount());
+		return new MemberExpenseResponse(
+			memberExpense.getGroupMember().getId(),
+			memberExpense.getGroupMember().getRole(),
+			memberExpense.getGroupMember().getName(),
+			memberExpense.getAmount());
 	}
 }

--- a/src/test/java/com/dnd/moddo/domain/expense/service/QueryExpenseServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/expense/service/QueryExpenseServiceTest.java
@@ -21,6 +21,7 @@ import com.dnd.moddo.domain.expense.entity.Expense;
 import com.dnd.moddo.domain.expense.exception.ExpenseNotFoundException;
 import com.dnd.moddo.domain.expense.service.implementation.ExpenseReader;
 import com.dnd.moddo.domain.group.entity.Group;
+import com.dnd.moddo.domain.groupMember.entity.type.ExpenseRole;
 import com.dnd.moddo.domain.memberExpense.dto.response.MemberExpenseResponse;
 import com.dnd.moddo.domain.memberExpense.service.QueryMemberExpenseService;
 
@@ -55,10 +56,12 @@ class QueryExpenseServiceTest {
 		when(expenseReader.findAllByGroupId(eq(groupId))).thenReturn(mockExpenses);
 		Long expenseId1 = 1L, expenseId2 = 2L;
 
-		List<MemberExpenseResponse> responses1 = List.of(new MemberExpenseResponse("김반숙", 15000L),
-			new MemberExpenseResponse("박완숙", 5000L));
-		List<MemberExpenseResponse> responses2 = List.of(new MemberExpenseResponse("김반숙", 15000L),
-			new MemberExpenseResponse("박완숙", 2000L));
+		List<MemberExpenseResponse> responses1 = List.of(
+			new MemberExpenseResponse(1L, ExpenseRole.MANAGER, "김모또", 15000L),
+			new MemberExpenseResponse(2L, ExpenseRole.PARTICIPANT, "박완숙", 5000L));
+		List<MemberExpenseResponse> responses2 = List.of(
+			new MemberExpenseResponse(1L, ExpenseRole.MANAGER, "김모또", 15000L),
+			new MemberExpenseResponse(2L, ExpenseRole.PARTICIPANT, "박완숙", 2000L));
 
 		when(queryMemberExpenseService.findAllByExpenseId(any()))
 			.thenReturn(responses1)

--- a/src/test/java/com/dnd/moddo/domain/groupMember/entity/GroupMemberTest.java
+++ b/src/test/java/com/dnd/moddo/domain/groupMember/entity/GroupMemberTest.java
@@ -1,0 +1,50 @@
+package com.dnd.moddo.domain.groupMember.entity;
+
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.dnd.moddo.domain.group.entity.Group;
+import com.dnd.moddo.domain.groupMember.entity.type.ExpenseRole;
+
+class GroupMemberTest {
+
+	private Group mockGroup;
+
+	@BeforeEach
+	void setUp() {
+		mockGroup = new Group("group 1", 1L, "1234", LocalDateTime.now(), LocalDateTime.now().plusMinutes(1),
+			"은행", "계좌");
+	}
+
+	@DisplayName("참여자의 역할이 총무인 경우 true를 반환한다.")
+	@Test
+	void testIsManager_whenRoleIsManager() {
+		// given
+		GroupMember groupMember = new GroupMember("김모또", mockGroup, ExpenseRole.MANAGER);
+
+		// when
+		boolean isManager = groupMember.isManager();
+
+		// then
+		assertThat(isManager).isTrue();
+	}
+
+	@DisplayName("참여자의 역할이 총무가 아닌 경우 false를 반환한다.")
+	@Test
+	void testIsManager_whenRoleIsNotManager() {
+		// given
+		GroupMember groupMember = new GroupMember("김모또", mockGroup, ExpenseRole.PARTICIPANT);
+
+		// when
+		boolean isManager = groupMember.isManager();
+
+		// then
+		assertThat(isManager).isFalse();
+	}
+
+}

--- a/src/test/java/com/dnd/moddo/domain/groupMember/service/CommandGroupMemberServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/groupMember/service/CommandGroupMemberServiceTest.java
@@ -21,6 +21,7 @@ import com.dnd.moddo.domain.groupMember.dto.request.GroupMembersSaveRequest;
 import com.dnd.moddo.domain.groupMember.dto.response.GroupMemberResponse;
 import com.dnd.moddo.domain.groupMember.dto.response.GroupMembersResponse;
 import com.dnd.moddo.domain.groupMember.entity.GroupMember;
+import com.dnd.moddo.domain.groupMember.entity.type.ExpenseRole;
 import com.dnd.moddo.domain.groupMember.service.implementation.GroupMemberCreator;
 import com.dnd.moddo.domain.groupMember.service.implementation.GroupMemberUpdater;
 
@@ -47,7 +48,10 @@ public class CommandGroupMemberServiceTest {
 		//given
 		Long groupId = mockGroup.getId();
 		GroupMembersSaveRequest request = new GroupMembersSaveRequest(new ArrayList<>());
-		List<GroupMember> expectedMembers = List.of(new GroupMember("김반숙", 1, mockGroup));
+		List<GroupMember> expectedMembers = List.of(
+			new GroupMember("김모또", 1, mockGroup, ExpenseRole.MANAGER),
+			new GroupMember("김반숙", 2, mockGroup, ExpenseRole.PARTICIPANT)
+		);
 
 		when(groupMemberCreator.create(eq(groupId), eq(request))).thenReturn(expectedMembers);
 
@@ -56,8 +60,9 @@ public class CommandGroupMemberServiceTest {
 
 		//then
 		assertThat(response).isNotNull();
-		assertThat(response.members().size()).isEqualTo(1);
-		assertThat(response.members().get(0).name()).isEqualTo("김반숙");
+		assertThat(response.members().size()).isEqualTo(2);
+		assertThat(response.members().get(0).name()).isEqualTo("김모또");
+		assertThat(response.members().get(0).role()).isEqualTo(ExpenseRole.MANAGER);
 		verify(groupMemberCreator, times(1)).create(eq(groupId), eq(request));
 	}
 
@@ -67,7 +72,7 @@ public class CommandGroupMemberServiceTest {
 		//given
 		Long groupId = mockGroup.getId();
 		GroupMemberSaveRequest request = mock(GroupMemberSaveRequest.class);
-		GroupMember expectedMember = new GroupMember("김반숙", mockGroup);
+		GroupMember expectedMember = new GroupMember("김반숙", mockGroup, ExpenseRole.PARTICIPANT);
 
 		when(groupMemberUpdater.addToGroup(eq(groupId), any(GroupMemberSaveRequest.class))).thenReturn(expectedMember);
 

--- a/src/test/java/com/dnd/moddo/domain/groupMember/service/QueryGroupMemberServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/groupMember/service/QueryGroupMemberServiceTest.java
@@ -17,6 +17,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.dnd.moddo.domain.group.entity.Group;
 import com.dnd.moddo.domain.groupMember.dto.response.GroupMembersResponse;
 import com.dnd.moddo.domain.groupMember.entity.GroupMember;
+import com.dnd.moddo.domain.groupMember.entity.type.ExpenseRole;
 import com.dnd.moddo.domain.groupMember.service.implementation.GroupMemberReader;
 
 @ExtendWith(MockitoExtension.class)
@@ -28,11 +29,17 @@ public class QueryGroupMemberServiceTest {
 	private QueryGroupMemberService queryGroupMemberService;
 
 	private Group mockGroup;
+	private List<GroupMember> mockMembers;
 
 	@BeforeEach
 	void setUp() {
 		mockGroup = new Group("group 1", 1L, "1234", LocalDateTime.now(), LocalDateTime.now().plusMinutes(1),
 			"은행", "계좌");
+
+		mockMembers = List.of(
+			new GroupMember("김모또", 1, mockGroup, ExpenseRole.MANAGER),
+			new GroupMember("김반숙", 2, mockGroup, ExpenseRole.PARTICIPANT)
+		);
 	}
 
 	@DisplayName("모임이 존재하면 모임의 모든 참여자를 조회할 수 있다.")
@@ -41,16 +48,14 @@ public class QueryGroupMemberServiceTest {
 		//given
 		Long groupId = mockGroup.getId();
 
-		List<GroupMember> mockMembers = List.of(new GroupMember("김반숙", 1, mockGroup));
-
 		when(groupMemberReader.findAllByGroupId(eq(groupId))).thenReturn(mockMembers);
 		//when
 		GroupMembersResponse response = queryGroupMemberService.findAll(groupId);
 
 		//then
 		assertThat(response).isNotNull();
-		assertThat(response.members().size()).isEqualTo(1);
-		assertThat(response.members().get(0).name()).isEqualTo("김반숙");
+		assertThat(response.members().size()).isEqualTo(2);
+		assertThat(response.members().get(0).name()).isEqualTo("김모또");
 		verify(groupMemberReader, times(1)).findAllByGroupId(eq(groupId));
 	}
 }

--- a/src/test/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberDeleterTest.java
+++ b/src/test/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberDeleterTest.java
@@ -1,0 +1,87 @@
+package com.dnd.moddo.domain.groupMember.service.implementation;
+
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.dnd.moddo.domain.group.entity.Group;
+import com.dnd.moddo.domain.groupMember.entity.GroupMember;
+import com.dnd.moddo.domain.groupMember.entity.type.ExpenseRole;
+import com.dnd.moddo.domain.groupMember.exception.GroupMemberNotFoundException;
+import com.dnd.moddo.domain.groupMember.repository.GroupMemberRepository;
+
+@ExtendWith(MockitoExtension.class)
+class GroupMemberDeleterTest {
+
+	@Mock
+	private GroupMemberRepository groupMemberRepository;
+	@Mock
+	private GroupMemberReader groupMemberReader;
+	@InjectMocks
+	private GroupMemberDeleter groupMemberDeleter;
+
+	private Group mockGroup;
+
+	@BeforeEach
+	void setUp() {
+		mockGroup = new Group("group 1", 1L, "1234", LocalDateTime.now(), LocalDateTime.now().plusMinutes(1),
+			"은행", "계좌");
+	}
+
+	@DisplayName("유효한 참여자 id로 삭제를 요청하면 성공적으로 삭제된다.")
+	@Test
+	void delete_Success_ValidGroupMemberId() {
+		//given
+		Long groupMemberId = 1L;
+		GroupMember expectedMember = new GroupMember("김반숙", mockGroup, ExpenseRole.PARTICIPANT);
+
+		when(groupMemberReader.findByGroupMemberId(eq(groupMemberId))).thenReturn(expectedMember);
+		doNothing().when(groupMemberRepository).delete(any(GroupMember.class));
+
+		//when
+		groupMemberDeleter.delete(groupMemberId);
+
+		//then
+		verify(groupMemberRepository, times(1)).delete(any(GroupMember.class));
+	}
+
+	@DisplayName("유효하지 않은 참여자 id로 삭제를 요청하면 예외가 발생한다.")
+	@Test
+	void delete_ThrowException_WithInvalidExpenseId() {
+		//given
+		Long groupMemberId = 1L;
+
+		doThrow(new GroupMemberNotFoundException(groupMemberId)).when(groupMemberReader)
+			.findByGroupMemberId(eq(groupMemberId));
+
+		//when & then
+		assertThatThrownBy(() -> {
+			groupMemberDeleter.delete(groupMemberId);
+		}).hasMessage("해당 참여자를 찾을 수 없습니다. (GroupMember ID: " + groupMemberId + ")");
+
+	}
+
+	@DisplayName("유효한 참여자 id로 삭제를 요청하면 성공적으로 삭제된다.")
+	@Test
+	void delete_ThrowException_WhenRoleIsManager() {
+		//given
+		Long groupMemberId = 1L;
+		GroupMember expectedMember = new GroupMember("김모또", mockGroup, ExpenseRole.MANAGER);
+
+		when(groupMemberReader.findByGroupMemberId(eq(groupMemberId))).thenReturn(expectedMember);
+
+		//when & then
+		assertThatThrownBy(() -> {
+			groupMemberDeleter.delete(groupMemberId);
+		}).hasMessage("총무(MANAGER)는 삭제할 수 없습니다. (Member ID: " + groupMemberId + ")");
+	}
+}

--- a/src/test/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberReaderTest.java
+++ b/src/test/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberReaderTest.java
@@ -16,6 +16,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.dnd.moddo.domain.group.entity.Group;
 import com.dnd.moddo.domain.groupMember.entity.GroupMember;
+import com.dnd.moddo.domain.groupMember.entity.type.ExpenseRole;
 import com.dnd.moddo.domain.groupMember.exception.GroupMemberNotFoundException;
 import com.dnd.moddo.domain.groupMember.repository.GroupMemberRepository;
 
@@ -39,7 +40,10 @@ public class GroupMemberReaderTest {
 	void findAllByGroupIdSuccess() {
 		//given
 		Long groupId = mockGroup.getId();
-		List<GroupMember> expectedMembers = List.of(new GroupMember("김반숙", 1, mockGroup));
+		List<GroupMember> expectedMembers = List.of(
+			new GroupMember("김모또", 1, mockGroup, ExpenseRole.MANAGER),
+			new GroupMember("김반숙", 2, mockGroup, ExpenseRole.PARTICIPANT)
+		);
 
 		when(groupMemberRepository.findByGroupId(eq(groupId))).thenReturn(expectedMembers);
 
@@ -48,8 +52,9 @@ public class GroupMemberReaderTest {
 
 		//then
 		assertThat(result).isNotNull();
-		assertThat(result.size()).isEqualTo(1);
-		assertThat(result.get(0).getName()).isEqualTo("김반숙");
+		assertThat(result.size()).isEqualTo(2);
+		assertThat(result.get(0).getName()).isEqualTo("김모또");
+		assertThat(result.get(0).getRole()).isEqualTo(ExpenseRole.MANAGER);
 		verify(groupMemberRepository, times(1)).findByGroupId(groupId);
 	}
 
@@ -58,7 +63,7 @@ public class GroupMemberReaderTest {
 	void findByGroupMemberIdSuccess() {
 		//given
 		Long groupMemberId = 1L;
-		GroupMember expectedMember = new GroupMember("김반숙", mockGroup);
+		GroupMember expectedMember = new GroupMember("김반숙", mockGroup, ExpenseRole.PARTICIPANT);
 
 		when(groupMemberRepository.getById(eq(groupMemberId))).thenReturn(expectedMember);
 

--- a/src/test/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberUpdaterTest.java
+++ b/src/test/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberUpdaterTest.java
@@ -20,6 +20,7 @@ import com.dnd.moddo.domain.group.entity.Group;
 import com.dnd.moddo.domain.group.repository.GroupRepository;
 import com.dnd.moddo.domain.groupMember.dto.request.GroupMemberSaveRequest;
 import com.dnd.moddo.domain.groupMember.entity.GroupMember;
+import com.dnd.moddo.domain.groupMember.entity.type.ExpenseRole;
 import com.dnd.moddo.domain.groupMember.exception.GroupMemberDuplicateNameException;
 import com.dnd.moddo.domain.groupMember.repository.GroupMemberRepository;
 
@@ -57,7 +58,7 @@ class GroupMemberUpdaterTest {
 
 		doNothing().when(groupMemberValidator).validateMemberNamesNotDuplicate(any());
 
-		GroupMember expectedGroupMember = new GroupMember("김반숙", mockGroup);
+		GroupMember expectedGroupMember = new GroupMember("김반숙", mockGroup, ExpenseRole.PARTICIPANT);
 		when(groupMemberRepository.save(any())).thenReturn(expectedGroupMember);
 
 		//when

--- a/src/test/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberValidatorTest.java
+++ b/src/test/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberValidatorTest.java
@@ -7,6 +7,8 @@ import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import com.dnd.moddo.domain.groupMember.dto.request.GroupMemberSaveRequest;
+
 class GroupMemberValidatorTest {
 	private final GroupMemberValidator groupMemberValidator = new GroupMemberValidator();
 
@@ -22,11 +24,33 @@ class GroupMemberValidatorTest {
 
 	@DisplayName("중복된 이름이 있는 경우 검증에 실패하여 예외가 발생한다.")
 	@Test
-	void validateGroupMemberManesIsDuplicate() {
+	void validateGroupMemberNamesIsDuplicate() {
 		List<String> names = List.of("김반숙", "이계란", "김반숙");
 
 		assertThatThrownBy(() -> {
 			groupMemberValidator.validateMemberNamesNotDuplicate(names);
 		}).hasMessage("중복된 참여자의 이름은 저장할 수 없습니다.");
+	}
+
+	@DisplayName("참여자 역할에 정산담당자가 존재하면 성공한다.")
+	@Test
+	void validateParticipant_Success() {
+		List<GroupMemberSaveRequest> members = List.of(new GroupMemberSaveRequest("김모또", "MANAGER"),
+			new GroupMemberSaveRequest("김반숙", "PARTICIPANT"));
+
+		assertThatCode(() -> {
+			groupMemberValidator.validateManagerExists(members);
+		}).doesNotThrowAnyException();
+	}
+
+	@DisplayName("참여자 역할에 정산담당자가 존재하지 않으면 예외가 발생한다.")
+	@Test
+	void validateParticipant_ThrowException_WhenNoManagerPresent() {
+		List<GroupMemberSaveRequest> members = List.of(new GroupMemberSaveRequest("김모또", "PARTICIPANT"),
+			new GroupMemberSaveRequest("김반숙", "PARTICIPANT"));
+
+		assertThatThrownBy(() -> {
+			groupMemberValidator.validateManagerExists(members);
+		}).hasMessage("총무(MANAGER)는 한 명 있어야 합니다.");
 	}
 }

--- a/src/test/java/com/dnd/moddo/domain/memberExpense/service/QueryMemberExpenseServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/memberExpense/service/QueryMemberExpenseServiceTest.java
@@ -18,6 +18,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.dnd.moddo.domain.expense.entity.Expense;
 import com.dnd.moddo.domain.group.entity.Group;
 import com.dnd.moddo.domain.groupMember.entity.GroupMember;
+import com.dnd.moddo.domain.groupMember.entity.type.ExpenseRole;
 import com.dnd.moddo.domain.memberExpense.dto.response.MemberExpenseResponse;
 import com.dnd.moddo.domain.memberExpense.entity.MemberExpense;
 import com.dnd.moddo.domain.memberExpense.service.implementation.MemberExpenseReader;
@@ -45,8 +46,8 @@ class QueryMemberExpenseServiceTest {
 	void findAllByExpenseId() {
 		//given
 		Long expenseId = 1L;
-		GroupMember mockGroupMember1 = new GroupMember("박완숙", mockGroup);
-		GroupMember mockGroupMember2 = new GroupMember("김반숙", mockGroup);
+		GroupMember mockGroupMember1 = new GroupMember("김모또", mockGroup, ExpenseRole.MANAGER);
+		GroupMember mockGroupMember2 = new GroupMember("박완숙", mockGroup, ExpenseRole.PARTICIPANT);
 
 		List<MemberExpense> expectedMemberExpense = List.of(
 			new MemberExpense(mockExpense, mockGroupMember1, 15000L),
@@ -60,8 +61,8 @@ class QueryMemberExpenseServiceTest {
 
 		//then
 		assertThat(responses).isNotNull();
-		assertThat(responses.size()).isEqualTo(expectedMemberExpense.size());
-		assertThat(responses.get(0).name()).isEqualTo("박완숙");
+		assertThat(responses.size()).isEqualTo(2);
+		assertThat(responses.get(0).name()).isEqualTo("김모또");
 		assertThat(responses.get(0).amount()).isEqualTo(15000L);
 
 	}

--- a/src/test/java/com/dnd/moddo/domain/memberExpense/service/implementation/MemberExpenseCreatorTest.java
+++ b/src/test/java/com/dnd/moddo/domain/memberExpense/service/implementation/MemberExpenseCreatorTest.java
@@ -17,6 +17,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.dnd.moddo.domain.expense.entity.Expense;
 import com.dnd.moddo.domain.group.entity.Group;
 import com.dnd.moddo.domain.groupMember.entity.GroupMember;
+import com.dnd.moddo.domain.groupMember.entity.type.ExpenseRole;
 import com.dnd.moddo.domain.memberExpense.dto.request.MemberExpenseRequest;
 import com.dnd.moddo.domain.memberExpense.entity.MemberExpense;
 import com.dnd.moddo.domain.memberExpense.repotiroy.MemberExpenseRepository;
@@ -38,7 +39,7 @@ class MemberExpenseCreatorTest {
 		mockGroup = new Group("group 1", 1L, "1234", LocalDateTime.now(), LocalDateTime.now().plusMinutes(1),
 			"은행", "계좌");
 		mockExpense = new Expense(mockGroup, 20000L, "투썸플레이스", 1, LocalDate.of(2025, 02, 03));
-		mockGroupMember = new GroupMember("박완수", mockGroup);
+		mockGroupMember = new GroupMember("박완수", mockGroup, ExpenseRole.MANAGER);
 		mockMemberExpenseRequest = mock(MemberExpenseRequest.class);
 	}
 

--- a/src/test/java/com/dnd/moddo/domain/memberExpense/service/implementation/MemberExpenseReaderTest.java
+++ b/src/test/java/com/dnd/moddo/domain/memberExpense/service/implementation/MemberExpenseReaderTest.java
@@ -18,6 +18,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.dnd.moddo.domain.expense.entity.Expense;
 import com.dnd.moddo.domain.group.entity.Group;
 import com.dnd.moddo.domain.groupMember.entity.GroupMember;
+import com.dnd.moddo.domain.groupMember.entity.type.ExpenseRole;
 import com.dnd.moddo.domain.memberExpense.entity.MemberExpense;
 import com.dnd.moddo.domain.memberExpense.repotiroy.MemberExpenseRepository;
 
@@ -38,7 +39,7 @@ class MemberExpenseReaderTest {
 			"은행", "계좌");
 		mockExpense = new Expense(mockGroup, 20000L, "투썸플레이스", 0, LocalDate.of(2025, 02, 03));
 
-		mockGroupMember = new GroupMember("박완숙", mockGroup);
+		mockGroupMember = new GroupMember("박완숙", mockGroup, ExpenseRole.MANAGER);
 
 	}
 


### PR DESCRIPTION
### #️⃣연관된 이슈
#38 

### 🔀반영 브랜치
feat/#38-groupmember-add-role -> develop

### 🔧변경 사항
- 참여자 엔티티에 역할에 대한 필드를 추가하였습니다.
- 해당 필드를 입력받기 위해 참여자 생성 request를 수정하였습니다.
- 참여자 생성 시 역할에 대한 유효성 검사를 추가하였습니다.
- 참여자별 지출 내역 조회에 id 및 역할을 함께 조회 할 수 있도록 수정하였습니다.
- 참여자 삭제에 대한 기능을 추가하였습니다.

### 💬리뷰 요구사항(선택)
