### PR TITLE
지출 내역 순서 변경에 대한 기능 추가

### DIFF
--- a/src/main/java/com/dnd/moddo/domain/expense/controller/ExpenseController.java
+++ b/src/main/java/com/dnd/moddo/domain/expense/controller/ExpenseController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.dnd.moddo.domain.expense.dto.request.ExpenseRequest;
 import com.dnd.moddo.domain.expense.dto.request.ExpensesRequest;
+import com.dnd.moddo.domain.expense.dto.request.ExpensesUpdateOrderRequest;
 import com.dnd.moddo.domain.expense.dto.response.ExpenseResponse;
 import com.dnd.moddo.domain.expense.dto.response.ExpensesResponse;
 import com.dnd.moddo.domain.expense.service.CommandExpenseService;
@@ -54,6 +55,14 @@ public class ExpenseController {
 		@PathVariable("expenseId") Long expenseId,
 		@RequestBody ExpenseRequest request) {
 		ExpenseResponse response = commandExpenseService.update(expenseId, request);
+		return ResponseEntity.ok(response);
+
+	}
+
+	@PutMapping("/order")
+	public ResponseEntity<ExpensesResponse> updateExpenseOrder(@RequestParam("groupId") Long groupId,
+		@RequestBody ExpensesUpdateOrderRequest request) {
+		ExpensesResponse response = commandExpenseService.updateOrder(request);
 		return ResponseEntity.ok(response);
 
 	}

--- a/src/main/java/com/dnd/moddo/domain/expense/dto/request/ExpensesUpdateOrderRequest.java
+++ b/src/main/java/com/dnd/moddo/domain/expense/dto/request/ExpensesUpdateOrderRequest.java
@@ -1,0 +1,8 @@
+package com.dnd.moddo.domain.expense.dto.request;
+
+import java.util.List;
+
+public record ExpensesUpdateOrderRequest(
+	List<ExpenseUpdateOrderRequest> orders
+) {
+}

--- a/src/main/java/com/dnd/moddo/domain/expense/service/CommandExpenseService.java
+++ b/src/main/java/com/dnd/moddo/domain/expense/service/CommandExpenseService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 
 import com.dnd.moddo.domain.expense.dto.request.ExpenseRequest;
 import com.dnd.moddo.domain.expense.dto.request.ExpensesRequest;
+import com.dnd.moddo.domain.expense.dto.request.ExpensesUpdateOrderRequest;
 import com.dnd.moddo.domain.expense.dto.response.ExpenseResponse;
 import com.dnd.moddo.domain.expense.dto.response.ExpensesResponse;
 import com.dnd.moddo.domain.expense.entity.Expense;
@@ -15,6 +16,7 @@ import com.dnd.moddo.domain.expense.service.implementation.ExpenseReader;
 import com.dnd.moddo.domain.expense.service.implementation.ExpenseUpdater;
 import com.dnd.moddo.domain.memberExpense.dto.response.MemberExpenseResponse;
 import com.dnd.moddo.domain.memberExpense.service.CommandMemberExpenseService;
+import com.dnd.moddo.domain.memberExpense.service.QueryMemberExpenseService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -26,6 +28,7 @@ public class CommandExpenseService {
 	private final ExpenseUpdater expenseUpdater;
 	private final ExpenseDeleter expenseDeleter;
 	private final CommandMemberExpenseService commandMemberExpenseService;
+	private final QueryMemberExpenseService queryMemberExpenseService;
 
 	public ExpensesResponse createExpenses(Long groupId, ExpensesRequest request) {
 		List<ExpenseResponse> expenses = request.expenses()
@@ -48,6 +51,16 @@ public class CommandExpenseService {
 		Expense expense = expenseUpdater.update(expenseId, request);
 		return ExpenseResponse.of(expense);
 
+	}
+
+	public ExpensesResponse updateOrder(ExpensesUpdateOrderRequest request) {
+		List<Expense> expenses = expenseUpdater.updateOrder(request);
+		return new ExpensesResponse(
+			expenses.stream()
+				.map(expense ->
+					ExpenseResponse.of(expense, queryMemberExpenseService.findAllByExpenseId(expense.getId()))
+				).toList()
+		);
 	}
 
 	public void delete(Long expenseId) {

--- a/src/main/java/com/dnd/moddo/domain/expense/service/implementation/ExpenseUpdater.java
+++ b/src/main/java/com/dnd/moddo/domain/expense/service/implementation/ExpenseUpdater.java
@@ -1,9 +1,12 @@
 package com.dnd.moddo.domain.expense.service.implementation;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.dnd.moddo.domain.expense.dto.request.ExpenseRequest;
+import com.dnd.moddo.domain.expense.dto.request.ExpensesUpdateOrderRequest;
 import com.dnd.moddo.domain.expense.entity.Expense;
 import com.dnd.moddo.domain.expense.repository.ExpenseRepository;
 
@@ -19,5 +22,15 @@ public class ExpenseUpdater {
 		Expense expense = expenseRepository.getById(expenseId);
 		expense.update(request.amount(), request.content(), request.date());
 		return expense;
+	}
+
+	public List<Expense> updateOrder(ExpensesUpdateOrderRequest request) {
+		return request.orders()
+			.stream()
+			.map(r -> {
+				Expense expense = expenseRepository.getById(r.expenseId());
+				expense.updateOrder(r.newOrder());
+				return expense;
+			}).toList();
 	}
 }

--- a/src/test/java/com/dnd/moddo/domain/expense/service/CommandExpenseServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/expense/service/CommandExpenseServiceTest.java
@@ -18,6 +18,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.dnd.moddo.domain.expense.dto.request.ExpenseRequest;
 import com.dnd.moddo.domain.expense.dto.request.ExpensesRequest;
+import com.dnd.moddo.domain.expense.dto.request.ExpensesUpdateOrderRequest;
 import com.dnd.moddo.domain.expense.dto.response.ExpenseResponse;
 import com.dnd.moddo.domain.expense.dto.response.ExpensesResponse;
 import com.dnd.moddo.domain.expense.entity.Expense;
@@ -27,7 +28,10 @@ import com.dnd.moddo.domain.expense.service.implementation.ExpenseDeleter;
 import com.dnd.moddo.domain.expense.service.implementation.ExpenseReader;
 import com.dnd.moddo.domain.expense.service.implementation.ExpenseUpdater;
 import com.dnd.moddo.domain.group.entity.Group;
+import com.dnd.moddo.domain.groupMember.entity.type.ExpenseRole;
+import com.dnd.moddo.domain.memberExpense.dto.response.MemberExpenseResponse;
 import com.dnd.moddo.domain.memberExpense.service.CommandMemberExpenseService;
+import com.dnd.moddo.domain.memberExpense.service.QueryMemberExpenseService;
 
 @ExtendWith(MockitoExtension.class)
 class CommandExpenseServiceTest {
@@ -42,6 +46,8 @@ class CommandExpenseServiceTest {
 	private ExpenseDeleter expenseDeleter;
 	@Mock
 	private CommandMemberExpenseService commandMemberExpenseService;
+	@Mock
+	private QueryMemberExpenseService queryMemberExpenseService;
 	@InjectMocks
 	private CommandExpenseService commandExpenseService;
 
@@ -102,6 +108,40 @@ class CommandExpenseServiceTest {
 		assertThat(response).isEqualTo(expectedResponse);
 
 		verify(expenseUpdater, times(1)).update(expenseId, expenseRequest);
+	}
+
+	@DisplayName("지출내역이 존재할 때 기존의 지출내역의 순서를 변경할 수 있다.")
+	@Test
+	void updateOrder_Success_ValidRequest() {
+		//given
+		Expense expense1 = new Expense(mockGroup, 20000L, "expense 1", 1, LocalDate.of(2025, 02, 03));
+		Expense expense2 = new Expense(mockGroup, 15000L, "expense 2", 2, LocalDate.of(2025, 02, 03));
+		List<Expense> expectedExpenses = List.of(expense1, expense2);
+		ExpensesUpdateOrderRequest request = new ExpensesUpdateOrderRequest(new ArrayList<>());
+
+		when(expenseUpdater.updateOrder(request)).thenReturn(expectedExpenses);
+
+		List<MemberExpenseResponse> responses1 = List.of(
+			new MemberExpenseResponse(1L, ExpenseRole.MANAGER, "김모또", 15000L),
+			new MemberExpenseResponse(2L, ExpenseRole.PARTICIPANT, "박완숙", 5000L));
+		List<MemberExpenseResponse> responses2 = List.of(
+			new MemberExpenseResponse(1L, ExpenseRole.MANAGER, "김모또", 15000L),
+			new MemberExpenseResponse(2L, ExpenseRole.PARTICIPANT, "박완숙", 2000L));
+
+		when(queryMemberExpenseService.findAllByExpenseId(any()))
+			.thenReturn(responses1)
+			.thenReturn(responses2);
+
+		// when
+		ExpensesResponse response = commandExpenseService.updateOrder(request);
+
+		//then
+		assertThat(response).isNotNull();
+		assertThat(response.expenses().size()).isEqualTo(2);
+		assertThat(response.expenses().get(0).content()).isEqualTo("expense 1");
+		assertThat(response.expenses().get(0).memberExpenses().size()).isEqualTo(2);
+
+		verify(expenseUpdater, times(1)).updateOrder(request);
 	}
 
 	@DisplayName("업데이트하려는 지출 내역을 찾을 수 없을때 예외를 발생시킨다.")

--- a/src/test/java/com/dnd/moddo/domain/expense/service/implementation/ExpenseUpdaterTest.java
+++ b/src/test/java/com/dnd/moddo/domain/expense/service/implementation/ExpenseUpdaterTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.*;
 import static org.mockito.Mockito.*;
 
 import java.time.LocalDate;
+import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -13,9 +14,12 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.dnd.moddo.domain.expense.dto.request.ExpenseRequest;
+import com.dnd.moddo.domain.expense.dto.request.ExpenseUpdateOrderRequest;
+import com.dnd.moddo.domain.expense.dto.request.ExpensesUpdateOrderRequest;
 import com.dnd.moddo.domain.expense.entity.Expense;
 import com.dnd.moddo.domain.expense.exception.ExpenseNotFoundException;
 import com.dnd.moddo.domain.expense.repository.ExpenseRepository;
+import com.dnd.moddo.domain.group.entity.Group;
 
 @ExtendWith(MockitoExtension.class)
 class ExpenseUpdaterTest {
@@ -57,5 +61,30 @@ class ExpenseUpdaterTest {
 		assertThatThrownBy(() -> {
 			expenseUpdater.update(expenseId, request);
 		}).hasMessage("해당 지출내역을 찾을 수 없습니다. (Expense ID: " + expenseId + ")");
+	}
+
+	@DisplayName("요청이 유효하게 들어오면 지출 내역의 순서를 변경할 수 있다.")
+	@Test
+	void upateOrder_Success() {
+		//given
+		ExpensesUpdateOrderRequest request = new ExpensesUpdateOrderRequest(
+			List.of(new ExpenseUpdateOrderRequest(2, 1L),
+				new ExpenseUpdateOrderRequest(1, 2L)
+			)
+		);
+		Group group = mock(Group.class);
+		Expense expense1 = new Expense(group, 20000L, "expense 1", 1, LocalDate.of(2025, 02, 03));
+		Expense expense2 = new Expense(group, 15000L, "expense 2", 2, LocalDate.of(2025, 02, 03));
+
+		when(expenseRepository.getById(any()))
+			.thenReturn(expense1)
+			.thenReturn(expense2);
+
+		//when
+		expenseUpdater.updateOrder(request);
+
+		//then
+		assertThat(expense1.getOrder()).isEqualTo(2);
+		assertThat(expense2.getOrder()).isEqualTo(1);
 	}
 }


### PR DESCRIPTION
### #️⃣연관된 이슈
#43 

### 🔀반영 브랜치
feat/#43-change-expense-order -> develop

### 🔧변경 사항
- 지출 내역의 순서를 변경하는 기능을 추가하였습니다.
- 지출 내역 순서 변겡에 대한 테스트 코드를 추가하였습니다.

### 💬리뷰 요구사항(선택)
