### PR TITLE
참여자별 정산내역 조회 기능 추가

### DIFF
--- a/src/main/java/com/dnd/moddo/domain/expense/controller/ExpenseController.java
+++ b/src/main/java/com/dnd/moddo/domain/expense/controller/ExpenseController.java
@@ -1,7 +1,5 @@
 package com.dnd.moddo.domain.expense.controller;
 
-import com.dnd.moddo.global.jwt.service.JwtService;
-import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -19,6 +17,8 @@ import com.dnd.moddo.domain.expense.dto.response.ExpenseResponse;
 import com.dnd.moddo.domain.expense.dto.response.ExpensesResponse;
 import com.dnd.moddo.domain.expense.service.CommandExpenseService;
 import com.dnd.moddo.domain.expense.service.QueryExpenseService;
+import com.dnd.moddo.domain.groupMember.dto.response.GroupMembersExpenseResponse;
+import com.dnd.moddo.global.jwt.service.JwtService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -33,8 +33,8 @@ public class ExpenseController {
 
 	@PostMapping
 	public ResponseEntity<ExpensesResponse> saveExpenses(
-			@RequestParam("groupToken") String groupToken,
-			@RequestBody ExpensesRequest request) {
+		@RequestParam("groupToken") String groupToken,
+		@RequestBody ExpensesRequest request) {
 		Long groupId = jwtService.getGroupId(groupToken);
 		ExpensesResponse response = commandExpenseService.createExpenses(groupId, request);
 		return ResponseEntity.ok(response);
@@ -66,5 +66,13 @@ public class ExpenseController {
 	public ResponseEntity<Void> deleteByExpenseId(@PathVariable("expenseId") Long expenseId) {
 		commandExpenseService.delete(expenseId);
 		return ResponseEntity.noContent().build();
+	}
+
+	@GetMapping("/settlement")
+	public ResponseEntity<GroupMembersExpenseResponse> getSettlement(
+		@RequestParam("groupId") Long groupId
+	) {
+		GroupMembersExpenseResponse response = queryExpenseService.findSettlementByGroupId(groupId);
+		return ResponseEntity.ok(response);
 	}
 }

--- a/src/main/java/com/dnd/moddo/domain/expense/controller/ExpenseController.java
+++ b/src/main/java/com/dnd/moddo/domain/expense/controller/ExpenseController.java
@@ -17,7 +17,6 @@ import com.dnd.moddo.domain.expense.dto.response.ExpenseResponse;
 import com.dnd.moddo.domain.expense.dto.response.ExpensesResponse;
 import com.dnd.moddo.domain.expense.service.CommandExpenseService;
 import com.dnd.moddo.domain.expense.service.QueryExpenseService;
-import com.dnd.moddo.domain.groupMember.dto.response.GroupMembersExpenseResponse;
 import com.dnd.moddo.global.jwt.service.JwtService;
 
 import lombok.RequiredArgsConstructor;
@@ -68,12 +67,4 @@ public class ExpenseController {
 		return ResponseEntity.noContent().build();
 	}
 
-	@GetMapping("/settlement")
-	public ResponseEntity<GroupMembersExpenseResponse> getSettlement(
-		@RequestParam("groupToken") String groupToken
-	) {
-		Long groupId = jwtService.getGroupId(groupToken);
-		GroupMembersExpenseResponse response = queryExpenseService.findSettlementsByGroupId(groupId);
-		return ResponseEntity.ok(response);
-	}
 }

--- a/src/main/java/com/dnd/moddo/domain/expense/controller/ExpenseController.java
+++ b/src/main/java/com/dnd/moddo/domain/expense/controller/ExpenseController.java
@@ -13,7 +13,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.dnd.moddo.domain.expense.dto.request.ExpenseRequest;
 import com.dnd.moddo.domain.expense.dto.request.ExpensesRequest;
-import com.dnd.moddo.domain.expense.dto.request.ExpensesUpdateOrderRequest;
 import com.dnd.moddo.domain.expense.dto.response.ExpenseResponse;
 import com.dnd.moddo.domain.expense.dto.response.ExpensesResponse;
 import com.dnd.moddo.domain.expense.service.CommandExpenseService;
@@ -55,14 +54,6 @@ public class ExpenseController {
 		@PathVariable("expenseId") Long expenseId,
 		@RequestBody ExpenseRequest request) {
 		ExpenseResponse response = commandExpenseService.update(expenseId, request);
-		return ResponseEntity.ok(response);
-
-	}
-
-	@PutMapping("/order")
-	public ResponseEntity<ExpensesResponse> updateExpenseOrder(@RequestParam("groupId") Long groupId,
-		@RequestBody ExpensesUpdateOrderRequest request) {
-		ExpensesResponse response = commandExpenseService.updateOrder(request);
 		return ResponseEntity.ok(response);
 
 	}

--- a/src/main/java/com/dnd/moddo/domain/expense/controller/ExpenseController.java
+++ b/src/main/java/com/dnd/moddo/domain/expense/controller/ExpenseController.java
@@ -70,8 +70,9 @@ public class ExpenseController {
 
 	@GetMapping("/settlement")
 	public ResponseEntity<GroupMembersExpenseResponse> getSettlement(
-		@RequestParam("groupId") Long groupId
+		@RequestParam("groupToken") String groupToken
 	) {
+		Long groupId = jwtService.getGroupId(groupToken);
 		GroupMembersExpenseResponse response = queryExpenseService.findSettlementByGroupId(groupId);
 		return ResponseEntity.ok(response);
 	}

--- a/src/main/java/com/dnd/moddo/domain/expense/controller/ExpenseController.java
+++ b/src/main/java/com/dnd/moddo/domain/expense/controller/ExpenseController.java
@@ -73,7 +73,7 @@ public class ExpenseController {
 		@RequestParam("groupToken") String groupToken
 	) {
 		Long groupId = jwtService.getGroupId(groupToken);
-		GroupMembersExpenseResponse response = queryExpenseService.findSettlementByGroupId(groupId);
+		GroupMembersExpenseResponse response = queryExpenseService.findSettlementsByGroupId(groupId);
 		return ResponseEntity.ok(response);
 	}
 }

--- a/src/main/java/com/dnd/moddo/domain/expense/dto/request/ExpenseRequest.java
+++ b/src/main/java/com/dnd/moddo/domain/expense/dto/request/ExpenseRequest.java
@@ -17,7 +17,7 @@ public record ExpenseRequest(
 
 ) {
 
-	public Expense toEntity(Group group, int maxOrder) {
-		return new Expense(group, amount(), content(), maxOrder, date());
+	public Expense toEntity(Group group) {
+		return new Expense(group, amount(), content(), date());
 	}
 }

--- a/src/main/java/com/dnd/moddo/domain/expense/dto/request/ExpenseUpdateOrderRequest.java
+++ b/src/main/java/com/dnd/moddo/domain/expense/dto/request/ExpenseUpdateOrderRequest.java
@@ -1,4 +1,0 @@
-package com.dnd.moddo.domain.expense.dto.request;
-
-public record ExpenseUpdateOrderRequest(int newOrder, Long expenseId) {
-}

--- a/src/main/java/com/dnd/moddo/domain/expense/dto/request/ExpensesRequest.java
+++ b/src/main/java/com/dnd/moddo/domain/expense/dto/request/ExpensesRequest.java
@@ -8,9 +8,9 @@ import com.dnd.moddo.domain.group.entity.Group;
 public record ExpensesRequest(
 	List<ExpenseRequest> expenses
 ) {
-	public List<Expense> toEntity(Group group, int maxOrder) {
+	public List<Expense> toEntity(Group group) {
 		return expenses.stream()
-			.map(e -> e.toEntity(group, maxOrder))
+			.map(e -> e.toEntity(group))
 			.toList();
 	}
 }

--- a/src/main/java/com/dnd/moddo/domain/expense/dto/request/ExpensesUpdateOrderRequest.java
+++ b/src/main/java/com/dnd/moddo/domain/expense/dto/request/ExpensesUpdateOrderRequest.java
@@ -1,8 +1,0 @@
-package com.dnd.moddo.domain.expense.dto.request;
-
-import java.util.List;
-
-public record ExpensesUpdateOrderRequest(
-	List<ExpenseUpdateOrderRequest> orders
-) {
-}

--- a/src/main/java/com/dnd/moddo/domain/expense/dto/response/ExpenseResponse.java
+++ b/src/main/java/com/dnd/moddo/domain/expense/dto/response/ExpenseResponse.java
@@ -7,17 +7,17 @@ import com.dnd.moddo.domain.expense.entity.Expense;
 import com.dnd.moddo.domain.memberExpense.dto.response.MemberExpenseResponse;
 
 public record ExpenseResponse(
-	Long id, Long amount, String content, int order, LocalDate date,
+	Long id, Long amount, String content, LocalDate date,
 	List<MemberExpenseResponse> memberExpenses
 ) {
 	public static ExpenseResponse of(Expense expense, List<MemberExpenseResponse> memberExpenses) {
-		return new ExpenseResponse(expense.getId(), expense.getAmount(), expense.getContent(), expense.getOrder(),
+		return new ExpenseResponse(expense.getId(), expense.getAmount(), expense.getContent(),
 			expense.getDate(),
 			memberExpenses);
 	}
 
 	public static ExpenseResponse of(Expense expense) {
-		return new ExpenseResponse(expense.getId(), expense.getAmount(), expense.getContent(), expense.getOrder(),
+		return new ExpenseResponse(expense.getId(), expense.getAmount(), expense.getContent(),
 			expense.getDate(), null);
 	}
 }

--- a/src/main/java/com/dnd/moddo/domain/expense/entity/Expense.java
+++ b/src/main/java/com/dnd/moddo/domain/expense/entity/Expense.java
@@ -6,7 +6,6 @@ import java.util.List;
 import com.dnd.moddo.domain.group.entity.Group;
 import com.fasterxml.jackson.annotation.JsonFormat;
 
-import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -37,31 +36,23 @@ public class Expense {
 
 	private String content;
 
-	@Column(name = "`order`")
-	private Integer order;
-
 	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
 	private LocalDate date;
 
 	//TODO List 직렬화 @Convert 추가하기
 	private List<String> images;
 
-	public Expense(Group group, Long amount, String content, int order, LocalDate date) {
-		this(group, amount, content, order, date, null);
+	public Expense(Group group, Long amount, String content, LocalDate date) {
+		this(group, amount, content, date, null);
 	}
 
 	@Builder
-	public Expense(Group group, Long amount, String content, int order, LocalDate date, List<String> images) {
+	public Expense(Group group, Long amount, String content, LocalDate date, List<String> images) {
 		this.group = group;
 		this.amount = amount;
 		this.content = content;
-		this.order = order;
 		this.date = date;
 		this.images = images;
-	}
-
-	public void updateOrder(int order) {
-		this.order = order;
 	}
 
 	public void update(Long amount, String content, LocalDate date) {

--- a/src/main/java/com/dnd/moddo/domain/expense/repository/ExpenseRepository.java
+++ b/src/main/java/com/dnd/moddo/domain/expense/repository/ExpenseRepository.java
@@ -3,8 +3,6 @@ package com.dnd.moddo.domain.expense.repository;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import com.dnd.moddo.domain.expense.entity.Expense;
 import com.dnd.moddo.domain.expense.exception.ExpenseNotFoundException;
@@ -12,14 +10,10 @@ import com.dnd.moddo.domain.expense.exception.ExpenseNotFoundException;
 public interface ExpenseRepository extends JpaRepository<Expense, Long> {
 	List<Expense> findByGroupId(Long groupId);
 
-	List<Expense> findByGroupIdOrderByOrderAsc(Long id);
-
-	@Query("select COALESCE(MAX(e.order),0) from Expense e where e.group.id = :groupId")
-	int findMaxOrderByGroupId(@Param("groupId") Long groupId);
-
+	List<Expense> findByGroupIdOrderByDateAsc(Long id);
+	
 	default Expense getById(Long id) {
 		return findById(id)
 			.orElseThrow(() -> new ExpenseNotFoundException(id));
 	}
-
 }

--- a/src/main/java/com/dnd/moddo/domain/expense/service/CommandExpenseService.java
+++ b/src/main/java/com/dnd/moddo/domain/expense/service/CommandExpenseService.java
@@ -43,7 +43,9 @@ public class CommandExpenseService {
 
 	public ExpenseResponse update(Long expenseId, ExpenseRequest request) {
 		Expense expense = expenseUpdater.update(expenseId, request);
-		return ExpenseResponse.of(expense);
+		List<MemberExpenseResponse> memberExpenseResponses = commandMemberExpenseService.update(expenseId,
+			request.memberExpenses());
+		return ExpenseResponse.of(expense, memberExpenseResponses);
 
 	}
 

--- a/src/main/java/com/dnd/moddo/domain/expense/service/CommandExpenseService.java
+++ b/src/main/java/com/dnd/moddo/domain/expense/service/CommandExpenseService.java
@@ -36,7 +36,7 @@ public class CommandExpenseService {
 	private ExpenseResponse createExpense(Long groupId, ExpenseRequest request) {
 		Expense expense = expenseCreator.create(groupId, request);
 
-		List<MemberExpenseResponse> memberExpenseResponses = commandMemberExpenseService.create(expense,
+		List<MemberExpenseResponse> memberExpenseResponses = commandMemberExpenseService.create(expense.getId(),
 			request.memberExpenses());
 		return ExpenseResponse.of(expense, memberExpenseResponses);
 	}

--- a/src/main/java/com/dnd/moddo/domain/expense/service/CommandExpenseService.java
+++ b/src/main/java/com/dnd/moddo/domain/expense/service/CommandExpenseService.java
@@ -6,17 +6,14 @@ import org.springframework.stereotype.Service;
 
 import com.dnd.moddo.domain.expense.dto.request.ExpenseRequest;
 import com.dnd.moddo.domain.expense.dto.request.ExpensesRequest;
-import com.dnd.moddo.domain.expense.dto.request.ExpensesUpdateOrderRequest;
 import com.dnd.moddo.domain.expense.dto.response.ExpenseResponse;
 import com.dnd.moddo.domain.expense.dto.response.ExpensesResponse;
 import com.dnd.moddo.domain.expense.entity.Expense;
 import com.dnd.moddo.domain.expense.service.implementation.ExpenseCreator;
 import com.dnd.moddo.domain.expense.service.implementation.ExpenseDeleter;
-import com.dnd.moddo.domain.expense.service.implementation.ExpenseReader;
 import com.dnd.moddo.domain.expense.service.implementation.ExpenseUpdater;
 import com.dnd.moddo.domain.memberExpense.dto.response.MemberExpenseResponse;
 import com.dnd.moddo.domain.memberExpense.service.CommandMemberExpenseService;
-import com.dnd.moddo.domain.memberExpense.service.QueryMemberExpenseService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -24,11 +21,9 @@ import lombok.RequiredArgsConstructor;
 @Service
 public class CommandExpenseService {
 	private final ExpenseCreator expenseCreator;
-	private final ExpenseReader expenseReader;
 	private final ExpenseUpdater expenseUpdater;
 	private final ExpenseDeleter expenseDeleter;
 	private final CommandMemberExpenseService commandMemberExpenseService;
-	private final QueryMemberExpenseService queryMemberExpenseService;
 
 	public ExpensesResponse createExpenses(Long groupId, ExpensesRequest request) {
 		List<ExpenseResponse> expenses = request.expenses()
@@ -39,8 +34,7 @@ public class CommandExpenseService {
 	}
 
 	private ExpenseResponse createExpense(Long groupId, ExpenseRequest request) {
-		int maxOrder = expenseReader.findMaxOrderForGroup(groupId) + 1;
-		Expense expense = expenseCreator.create(groupId, maxOrder, request);
+		Expense expense = expenseCreator.create(groupId, request);
 
 		List<MemberExpenseResponse> memberExpenseResponses = commandMemberExpenseService.create(expense,
 			request.memberExpenses());
@@ -51,16 +45,6 @@ public class CommandExpenseService {
 		Expense expense = expenseUpdater.update(expenseId, request);
 		return ExpenseResponse.of(expense);
 
-	}
-
-	public ExpensesResponse updateOrder(ExpensesUpdateOrderRequest request) {
-		List<Expense> expenses = expenseUpdater.updateOrder(request);
-		return new ExpensesResponse(
-			expenses.stream()
-				.map(expense ->
-					ExpenseResponse.of(expense, queryMemberExpenseService.findAllByExpenseId(expense.getId()))
-				).toList()
-		);
 	}
 
 	public void delete(Long expenseId) {

--- a/src/main/java/com/dnd/moddo/domain/expense/service/QueryExpenseService.java
+++ b/src/main/java/com/dnd/moddo/domain/expense/service/QueryExpenseService.java
@@ -1,6 +1,9 @@
 package com.dnd.moddo.domain.expense.service;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 
@@ -8,7 +11,14 @@ import com.dnd.moddo.domain.expense.dto.response.ExpenseResponse;
 import com.dnd.moddo.domain.expense.dto.response.ExpensesResponse;
 import com.dnd.moddo.domain.expense.entity.Expense;
 import com.dnd.moddo.domain.expense.service.implementation.ExpenseReader;
+import com.dnd.moddo.domain.groupMember.dto.response.GroupMemberExpenseResponse;
+import com.dnd.moddo.domain.groupMember.dto.response.GroupMembersExpenseResponse;
+import com.dnd.moddo.domain.groupMember.entity.GroupMember;
+import com.dnd.moddo.domain.groupMember.service.implementation.GroupMemberReader;
+import com.dnd.moddo.domain.memberExpense.dto.response.MemberExpenseDetailResponse;
+import com.dnd.moddo.domain.memberExpense.entity.MemberExpense;
 import com.dnd.moddo.domain.memberExpense.service.QueryMemberExpenseService;
+import com.dnd.moddo.domain.memberExpense.service.implementation.MemberExpenseReader;
 
 import lombok.RequiredArgsConstructor;
 
@@ -16,6 +26,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class QueryExpenseService {
 	private final ExpenseReader expenseReader;
+	private final GroupMemberReader groupMemberReader;
+	private final MemberExpenseReader memberExpenseReader;
 	private final QueryMemberExpenseService queryMemberExpenseService;
 
 	public ExpensesResponse findAllByGroupId(Long groupId) {
@@ -31,5 +43,53 @@ public class QueryExpenseService {
 	public ExpenseResponse findOneByExpenseId(Long expenseId) {
 		Expense expense = expenseReader.findOneByExpenseId(expenseId);
 		return ExpenseResponse.of(expense);
+	}
+
+	public GroupMembersExpenseResponse findSettlementByGroupId(Long groupId) {
+		List<GroupMember> groupMembers = groupMemberReader.findAllByGroupId(groupId);
+
+		Map<Long, GroupMember> groupMemberById = mapGroupMembers(groupMembers);
+
+		Map<Long, List<MemberExpense>> memberExpenses = memberExpenseReader.findAllByGroupMemberIds(
+			groupMemberById.keySet().stream().toList());
+
+		List<Expense> expenses = expenseReader.findAllByGroupId(groupId);
+
+		List<GroupMemberExpenseResponse> responses = groupMemberById.keySet()
+			.stream()
+			.map(key -> {
+					if (memberExpenses.get(key) == null)
+						return null;
+					return findSettlementByGroupMember(groupMemberById.get(key), memberExpenses.get(key), expenses);
+				}
+			)
+			.filter(Objects::nonNull)
+			.toList();
+
+		return new GroupMembersExpenseResponse(responses);
+	}
+
+	// 그룹 멤버들을 id별로 Map으로 매핑
+	private Map<Long, GroupMember> mapGroupMembers(List<GroupMember> groupMembers) {
+		return groupMembers.stream()
+			.collect(Collectors.toMap(GroupMember::getId, groupMember -> groupMember));
+	}
+
+	private GroupMemberExpenseResponse findSettlementByGroupMember(GroupMember groupMember,
+		List<MemberExpense> memberExpenses, List<Expense> expenses) {
+
+		// Map으로 변환하여 빠른 조회 가능
+		Map<Long, MemberExpense> expenseToMemberExpenseMap = memberExpenses.stream()
+			.collect(Collectors.toMap(me -> me.getExpense().getId(), me -> me));
+
+		List<MemberExpenseDetailResponse> memberExpenseDetails = expenses.stream()
+			.map(expense -> {
+				MemberExpense memberExpense = expenseToMemberExpenseMap.get(expense.getId());
+				return (memberExpense != null) ? MemberExpenseDetailResponse.of(expense, memberExpense) : null;
+			})
+			.filter(Objects::nonNull)
+			.toList();
+
+		return GroupMemberExpenseResponse.of(groupMember, memberExpenseDetails);
 	}
 }

--- a/src/main/java/com/dnd/moddo/domain/expense/service/QueryExpenseService.java
+++ b/src/main/java/com/dnd/moddo/domain/expense/service/QueryExpenseService.java
@@ -46,10 +46,10 @@ public class QueryExpenseService {
 		return ExpenseResponse.of(expense);
 	}
 
-	public GroupMembersExpenseResponse findSettlementByGroupId(Long groupId) {
+	public GroupMembersExpenseResponse findSettlementsByGroupId(Long groupId) {
 		List<GroupMember> groupMembers = groupMemberReader.findAllByGroupId(groupId);
 
-		Map<Long, GroupMember> groupMemberById = mapGroupMembers(groupMembers);
+		Map<Long, GroupMember> groupMemberById = convertGroupMembersToMap(groupMembers);
 
 		Map<Long, List<MemberExpense>> memberExpenses = memberExpenseReader.findAllByGroupMemberIds(
 			groupMemberById.keySet().stream().toList());
@@ -70,8 +70,7 @@ public class QueryExpenseService {
 		return new GroupMembersExpenseResponse(responses);
 	}
 
-	// 그룹 멤버들을 id별로 Map으로 매핑
-	private Map<Long, GroupMember> mapGroupMembers(List<GroupMember> groupMembers) {
+	private Map<Long, GroupMember> convertGroupMembersToMap(List<GroupMember> groupMembers) {
 		return groupMembers.stream()
 			.collect(Collectors.toMap(GroupMember::getId, groupMember -> groupMember,
 				(existing, replacement) -> existing,
@@ -82,7 +81,6 @@ public class QueryExpenseService {
 	private GroupMemberExpenseResponse findSettlementByGroupMember(GroupMember groupMember,
 		List<MemberExpense> memberExpenses, List<Expense> expenses) {
 
-		// Map으로 변환하여 빠른 조회 가능
 		Map<Long, MemberExpense> expenseToMemberExpenseMap = memberExpenses.stream()
 			.collect(Collectors.toMap(MemberExpense::getExpenseId, me -> me));
 

--- a/src/main/java/com/dnd/moddo/domain/expense/service/QueryExpenseService.java
+++ b/src/main/java/com/dnd/moddo/domain/expense/service/QueryExpenseService.java
@@ -1,10 +1,6 @@
 package com.dnd.moddo.domain.expense.service;
 
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 
@@ -12,14 +8,7 @@ import com.dnd.moddo.domain.expense.dto.response.ExpenseResponse;
 import com.dnd.moddo.domain.expense.dto.response.ExpensesResponse;
 import com.dnd.moddo.domain.expense.entity.Expense;
 import com.dnd.moddo.domain.expense.service.implementation.ExpenseReader;
-import com.dnd.moddo.domain.groupMember.dto.response.GroupMemberExpenseResponse;
-import com.dnd.moddo.domain.groupMember.dto.response.GroupMembersExpenseResponse;
-import com.dnd.moddo.domain.groupMember.entity.GroupMember;
-import com.dnd.moddo.domain.groupMember.service.implementation.GroupMemberReader;
-import com.dnd.moddo.domain.memberExpense.dto.response.MemberExpenseDetailResponse;
-import com.dnd.moddo.domain.memberExpense.entity.MemberExpense;
 import com.dnd.moddo.domain.memberExpense.service.QueryMemberExpenseService;
-import com.dnd.moddo.domain.memberExpense.service.implementation.MemberExpenseReader;
 
 import lombok.RequiredArgsConstructor;
 
@@ -27,8 +16,6 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class QueryExpenseService {
 	private final ExpenseReader expenseReader;
-	private final GroupMemberReader groupMemberReader;
-	private final MemberExpenseReader memberExpenseReader;
 	private final QueryMemberExpenseService queryMemberExpenseService;
 
 	public ExpensesResponse findAllByGroupId(Long groupId) {
@@ -46,52 +33,4 @@ public class QueryExpenseService {
 		return ExpenseResponse.of(expense);
 	}
 
-	public GroupMembersExpenseResponse findSettlementsByGroupId(Long groupId) {
-		List<GroupMember> groupMembers = groupMemberReader.findAllByGroupId(groupId);
-
-		Map<Long, GroupMember> groupMemberById = convertGroupMembersToMap(groupMembers);
-
-		Map<Long, List<MemberExpense>> memberExpenses = memberExpenseReader.findAllByGroupMemberIds(
-			groupMemberById.keySet().stream().toList());
-
-		List<Expense> expenses = expenseReader.findAllByGroupId(groupId);
-
-		List<GroupMemberExpenseResponse> responses = groupMemberById.keySet()
-			.stream()
-			.map(key -> {
-					if (memberExpenses.get(key) == null)
-						return null;
-					return findSettlementByGroupMember(groupMemberById.get(key), memberExpenses.get(key), expenses);
-				}
-			)
-			.filter(Objects::nonNull)
-			.toList();
-
-		return new GroupMembersExpenseResponse(responses);
-	}
-
-	private Map<Long, GroupMember> convertGroupMembersToMap(List<GroupMember> groupMembers) {
-		return groupMembers.stream()
-			.collect(Collectors.toMap(GroupMember::getId, groupMember -> groupMember,
-				(existing, replacement) -> existing,
-				LinkedHashMap::new)
-			);
-	}
-
-	private GroupMemberExpenseResponse findSettlementByGroupMember(GroupMember groupMember,
-		List<MemberExpense> memberExpenses, List<Expense> expenses) {
-
-		Map<Long, MemberExpense> expenseToMemberExpenseMap = memberExpenses.stream()
-			.collect(Collectors.toMap(MemberExpense::getExpenseId, me -> me));
-
-		List<MemberExpenseDetailResponse> memberExpenseDetails = expenses.stream()
-			.map(expense -> {
-				MemberExpense memberExpense = expenseToMemberExpenseMap.get(expense.getId());
-				return (memberExpense != null) ? MemberExpenseDetailResponse.of(expense, memberExpense) : null;
-			})
-			.filter(Objects::nonNull)
-			.toList();
-
-		return GroupMemberExpenseResponse.of(groupMember, memberExpenseDetails);
-	}
 }

--- a/src/main/java/com/dnd/moddo/domain/expense/service/QueryExpenseService.java
+++ b/src/main/java/com/dnd/moddo/domain/expense/service/QueryExpenseService.java
@@ -1,5 +1,6 @@
 package com.dnd.moddo.domain.expense.service;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -72,7 +73,10 @@ public class QueryExpenseService {
 	// 그룹 멤버들을 id별로 Map으로 매핑
 	private Map<Long, GroupMember> mapGroupMembers(List<GroupMember> groupMembers) {
 		return groupMembers.stream()
-			.collect(Collectors.toMap(GroupMember::getId, groupMember -> groupMember));
+			.collect(Collectors.toMap(GroupMember::getId, groupMember -> groupMember,
+				(existing, replacement) -> existing,
+				LinkedHashMap::new)
+			);
 	}
 
 	private GroupMemberExpenseResponse findSettlementByGroupMember(GroupMember groupMember,

--- a/src/main/java/com/dnd/moddo/domain/expense/service/QueryExpenseService.java
+++ b/src/main/java/com/dnd/moddo/domain/expense/service/QueryExpenseService.java
@@ -80,7 +80,7 @@ public class QueryExpenseService {
 
 		// Map으로 변환하여 빠른 조회 가능
 		Map<Long, MemberExpense> expenseToMemberExpenseMap = memberExpenses.stream()
-			.collect(Collectors.toMap(me -> me.getExpense().getId(), me -> me));
+			.collect(Collectors.toMap(MemberExpense::getExpenseId, me -> me));
 
 		List<MemberExpenseDetailResponse> memberExpenseDetails = expenses.stream()
 			.map(expense -> {

--- a/src/main/java/com/dnd/moddo/domain/expense/service/implementation/ExpenseCreator.java
+++ b/src/main/java/com/dnd/moddo/domain/expense/service/implementation/ExpenseCreator.java
@@ -20,12 +20,12 @@ public class ExpenseCreator {
 	private final MemberExpenseValidator memberExpenseValidator;
 	private final GroupRepository groupRepository;
 
-	public Expense create(Long groupId, int maxOrder, ExpenseRequest request) {
+	public Expense create(Long groupId, ExpenseRequest request) {
 		Group group = groupRepository.getById(groupId);
 
 		memberExpenseValidator.validateMembersArePartOfGroup(groupId, request.memberExpenses());
 
-		Expense expense = request.toEntity(group, maxOrder);
+		Expense expense = request.toEntity(group);
 		return expenseRepository.save(expense);
 	}
 

--- a/src/main/java/com/dnd/moddo/domain/expense/service/implementation/ExpenseReader.java
+++ b/src/main/java/com/dnd/moddo/domain/expense/service/implementation/ExpenseReader.java
@@ -17,14 +17,11 @@ public class ExpenseReader {
 	private final ExpenseRepository expenseRepository;
 
 	public List<Expense> findAllByGroupId(Long groupId) {
-		return expenseRepository.findByGroupIdOrderByOrderAsc(groupId);
+		return expenseRepository.findByGroupIdOrderByDateAsc(groupId);
 	}
 
 	public Expense findOneByExpenseId(Long expenseId) {
 		return expenseRepository.getById(expenseId);
 	}
 
-	public int findMaxOrderForGroup(Long groupId) {
-		return expenseRepository.findMaxOrderByGroupId(groupId);
-	}
 }

--- a/src/main/java/com/dnd/moddo/domain/expense/service/implementation/ExpenseUpdater.java
+++ b/src/main/java/com/dnd/moddo/domain/expense/service/implementation/ExpenseUpdater.java
@@ -1,12 +1,9 @@
 package com.dnd.moddo.domain.expense.service.implementation;
 
-import java.util.List;
-
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.dnd.moddo.domain.expense.dto.request.ExpenseRequest;
-import com.dnd.moddo.domain.expense.dto.request.ExpensesUpdateOrderRequest;
 import com.dnd.moddo.domain.expense.entity.Expense;
 import com.dnd.moddo.domain.expense.repository.ExpenseRepository;
 
@@ -22,15 +19,5 @@ public class ExpenseUpdater {
 		Expense expense = expenseRepository.getById(expenseId);
 		expense.update(request.amount(), request.content(), request.date());
 		return expense;
-	}
-
-	public List<Expense> updateOrder(ExpensesUpdateOrderRequest request) {
-		return request.orders()
-			.stream()
-			.map(r -> {
-				Expense expense = expenseRepository.getById(r.expenseId());
-				expense.updateOrder(r.newOrder());
-				return expense;
-			}).toList();
 	}
 }

--- a/src/main/java/com/dnd/moddo/domain/groupMember/controller/GroupMemberController.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/controller/GroupMemberController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.dnd.moddo.domain.groupMember.dto.request.GroupMemberSaveRequest;
 import com.dnd.moddo.domain.groupMember.dto.request.GroupMembersSaveRequest;
 import com.dnd.moddo.domain.groupMember.dto.response.GroupMemberResponse;
+import com.dnd.moddo.domain.groupMember.dto.response.GroupMembersExpenseResponse;
 import com.dnd.moddo.domain.groupMember.dto.response.GroupMembersResponse;
 import com.dnd.moddo.domain.groupMember.service.CommandGroupMemberService;
 import com.dnd.moddo.domain.groupMember.service.QueryGroupMemberService;
@@ -34,6 +35,14 @@ public class GroupMemberController {
 		@Valid @RequestBody GroupMembersSaveRequest request
 	) {
 		GroupMembersResponse response = commandGroupMemberService.create(groupId, request);
+		return ResponseEntity.ok(response);
+	}
+
+	@GetMapping("/settlement")
+	public ResponseEntity<GroupMembersExpenseResponse> getSettlement(
+		@RequestParam("groupId") Long groupId
+	) {
+		GroupMembersExpenseResponse response = queryGroupMemberService.findSettlementByGroupId(groupId);
 		return ResponseEntity.ok(response);
 	}
 

--- a/src/main/java/com/dnd/moddo/domain/groupMember/controller/GroupMemberController.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/controller/GroupMemberController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.dnd.moddo.domain.groupMember.dto.request.GroupMemberSaveRequest;
 import com.dnd.moddo.domain.groupMember.dto.request.GroupMembersSaveRequest;
+import com.dnd.moddo.domain.groupMember.dto.request.PaymentStatusUpdateRequest;
 import com.dnd.moddo.domain.groupMember.dto.response.GroupMemberResponse;
 import com.dnd.moddo.domain.groupMember.dto.response.GroupMembersResponse;
 import com.dnd.moddo.domain.groupMember.service.CommandGroupMemberService;
@@ -56,6 +57,15 @@ public class GroupMemberController {
 	) {
 		Long groupId = jwtService.getGroupId(groupToken);
 		GroupMemberResponse response = commandGroupMemberService.addGroupMember(groupId, request);
+		return ResponseEntity.ok(response);
+	}
+
+	@PutMapping("/{groupMemberId}/payment")
+	public ResponseEntity<GroupMemberResponse> updatePaymentStatus(
+		@RequestParam("groupToken") String groupToken,
+		@PathVariable("groupMemberId") Long groupMemberId,
+		@RequestBody PaymentStatusUpdateRequest request) {
+		GroupMemberResponse response = commandGroupMemberService.updatePaymentStatus(groupMemberId, request);
 		return ResponseEntity.ok(response);
 	}
 

--- a/src/main/java/com/dnd/moddo/domain/groupMember/controller/GroupMemberController.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/controller/GroupMemberController.java
@@ -1,6 +1,5 @@
 package com.dnd.moddo.domain.groupMember.controller;
 
-import com.dnd.moddo.global.jwt.service.JwtService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -15,10 +14,10 @@ import org.springframework.web.bind.annotation.RestController;
 import com.dnd.moddo.domain.groupMember.dto.request.GroupMemberSaveRequest;
 import com.dnd.moddo.domain.groupMember.dto.request.GroupMembersSaveRequest;
 import com.dnd.moddo.domain.groupMember.dto.response.GroupMemberResponse;
-import com.dnd.moddo.domain.groupMember.dto.response.GroupMembersExpenseResponse;
 import com.dnd.moddo.domain.groupMember.dto.response.GroupMembersResponse;
 import com.dnd.moddo.domain.groupMember.service.CommandGroupMemberService;
 import com.dnd.moddo.domain.groupMember.service.QueryGroupMemberService;
+import com.dnd.moddo.global.jwt.service.JwtService;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -33,25 +32,17 @@ public class GroupMemberController {
 
 	@PostMapping
 	public ResponseEntity<GroupMembersResponse> saveGroupMembers(
-			@RequestParam("groupToken") String groupToken,
-			@Valid @RequestBody GroupMembersSaveRequest request
+		@RequestParam("groupToken") String groupToken,
+		@Valid @RequestBody GroupMembersSaveRequest request
 	) {
 		Long groupId = jwtService.getGroupId(groupToken);
 		GroupMembersResponse response = commandGroupMemberService.create(groupId, request);
 		return ResponseEntity.ok(response);
 	}
 
-	@GetMapping("/settlement")
-	public ResponseEntity<GroupMembersExpenseResponse> getSettlement(
-		@RequestParam("groupId") Long groupId
-	) {
-		GroupMembersExpenseResponse response = queryGroupMemberService.findSettlementByGroupId(groupId);
-		return ResponseEntity.ok(response);
-	}
-
 	@GetMapping
 	public ResponseEntity<GroupMembersResponse> getGroupMembers(
-			@RequestParam("groupToken") String groupToken
+		@RequestParam("groupToken") String groupToken
 	) {
 		Long groupId = jwtService.getGroupId(groupToken);
 		GroupMembersResponse response = queryGroupMemberService.findAll(groupId);
@@ -60,8 +51,8 @@ public class GroupMemberController {
 
 	@PutMapping
 	public ResponseEntity<GroupMemberResponse> addGroupMember(
-			@RequestParam("groupToken") String groupToken,
-			@Valid @RequestBody GroupMemberSaveRequest request
+		@RequestParam("groupToken") String groupToken,
+		@Valid @RequestBody GroupMemberSaveRequest request
 	) {
 		Long groupId = jwtService.getGroupId(groupToken);
 		GroupMemberResponse response = commandGroupMemberService.addGroupMember(groupId, request);

--- a/src/main/java/com/dnd/moddo/domain/groupMember/dto/request/GroupMemberSaveRequest.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/dto/request/GroupMemberSaveRequest.java
@@ -12,6 +12,10 @@ public record GroupMemberSaveRequest(
 	String role
 ) {
 	public GroupMember toEntity(Group group, ExpenseRole role) {
-		return new GroupMember(name(), group, role);
+		boolean isPaid = false;
+		if (ExpenseRole.MANAGER.equals(role)) {
+			isPaid = true;
+		}
+		return new GroupMember(name(), group, isPaid, role);
 	}
 }

--- a/src/main/java/com/dnd/moddo/domain/groupMember/dto/request/PaymentStatusUpdateRequest.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/dto/request/PaymentStatusUpdateRequest.java
@@ -1,0 +1,4 @@
+package com.dnd.moddo.domain.groupMember.dto.request;
+
+public record PaymentStatusUpdateRequest(boolean isPaid) {
+}

--- a/src/main/java/com/dnd/moddo/domain/groupMember/dto/response/GroupMemberExpenseResponse.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/dto/response/GroupMemberExpenseResponse.java
@@ -13,6 +13,7 @@ public record GroupMemberExpenseResponse(
 	Long id,
 	ExpenseRole role,
 	String name,
+	boolean isPaid,
 	List<MemberExpenseDetailResponse> expenses
 ) {
 	public static GroupMemberExpenseResponse of(GroupMember groupMember, List<MemberExpenseDetailResponse> expenses) {
@@ -20,6 +21,7 @@ public record GroupMemberExpenseResponse(
 			.id(groupMember.getId())
 			.role(groupMember.getRole())
 			.name(groupMember.getName())
+			.isPaid(groupMember.isPaid())
 			.expenses(expenses).build();
 	}
 }

--- a/src/main/java/com/dnd/moddo/domain/groupMember/dto/response/GroupMemberExpenseResponse.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/dto/response/GroupMemberExpenseResponse.java
@@ -1,0 +1,25 @@
+package com.dnd.moddo.domain.groupMember.dto.response;
+
+import java.util.List;
+
+import com.dnd.moddo.domain.groupMember.entity.GroupMember;
+import com.dnd.moddo.domain.groupMember.entity.type.ExpenseRole;
+import com.dnd.moddo.domain.memberExpense.dto.response.MemberExpenseDetailResponse;
+
+import lombok.Builder;
+
+@Builder
+public record GroupMemberExpenseResponse(
+	Long id,
+	ExpenseRole role,
+	String name,
+	List<MemberExpenseDetailResponse> expenses
+) {
+	public static GroupMemberExpenseResponse of(GroupMember groupMember, List<MemberExpenseDetailResponse> expenses) {
+		return GroupMemberExpenseResponse.builder()
+			.id(groupMember.getId())
+			.role(groupMember.getRole())
+			.name(groupMember.getName())
+			.expenses(expenses).build();
+	}
+}

--- a/src/main/java/com/dnd/moddo/domain/groupMember/dto/response/GroupMemberExpenseResponse.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/dto/response/GroupMemberExpenseResponse.java
@@ -1,5 +1,6 @@
 package com.dnd.moddo.domain.groupMember.dto.response;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import com.dnd.moddo.domain.groupMember.entity.GroupMember;
@@ -14,6 +15,7 @@ public record GroupMemberExpenseResponse(
 	ExpenseRole role,
 	String name,
 	boolean isPaid,
+	LocalDateTime paidAt,
 	List<MemberExpenseDetailResponse> expenses
 ) {
 	public static GroupMemberExpenseResponse of(GroupMember groupMember, List<MemberExpenseDetailResponse> expenses) {
@@ -22,6 +24,7 @@ public record GroupMemberExpenseResponse(
 			.role(groupMember.getRole())
 			.name(groupMember.getName())
 			.isPaid(groupMember.isPaid())
+			.paidAt(groupMember.getPaidAt())
 			.expenses(expenses).build();
 	}
 }

--- a/src/main/java/com/dnd/moddo/domain/groupMember/dto/response/GroupMemberResponse.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/dto/response/GroupMemberResponse.java
@@ -1,19 +1,31 @@
 package com.dnd.moddo.domain.groupMember.dto.response;
 
+import java.time.LocalDateTime;
+
 import com.dnd.moddo.domain.groupMember.entity.GroupMember;
 import com.dnd.moddo.domain.groupMember.entity.type.ExpenseRole;
 
+import lombok.Builder;
+
+@Builder
 public record GroupMemberResponse(
 	Long id,
 	ExpenseRole role,
 	String name,
 	String profile,
-	boolean isPaid
+	boolean isPaid,
+	LocalDateTime paidAt
 ) {
 
 	public static GroupMemberResponse of(GroupMember groupMember) {
-		return new GroupMemberResponse(groupMember.getId(), groupMember.getRole(), groupMember.getName(),
-			generateProfileUrl(groupMember.getProfileId()), groupMember.isPaid());
+		return GroupMemberResponse.builder()
+			.id(groupMember.getId())
+			.name(groupMember.getName())
+			.role(groupMember.getRole())
+			.isPaid(groupMember.isPaid())
+			.paidAt(groupMember.getPaidAt())
+			.profile(generateProfileUrl(groupMember.getProfileId()))
+			.build();
 	}
 
 	private static String generateProfileUrl(Integer profile) {

--- a/src/main/java/com/dnd/moddo/domain/groupMember/dto/response/GroupMembersExpenseResponse.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/dto/response/GroupMembersExpenseResponse.java
@@ -1,0 +1,9 @@
+package com.dnd.moddo.domain.groupMember.dto.response;
+
+import java.util.List;
+
+public record GroupMembersExpenseResponse(
+	List<GroupMemberExpenseResponse> memberExpenses
+) {
+	
+}

--- a/src/main/java/com/dnd/moddo/domain/groupMember/entity/GroupMember.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/entity/GroupMember.java
@@ -1,5 +1,7 @@
 package com.dnd.moddo.domain.groupMember.entity;
 
+import java.time.LocalDateTime;
+
 import com.dnd.moddo.domain.group.entity.Group;
 import com.dnd.moddo.domain.groupMember.entity.type.ExpenseRole;
 
@@ -41,11 +43,18 @@ public class GroupMember {
 	@Column(name = "is_paid", nullable = false)
 	private boolean isPaid;
 
+	@Column(name = "paid_at")
+	private LocalDateTime paidAt;
+
 	@Enumerated(EnumType.STRING)
 	private ExpenseRole role;
 
 	public GroupMember(String name, Group group, ExpenseRole role) {
 		this(null, name, null, group, false, role);
+	}
+
+	public GroupMember(String name, Group group, boolean isPaid, ExpenseRole role) {
+		this(null, name, null, group, isPaid, role);
 	}
 
 	public GroupMember(String name, Integer profileId, Group group, ExpenseRole role) {
@@ -63,6 +72,15 @@ public class GroupMember {
 
 	public boolean isManager() {
 		return ExpenseRole.MANAGER.equals(role);
+	}
+
+	public void updatePaymentStatus(Boolean isPaid) {
+		this.isPaid = isPaid;
+		if (Boolean.TRUE.equals(isPaid)) {
+			this.paidAt = LocalDateTime.now();
+		} else {
+			this.paidAt = null;
+		}
 	}
 }
 

--- a/src/main/java/com/dnd/moddo/domain/groupMember/repository/GroupMemberRepository.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/repository/GroupMemberRepository.java
@@ -13,7 +13,8 @@ public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> 
 
 	@Query("select gm from GroupMember gm where gm.group.id = :groupId order by "
 		+ "case when gm.role = 'MANAGER' then 1 else 2 end, "
-		+ "gm.isPaid desc, "
+		+ "case when gm.paidAt is null then 1 else 0 end, "
+		+ "gm.paidAt asc, "
 		+ "gm.name asc")
 	List<GroupMember> findByGroupId(@Param("groupId") Long groupId);
 

--- a/src/main/java/com/dnd/moddo/domain/groupMember/repository/GroupMemberRepository.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/repository/GroupMemberRepository.java
@@ -11,9 +11,13 @@ import com.dnd.moddo.domain.groupMember.exception.GroupMemberNotFoundException;
 
 public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> {
 
-	List<GroupMember> findByGroupId(Long groupId);
+	@Query("select gm from GroupMember gm where gm.group.id = :groupId order by "
+		+ "case when gm.role = 'MANAGER' then 1 else 2 end, "
+		+ "gm.isPaid desc, "
+		+ "gm.name asc")
+	List<GroupMember> findByGroupId(@Param("groupId") Long groupId);
 
-	@Query("select m.id from GroupMember m where m.group.id = :groupId")
+	@Query("select gm.id from GroupMember gm where gm.group.id = :groupId")
 	List<Long> findGroupMemberIdsByGroupId(@Param("groupId") Long groupId);
 
 	default GroupMember getById(Long id) {

--- a/src/main/java/com/dnd/moddo/domain/groupMember/service/CommandGroupMemberService.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/service/CommandGroupMemberService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 
 import com.dnd.moddo.domain.groupMember.dto.request.GroupMemberSaveRequest;
 import com.dnd.moddo.domain.groupMember.dto.request.GroupMembersSaveRequest;
+import com.dnd.moddo.domain.groupMember.dto.request.PaymentStatusUpdateRequest;
 import com.dnd.moddo.domain.groupMember.dto.response.GroupMemberResponse;
 import com.dnd.moddo.domain.groupMember.dto.response.GroupMembersResponse;
 import com.dnd.moddo.domain.groupMember.entity.GroupMember;
@@ -29,6 +30,11 @@ public class CommandGroupMemberService {
 
 	public GroupMemberResponse addGroupMember(Long groupId, GroupMemberSaveRequest request) {
 		GroupMember groupMember = groupMemberUpdater.addToGroup(groupId, request);
+		return GroupMemberResponse.of(groupMember);
+	}
+
+	public GroupMemberResponse updatePaymentStatus(Long groupMemberId, PaymentStatusUpdateRequest request) {
+		GroupMember groupMember = groupMemberUpdater.updatePaymentStatus(groupMemberId, request);
 		return GroupMemberResponse.of(groupMember);
 	}
 

--- a/src/main/java/com/dnd/moddo/domain/groupMember/service/QueryGroupMemberService.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/service/QueryGroupMemberService.java
@@ -1,6 +1,5 @@
 package com.dnd.moddo.domain.groupMember.service;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -36,44 +35,48 @@ public class QueryGroupMemberService {
 	public GroupMembersExpenseResponse findSettlementByGroupId(Long groupId) {
 		List<GroupMember> groupMembers = groupMemberReader.findAllByGroupId(groupId);
 
-		Map<Long, GroupMember> groupMemberById = groupMembers.stream()
-			.collect(Collectors.toMap(GroupMember::getId, groupMember -> groupMember));
+		Map<Long, GroupMember> groupMemberById = mapGroupMembers(groupMembers);
 
 		Map<Long, List<MemberExpense>> memberExpenses = memberExpenseReader.findAllByGroupMemberIds(
-			new ArrayList<>(groupMemberById.keySet()));
+			groupMemberById.keySet().stream().toList());
 
 		List<Expense> expenses = expenseReader.findAllByGroupId(groupId);
 
 		List<GroupMemberExpenseResponse> responses = groupMemberById.keySet()
 			.stream()
 			.map(key -> {
-				if (memberExpenses.get(key) == null)
-					return null;
-				return findSettlementByGroupMember(groupMemberById.get(key), memberExpenses.get(key), expenses);
-			})
+					if (memberExpenses.get(key) == null)
+						return null;
+					return findSettlementByGroupMember(groupMemberById.get(key), memberExpenses.get(key), expenses);
+				}
+			)
 			.filter(Objects::nonNull)
 			.toList();
 
 		return new GroupMembersExpenseResponse(responses);
 	}
 
+	// 그룹 멤버들을 id별로 Map으로 매핑
+	private Map<Long, GroupMember> mapGroupMembers(List<GroupMember> groupMembers) {
+		return groupMembers.stream()
+			.collect(Collectors.toMap(GroupMember::getId, groupMember -> groupMember));
+	}
+
 	private GroupMemberExpenseResponse findSettlementByGroupMember(GroupMember groupMember,
-		List<MemberExpense> memberExpenses,
-		List<Expense> expenses) {
+		List<MemberExpense> memberExpenses, List<Expense> expenses) {
 
-		List<MemberExpenseDetailResponse> memberExepsneDetail = expenses.stream()
-			.map(e -> {
-				MemberExpense memberExpense = memberExpenses.stream()
-					.filter(me -> me.isExpenseMatched(e))
-					.findFirst()
-					.orElse(null);
+		// 🔥 Map으로 변환하여 빠른 조회 가능
+		Map<Long, MemberExpense> expenseToMemberExpenseMap = memberExpenses.stream()
+			.collect(Collectors.toMap(me -> me.getExpense().getId(), me -> me));
 
-				return memberExpense != null
-					? MemberExpenseDetailResponse.of(e, memberExpense)
-					: null;
-			}).filter(Objects::nonNull)
+		List<MemberExpenseDetailResponse> memberExpenseDetails = expenses.stream()
+			.map(expense -> {
+				MemberExpense memberExpense = expenseToMemberExpenseMap.get(expense.getId());
+				return (memberExpense != null) ? MemberExpenseDetailResponse.of(expense, memberExpense) : null;
+			})
+			.filter(Objects::nonNull)
 			.toList();
 
-		return GroupMemberExpenseResponse.of(groupMember, memberExepsneDetail);
+		return GroupMemberExpenseResponse.of(groupMember, memberExpenseDetails);
 	}
 }

--- a/src/main/java/com/dnd/moddo/domain/groupMember/service/QueryGroupMemberService.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/service/QueryGroupMemberService.java
@@ -1,12 +1,23 @@
 package com.dnd.moddo.domain.groupMember.service;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 
+import com.dnd.moddo.domain.expense.entity.Expense;
+import com.dnd.moddo.domain.expense.service.implementation.ExpenseReader;
+import com.dnd.moddo.domain.groupMember.dto.response.GroupMemberExpenseResponse;
+import com.dnd.moddo.domain.groupMember.dto.response.GroupMembersExpenseResponse;
 import com.dnd.moddo.domain.groupMember.dto.response.GroupMembersResponse;
 import com.dnd.moddo.domain.groupMember.entity.GroupMember;
 import com.dnd.moddo.domain.groupMember.service.implementation.GroupMemberReader;
+import com.dnd.moddo.domain.memberExpense.dto.response.MemberExpenseDetailResponse;
+import com.dnd.moddo.domain.memberExpense.entity.MemberExpense;
+import com.dnd.moddo.domain.memberExpense.service.implementation.MemberExpenseReader;
 
 import lombok.RequiredArgsConstructor;
 
@@ -14,9 +25,55 @@ import lombok.RequiredArgsConstructor;
 @Service
 public class QueryGroupMemberService {
 	private final GroupMemberReader groupMemberReader;
+	private final MemberExpenseReader memberExpenseReader;
+	private final ExpenseReader expenseReader;
 
 	public GroupMembersResponse findAll(Long groupId) {
 		List<GroupMember> members = groupMemberReader.findAllByGroupId(groupId);
 		return GroupMembersResponse.of(members);
+	}
+
+	public GroupMembersExpenseResponse findSettlementByGroupId(Long groupId) {
+		List<GroupMember> groupMembers = groupMemberReader.findAllByGroupId(groupId);
+
+		Map<Long, GroupMember> groupMemberById = groupMembers.stream()
+			.collect(Collectors.toMap(GroupMember::getId, groupMember -> groupMember));
+
+		Map<Long, List<MemberExpense>> memberExpenses = memberExpenseReader.findAllByGroupMemberIds(
+			new ArrayList<>(groupMemberById.keySet()));
+
+		List<Expense> expenses = expenseReader.findAllByGroupId(groupId);
+
+		List<GroupMemberExpenseResponse> responses = groupMemberById.keySet()
+			.stream()
+			.map(key -> {
+				if (memberExpenses.get(key) == null)
+					return null;
+				return findSettlementByGroupMember(groupMemberById.get(key), memberExpenses.get(key), expenses);
+			})
+			.filter(Objects::nonNull)
+			.toList();
+
+		return new GroupMembersExpenseResponse(responses);
+	}
+
+	private GroupMemberExpenseResponse findSettlementByGroupMember(GroupMember groupMember,
+		List<MemberExpense> memberExpenses,
+		List<Expense> expenses) {
+
+		List<MemberExpenseDetailResponse> memberExepsneDetail = expenses.stream()
+			.map(e -> {
+				MemberExpense memberExpense = memberExpenses.stream()
+					.filter(me -> me.isExpenseMatched(e))
+					.findFirst()
+					.orElse(null);
+
+				return memberExpense != null
+					? MemberExpenseDetailResponse.of(e, memberExpense)
+					: null;
+			}).filter(Objects::nonNull)
+			.toList();
+
+		return GroupMemberExpenseResponse.of(groupMember, memberExepsneDetail);
 	}
 }

--- a/src/main/java/com/dnd/moddo/domain/groupMember/service/QueryGroupMemberService.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/service/QueryGroupMemberService.java
@@ -1,21 +1,13 @@
 package com.dnd.moddo.domain.groupMember.service;
 
 import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 
-import com.dnd.moddo.domain.expense.entity.Expense;
 import com.dnd.moddo.domain.expense.service.implementation.ExpenseReader;
-import com.dnd.moddo.domain.groupMember.dto.response.GroupMemberExpenseResponse;
-import com.dnd.moddo.domain.groupMember.dto.response.GroupMembersExpenseResponse;
 import com.dnd.moddo.domain.groupMember.dto.response.GroupMembersResponse;
 import com.dnd.moddo.domain.groupMember.entity.GroupMember;
 import com.dnd.moddo.domain.groupMember.service.implementation.GroupMemberReader;
-import com.dnd.moddo.domain.memberExpense.dto.response.MemberExpenseDetailResponse;
-import com.dnd.moddo.domain.memberExpense.entity.MemberExpense;
 import com.dnd.moddo.domain.memberExpense.service.implementation.MemberExpenseReader;
 
 import lombok.RequiredArgsConstructor;
@@ -32,51 +24,4 @@ public class QueryGroupMemberService {
 		return GroupMembersResponse.of(members);
 	}
 
-	public GroupMembersExpenseResponse findSettlementByGroupId(Long groupId) {
-		List<GroupMember> groupMembers = groupMemberReader.findAllByGroupId(groupId);
-
-		Map<Long, GroupMember> groupMemberById = mapGroupMembers(groupMembers);
-
-		Map<Long, List<MemberExpense>> memberExpenses = memberExpenseReader.findAllByGroupMemberIds(
-			groupMemberById.keySet().stream().toList());
-
-		List<Expense> expenses = expenseReader.findAllByGroupId(groupId);
-
-		List<GroupMemberExpenseResponse> responses = groupMemberById.keySet()
-			.stream()
-			.map(key -> {
-					if (memberExpenses.get(key) == null)
-						return null;
-					return findSettlementByGroupMember(groupMemberById.get(key), memberExpenses.get(key), expenses);
-				}
-			)
-			.filter(Objects::nonNull)
-			.toList();
-
-		return new GroupMembersExpenseResponse(responses);
-	}
-
-	// 그룹 멤버들을 id별로 Map으로 매핑
-	private Map<Long, GroupMember> mapGroupMembers(List<GroupMember> groupMembers) {
-		return groupMembers.stream()
-			.collect(Collectors.toMap(GroupMember::getId, groupMember -> groupMember));
-	}
-
-	private GroupMemberExpenseResponse findSettlementByGroupMember(GroupMember groupMember,
-		List<MemberExpense> memberExpenses, List<Expense> expenses) {
-
-		// 🔥 Map으로 변환하여 빠른 조회 가능
-		Map<Long, MemberExpense> expenseToMemberExpenseMap = memberExpenses.stream()
-			.collect(Collectors.toMap(me -> me.getExpense().getId(), me -> me));
-
-		List<MemberExpenseDetailResponse> memberExpenseDetails = expenses.stream()
-			.map(expense -> {
-				MemberExpense memberExpense = expenseToMemberExpenseMap.get(expense.getId());
-				return (memberExpense != null) ? MemberExpenseDetailResponse.of(expense, memberExpense) : null;
-			})
-			.filter(Objects::nonNull)
-			.toList();
-
-		return GroupMemberExpenseResponse.of(groupMember, memberExpenseDetails);
-	}
 }

--- a/src/main/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberCreator.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberCreator.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.dnd.moddo.domain.group.entity.Group;
-import com.dnd.moddo.domain.group.repository.GroupRepository;
+import com.dnd.moddo.domain.group.service.implementation.GroupReader;
 import com.dnd.moddo.domain.groupMember.dto.request.GroupMemberSaveRequest;
 import com.dnd.moddo.domain.groupMember.dto.request.GroupMembersSaveRequest;
 import com.dnd.moddo.domain.groupMember.entity.GroupMember;
@@ -20,10 +20,10 @@ import lombok.RequiredArgsConstructor;
 public class GroupMemberCreator {
 	private final GroupMemberRepository groupMemberRepository;
 	private final GroupMemberValidator groupMemberValidator;
-	private final GroupRepository groupRepository; //추후 groupReader나 다른것으로 수정할 예정
+	private final GroupReader groupReader;
 
 	public List<GroupMember> create(Long groupId, GroupMembersSaveRequest request) {
-		Group group = groupRepository.getById(groupId);
+		Group group = groupReader.read(groupId);
 
 		List<String> requestNames = request.members().stream().map(GroupMemberSaveRequest::name).toList();
 

--- a/src/main/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberUpdater.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberUpdater.java
@@ -9,6 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.dnd.moddo.domain.group.entity.Group;
 import com.dnd.moddo.domain.group.repository.GroupRepository;
 import com.dnd.moddo.domain.groupMember.dto.request.GroupMemberSaveRequest;
+import com.dnd.moddo.domain.groupMember.dto.request.PaymentStatusUpdateRequest;
 import com.dnd.moddo.domain.groupMember.entity.GroupMember;
 import com.dnd.moddo.domain.groupMember.entity.type.ExpenseRole;
 import com.dnd.moddo.domain.groupMember.repository.GroupMemberRepository;
@@ -34,5 +35,11 @@ public class GroupMemberUpdater {
 		groupMemberValidator.validateMemberNamesNotDuplicate(existingNames);
 
 		return groupMemberRepository.save(request.toEntity(group, ExpenseRole.PARTICIPANT));
+	}
+
+	public GroupMember updatePaymentStatus(Long groupMemberId, PaymentStatusUpdateRequest request) {
+		GroupMember groupMember = groupMemberRepository.getById(groupMemberId);
+		groupMember.updatePaymentStatus(request.isPaid());
+		return groupMember;
 	}
 }

--- a/src/main/java/com/dnd/moddo/domain/memberExpense/controller/MemberExpenseController.java
+++ b/src/main/java/com/dnd/moddo/domain/memberExpense/controller/MemberExpenseController.java
@@ -1,0 +1,30 @@
+package com.dnd.moddo.domain.memberExpense.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.dnd.moddo.domain.groupMember.dto.response.GroupMembersExpenseResponse;
+import com.dnd.moddo.domain.memberExpense.service.QueryMemberExpenseService;
+import com.dnd.moddo.global.jwt.service.JwtService;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/member-expenses")
+@RestController
+public class MemberExpenseController {
+	private final QueryMemberExpenseService queryMemberExpenseService;
+	private final JwtService jwtService;
+
+	@GetMapping
+	public ResponseEntity<GroupMembersExpenseResponse> getMemberExpensesDetails(
+		@RequestParam("groupToken") String groupToken
+	) {
+		Long groupId = jwtService.getGroupId(groupToken);
+		GroupMembersExpenseResponse response = queryMemberExpenseService.findMemberExpenseDetailsByGroupId(groupId);
+		return ResponseEntity.ok(response);
+	}
+}

--- a/src/main/java/com/dnd/moddo/domain/memberExpense/dto/request/MemberExpenseRequest.java
+++ b/src/main/java/com/dnd/moddo/domain/memberExpense/dto/request/MemberExpenseRequest.java
@@ -1,13 +1,12 @@
 package com.dnd.moddo.domain.memberExpense.dto.request;
 
-import com.dnd.moddo.domain.expense.entity.Expense;
 import com.dnd.moddo.domain.groupMember.entity.GroupMember;
 import com.dnd.moddo.domain.memberExpense.entity.MemberExpense;
 
 public record MemberExpenseRequest(Long memberId, Long amount) {
-	public MemberExpense toEntity(Expense expense, GroupMember groupMember) {
+	public MemberExpense toEntity(Long expenseId, GroupMember groupMember) {
 		return MemberExpense.builder()
-			.expense(expense)
+			.expenseId(expenseId)
 			.groupMember(groupMember)
 			.amount(amount())
 			.build();

--- a/src/main/java/com/dnd/moddo/domain/memberExpense/dto/response/MemberExpenseDetailResponse.java
+++ b/src/main/java/com/dnd/moddo/domain/memberExpense/dto/response/MemberExpenseDetailResponse.java
@@ -1,0 +1,13 @@
+package com.dnd.moddo.domain.memberExpense.dto.response;
+
+import com.dnd.moddo.domain.expense.entity.Expense;
+import com.dnd.moddo.domain.memberExpense.entity.MemberExpense;
+
+public record MemberExpenseDetailResponse(
+	String content,
+	Long amount
+) {
+	public static MemberExpenseDetailResponse of(Expense expense, MemberExpense memberExpense) {
+		return new MemberExpenseDetailResponse(expense.getContent(), memberExpense.getAmount());
+	}
+}

--- a/src/main/java/com/dnd/moddo/domain/memberExpense/entity/MemberExpense.java
+++ b/src/main/java/com/dnd/moddo/domain/memberExpense/entity/MemberExpense.java
@@ -41,5 +41,9 @@ public class MemberExpense {
 		this.groupMember = groupMember;
 		this.amount = amount;
 	}
+
+	public boolean isExpenseMatched(Expense expense) {
+		return this.expense.equals(expense);
+	}
 }
 

--- a/src/main/java/com/dnd/moddo/domain/memberExpense/entity/MemberExpense.java
+++ b/src/main/java/com/dnd/moddo/domain/memberExpense/entity/MemberExpense.java
@@ -1,8 +1,8 @@
 package com.dnd.moddo.domain.memberExpense.entity;
 
-import com.dnd.moddo.domain.expense.entity.Expense;
 import com.dnd.moddo.domain.groupMember.entity.GroupMember;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -18,16 +18,15 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "member-expenses")
+@Table(name = "member_expenses")
 @Entity
 public class MemberExpense {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "expense_id")
-	private Expense expense;
+	@Column(name = "expense_id")
+	private Long expenseId;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "group_member_id")
@@ -36,14 +35,14 @@ public class MemberExpense {
 	private Long amount;
 
 	@Builder
-	public MemberExpense(Expense expense, GroupMember groupMember, Long amount) {
-		this.expense = expense;
+	public MemberExpense(Long expenseId, GroupMember groupMember, Long amount) {
+		this.expenseId = expenseId;
 		this.groupMember = groupMember;
 		this.amount = amount;
 	}
 
-	public boolean isExpenseMatched(Expense expense) {
-		return this.expense.equals(expense);
+	public void updateAmount(Long amount) {
+		this.amount = amount;
 	}
 }
 

--- a/src/main/java/com/dnd/moddo/domain/memberExpense/repotiroy/MemberExpenseRepository.java
+++ b/src/main/java/com/dnd/moddo/domain/memberExpense/repotiroy/MemberExpenseRepository.java
@@ -11,6 +11,6 @@ import com.dnd.moddo.domain.memberExpense.entity.MemberExpense;
 public interface MemberExpenseRepository extends JpaRepository<MemberExpense, Long> {
 	List<MemberExpense> findByExpenseId(Long expenseId);
 
-	@Query("select me from MemberExpense me where me.expense.id in :groupMemberIds")
+	@Query("select me from MemberExpense me where me.groupMember.id in :groupMemberIds")
 	List<MemberExpense> findAllByGroupMemberIds(@Param("groupMemberIds") List<Long> groupMemberIds);
 }

--- a/src/main/java/com/dnd/moddo/domain/memberExpense/repotiroy/MemberExpenseRepository.java
+++ b/src/main/java/com/dnd/moddo/domain/memberExpense/repotiroy/MemberExpenseRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.repository.query.Param;
 import com.dnd.moddo.domain.memberExpense.entity.MemberExpense;
 
 public interface MemberExpenseRepository extends JpaRepository<MemberExpense, Long> {
+	//@EntityGraph(attributePaths = {"groupMember"})
 	List<MemberExpense> findByExpenseId(Long expenseId);
 
 	@Query("select me from MemberExpense me where me.groupMember.id in :groupMemberIds")

--- a/src/main/java/com/dnd/moddo/domain/memberExpense/repotiroy/MemberExpenseRepository.java
+++ b/src/main/java/com/dnd/moddo/domain/memberExpense/repotiroy/MemberExpenseRepository.java
@@ -3,9 +3,14 @@ package com.dnd.moddo.domain.memberExpense.repotiroy;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.dnd.moddo.domain.memberExpense.entity.MemberExpense;
 
 public interface MemberExpenseRepository extends JpaRepository<MemberExpense, Long> {
 	List<MemberExpense> findByExpenseId(Long expenseId);
+
+	@Query("select me from MemberExpense me where me.expense.id in :groupMemberIds")
+	List<MemberExpense> findAllByGroupMemberIds(@Param("groupMemberIds") List<Long> groupMemberIds);
 }

--- a/src/main/java/com/dnd/moddo/domain/memberExpense/service/CommandMemberExpenseService.java
+++ b/src/main/java/com/dnd/moddo/domain/memberExpense/service/CommandMemberExpenseService.java
@@ -7,7 +7,6 @@ import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 
-import com.dnd.moddo.domain.expense.entity.Expense;
 import com.dnd.moddo.domain.groupMember.entity.GroupMember;
 import com.dnd.moddo.domain.groupMember.service.implementation.GroupMemberReader;
 import com.dnd.moddo.domain.memberExpense.dto.request.MemberExpenseRequest;
@@ -29,11 +28,11 @@ public class CommandMemberExpenseService {
 	private final MemberExpenseUpdater memberExpenseUpdater;
 	private final MemberExpenseDeleter memberExpenseDeleter;
 
-	public List<MemberExpenseResponse> create(Expense expense, List<MemberExpenseRequest> memberExpenses) {
-		return memberExpenses.stream()
+	public List<MemberExpenseResponse> create(Long expenseId, List<MemberExpenseRequest> request) {
+		return request.stream()
 			.map(m -> {
 				GroupMember groupMember = groupMemberReader.findByGroupMemberId(m.memberId());
-				return MemberExpenseResponse.of(memberExpenseCreator.create(expense, groupMember, m));
+				return MemberExpenseResponse.of(memberExpenseCreator.create(expenseId, groupMember, m));
 			}).toList();
 
 	}

--- a/src/main/java/com/dnd/moddo/domain/memberExpense/service/CommandMemberExpenseService.java
+++ b/src/main/java/com/dnd/moddo/domain/memberExpense/service/CommandMemberExpenseService.java
@@ -1,6 +1,9 @@
 package com.dnd.moddo.domain.memberExpense.service;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 
@@ -9,7 +12,11 @@ import com.dnd.moddo.domain.groupMember.entity.GroupMember;
 import com.dnd.moddo.domain.groupMember.service.implementation.GroupMemberReader;
 import com.dnd.moddo.domain.memberExpense.dto.request.MemberExpenseRequest;
 import com.dnd.moddo.domain.memberExpense.dto.response.MemberExpenseResponse;
+import com.dnd.moddo.domain.memberExpense.entity.MemberExpense;
 import com.dnd.moddo.domain.memberExpense.service.implementation.MemberExpenseCreator;
+import com.dnd.moddo.domain.memberExpense.service.implementation.MemberExpenseDeleter;
+import com.dnd.moddo.domain.memberExpense.service.implementation.MemberExpenseReader;
+import com.dnd.moddo.domain.memberExpense.service.implementation.MemberExpenseUpdater;
 
 import lombok.RequiredArgsConstructor;
 
@@ -18,6 +25,9 @@ import lombok.RequiredArgsConstructor;
 public class CommandMemberExpenseService {
 	private final GroupMemberReader groupMemberReader;
 	private final MemberExpenseCreator memberExpenseCreator;
+	private final MemberExpenseReader memberExpenseReader;
+	private final MemberExpenseUpdater memberExpenseUpdater;
+	private final MemberExpenseDeleter memberExpenseDeleter;
 
 	public List<MemberExpenseResponse> create(Expense expense, List<MemberExpenseRequest> memberExpenses) {
 		return memberExpenses.stream()
@@ -27,4 +37,58 @@ public class CommandMemberExpenseService {
 			}).toList();
 
 	}
+
+	public List<MemberExpenseResponse> update(Long expenseId, List<MemberExpenseRequest> requests) {
+		//1. 지출내역에 딸린 멤버별 지출내역을 모두 가져온다
+		List<MemberExpense> memberExpenses = memberExpenseReader.findAllByExpenseId(expenseId);
+
+		Map<Long, MemberExpense> existingMemberExpenses = memberExpenses.stream()
+			.collect(Collectors.toMap(me -> me.getGroupMember().getId(), me -> me));
+
+		//2. 기존에 있던 멤버가 요청에 없는 경우 삭제한다.
+		deleteNonIncludedMemberExpenses(requests, memberExpenses);
+
+		// 3. 요청된 멤버별 지출 내역을 처리한다.
+		return requests.stream()
+			.map(request -> handleMemberExpenseUpdateOrCreate(expenseId, existingMemberExpenses, request))
+			.collect(Collectors.toList());
+	}
+
+	private MemberExpenseResponse handleMemberExpenseUpdateOrCreate(Long expenseId,
+		Map<Long, MemberExpense> existingMemberExpenses,
+		MemberExpenseRequest request) {
+
+		Long groupMemberId = request.memberId();
+		MemberExpenseResponse response;
+
+		if (existingMemberExpenses.containsKey(groupMemberId)) {
+			// 1. 기존 멤버가 있으면 업데이트
+			MemberExpense existingMemberExpense = existingMemberExpenses.get(groupMemberId);
+			memberExpenseUpdater.update(existingMemberExpense, request);
+			response = MemberExpenseResponse.of(existingMemberExpense);
+		} else {
+			// 2. 없는 멤버면 추가
+			GroupMember groupMember = groupMemberReader.findByGroupMemberId(groupMemberId);
+			MemberExpense newMemberExpense = memberExpenseCreator.create(expenseId, groupMember, request);
+			response = MemberExpenseResponse.of(newMemberExpense);
+		}
+
+		return response;
+	}
+
+	private void deleteNonIncludedMemberExpenses(List<MemberExpenseRequest> requests,
+		List<MemberExpense> memberExpenses) {
+		// 1. 요청된 멤버들의 memberId를 추출
+		Set<Long> requestMemberIds = requests.stream()
+			.map(MemberExpenseRequest::memberId)
+			.collect(Collectors.toSet());
+
+		//2. 멤버별 지출내역중 요청된 멤버 id에 포함되지 않는 지출내역을 찾는다.
+		List<MemberExpense> deleteMemberExpenses = memberExpenses.stream()
+			.filter(me -> !requestMemberIds.contains(me.getGroupMember().getId()))
+			.toList();
+
+		memberExpenseDeleter.deleteByMemberExpenses(deleteMemberExpenses);
+	}
+
 }

--- a/src/main/java/com/dnd/moddo/domain/memberExpense/service/QueryMemberExpenseService.java
+++ b/src/main/java/com/dnd/moddo/domain/memberExpense/service/QueryMemberExpenseService.java
@@ -1,9 +1,20 @@
 package com.dnd.moddo.domain.memberExpense.service;
 
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 
+import com.dnd.moddo.domain.expense.entity.Expense;
+import com.dnd.moddo.domain.expense.service.implementation.ExpenseReader;
+import com.dnd.moddo.domain.groupMember.dto.response.GroupMemberExpenseResponse;
+import com.dnd.moddo.domain.groupMember.dto.response.GroupMembersExpenseResponse;
+import com.dnd.moddo.domain.groupMember.entity.GroupMember;
+import com.dnd.moddo.domain.groupMember.service.implementation.GroupMemberReader;
+import com.dnd.moddo.domain.memberExpense.dto.response.MemberExpenseDetailResponse;
 import com.dnd.moddo.domain.memberExpense.dto.response.MemberExpenseResponse;
 import com.dnd.moddo.domain.memberExpense.entity.MemberExpense;
 import com.dnd.moddo.domain.memberExpense.service.implementation.MemberExpenseReader;
@@ -14,11 +25,63 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class QueryMemberExpenseService {
 	private final MemberExpenseReader memberExpenseReader;
+	private final GroupMemberReader groupMemberReader;
+	private final ExpenseReader expenseReader;
 
 	public List<MemberExpenseResponse> findAllByExpenseId(Long expenseId) {
 		List<MemberExpense> memberExpenses = memberExpenseReader.findAllByExpenseId(expenseId);
 		return memberExpenses.stream()
 			.map(MemberExpenseResponse::of)
 			.toList();
+	}
+
+	public GroupMembersExpenseResponse findMemberExpenseDetailsByGroupId(Long groupId) {
+		List<GroupMember> groupMembers = groupMemberReader.findAllByGroupId(groupId);
+
+		Map<Long, GroupMember> groupMemberById = convertGroupMembersToMap(groupMembers);
+
+		Map<Long, List<MemberExpense>> memberExpenses = memberExpenseReader.findAllByGroupMemberIds(
+			groupMemberById.keySet().stream().toList());
+
+		List<Expense> expenses = expenseReader.findAllByGroupId(groupId);
+
+		List<GroupMemberExpenseResponse> responses = groupMemberById.keySet()
+			.stream()
+			.map(key -> {
+					if (memberExpenses.get(key) == null)
+						return null;
+					return findMemberExpenseDetailByGroupMember(groupMemberById.get(key), memberExpenses.get(key),
+						expenses);
+				}
+			)
+			.filter(Objects::nonNull)
+			.toList();
+
+		return new GroupMembersExpenseResponse(responses);
+	}
+
+	private Map<Long, GroupMember> convertGroupMembersToMap(List<GroupMember> groupMembers) {
+		return groupMembers.stream()
+			.collect(Collectors.toMap(GroupMember::getId, groupMember -> groupMember,
+				(existing, replacement) -> existing,
+				LinkedHashMap::new)
+			);
+	}
+
+	private GroupMemberExpenseResponse findMemberExpenseDetailByGroupMember(GroupMember groupMember,
+		List<MemberExpense> memberExpenses, List<Expense> expenses) {
+
+		Map<Long, MemberExpense> expenseToMemberExpenseMap = memberExpenses.stream()
+			.collect(Collectors.toMap(MemberExpense::getExpenseId, me -> me));
+
+		List<MemberExpenseDetailResponse> memberExpenseDetails = expenses.stream()
+			.map(expense -> {
+				MemberExpense memberExpense = expenseToMemberExpenseMap.get(expense.getId());
+				return (memberExpense != null) ? MemberExpenseDetailResponse.of(expense, memberExpense) : null;
+			})
+			.filter(Objects::nonNull)
+			.toList();
+
+		return GroupMemberExpenseResponse.of(groupMember, memberExpenseDetails);
 	}
 }

--- a/src/main/java/com/dnd/moddo/domain/memberExpense/service/implementation/MemberExpenseCreator.java
+++ b/src/main/java/com/dnd/moddo/domain/memberExpense/service/implementation/MemberExpenseCreator.java
@@ -3,7 +3,6 @@ package com.dnd.moddo.domain.memberExpense.service.implementation;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.dnd.moddo.domain.expense.entity.Expense;
 import com.dnd.moddo.domain.groupMember.entity.GroupMember;
 import com.dnd.moddo.domain.memberExpense.dto.request.MemberExpenseRequest;
 import com.dnd.moddo.domain.memberExpense.entity.MemberExpense;
@@ -17,8 +16,8 @@ import lombok.RequiredArgsConstructor;
 public class MemberExpenseCreator {
 	private final MemberExpenseRepository memberExpenseRepository;
 
-	public MemberExpense create(Expense expense, GroupMember groupMember, MemberExpenseRequest memberExpenseRequest) {
-		MemberExpense memberExpense = memberExpenseRequest.toEntity(expense, groupMember);
+	public MemberExpense create(Long expenseId, GroupMember groupMember, MemberExpenseRequest memberExpenseRequest) {
+		MemberExpense memberExpense = memberExpenseRequest.toEntity(expenseId, groupMember);
 		return memberExpenseRepository.save(memberExpense);
 	}
 }

--- a/src/main/java/com/dnd/moddo/domain/memberExpense/service/implementation/MemberExpenseDeleter.java
+++ b/src/main/java/com/dnd/moddo/domain/memberExpense/service/implementation/MemberExpenseDeleter.java
@@ -1,0 +1,32 @@
+package com.dnd.moddo.domain.memberExpense.service.implementation;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.dnd.moddo.domain.memberExpense.entity.MemberExpense;
+import com.dnd.moddo.domain.memberExpense.repotiroy.MemberExpenseRepository;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Service
+@Transactional
+public class MemberExpenseDeleter {
+
+	private final MemberExpenseRepository memberExpenseRepository;
+
+	public void deleteAllByExpenseId(Long expenseId) {
+		List<MemberExpense> memberExpenses = memberExpenseRepository.findByExpenseId(expenseId);
+		memberExpenseRepository.deleteAll(memberExpenses);
+	}
+
+	public void deleteByMemberExpense(MemberExpense memberExpense) {
+		memberExpenseRepository.delete(memberExpense);
+	}
+
+	public void deleteByMemberExpenses(List<MemberExpense> memberExpenses) {
+		memberExpenseRepository.deleteAll(memberExpenses);
+	}
+}

--- a/src/main/java/com/dnd/moddo/domain/memberExpense/service/implementation/MemberExpenseReader.java
+++ b/src/main/java/com/dnd/moddo/domain/memberExpense/service/implementation/MemberExpenseReader.java
@@ -14,15 +14,14 @@ import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class MemberExpenseReader {
 	private final MemberExpenseRepository memberExpenseRepository;
 
-	@Transactional(readOnly = true)
 	public List<MemberExpense> findAllByExpenseId(Long expenseId) {
 		return memberExpenseRepository.findByExpenseId(expenseId);
 	}
 
-	@Transactional
 	public Map<Long, List<MemberExpense>> findAllByGroupMemberIds(List<Long> groupMemberIds) {
 		return memberExpenseRepository.findAllByGroupMemberIds(groupMemberIds)
 			.stream()

--- a/src/main/java/com/dnd/moddo/domain/memberExpense/service/implementation/MemberExpenseReader.java
+++ b/src/main/java/com/dnd/moddo/domain/memberExpense/service/implementation/MemberExpenseReader.java
@@ -1,6 +1,8 @@
 package com.dnd.moddo.domain.memberExpense.service.implementation;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -12,11 +14,18 @@ import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class MemberExpenseReader {
 	private final MemberExpenseRepository memberExpenseRepository;
 
+	@Transactional(readOnly = true)
 	public List<MemberExpense> findAllByExpenseId(Long expenseId) {
 		return memberExpenseRepository.findByExpenseId(expenseId);
+	}
+
+	@Transactional
+	public Map<Long, List<MemberExpense>> findAllByGroupMemberIds(List<Long> groupMemberIds) {
+		return memberExpenseRepository.findAllByGroupMemberIds(groupMemberIds)
+			.stream()
+			.collect(Collectors.groupingBy(me -> me.getGroupMember().getId()));
 	}
 }

--- a/src/main/java/com/dnd/moddo/domain/memberExpense/service/implementation/MemberExpenseUpdater.java
+++ b/src/main/java/com/dnd/moddo/domain/memberExpense/service/implementation/MemberExpenseUpdater.java
@@ -1,0 +1,22 @@
+package com.dnd.moddo.domain.memberExpense.service.implementation;
+
+import org.springframework.stereotype.Service;
+
+import com.dnd.moddo.domain.memberExpense.dto.request.MemberExpenseRequest;
+import com.dnd.moddo.domain.memberExpense.entity.MemberExpense;
+import com.dnd.moddo.domain.memberExpense.repotiroy.MemberExpenseRepository;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Service
+@Transactional
+public class MemberExpenseUpdater {
+	private final MemberExpenseRepository memberExpenseRepository;
+
+	public void update(MemberExpense memberExpense, MemberExpenseRequest request) {
+		memberExpense.updateAmount(request.amount());
+		memberExpenseRepository.save(memberExpense);
+	}
+}

--- a/src/test/java/com/dnd/moddo/domain/expense/entity/ExpenseTest.java
+++ b/src/test/java/com/dnd/moddo/domain/expense/entity/ExpenseTest.java
@@ -26,7 +26,7 @@ class ExpenseTest {
 		Long initAmount = 20000L;
 		String initContent = "old content";
 		LocalDate initDate = LocalDate.of(2025, 02, 03);
-		Expense expense = new Expense(mockGroup, initAmount, initContent, 0, initDate);
+		Expense expense = new Expense(mockGroup, initAmount, initContent, initDate);
 
 		// when
 		Long newAmount = 30000L;

--- a/src/test/java/com/dnd/moddo/domain/expense/service/CommandExpenseServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/expense/service/CommandExpenseServiceTest.java
@@ -26,6 +26,7 @@ import com.dnd.moddo.domain.expense.service.implementation.ExpenseCreator;
 import com.dnd.moddo.domain.expense.service.implementation.ExpenseDeleter;
 import com.dnd.moddo.domain.expense.service.implementation.ExpenseUpdater;
 import com.dnd.moddo.domain.group.entity.Group;
+import com.dnd.moddo.domain.memberExpense.dto.response.MemberExpenseResponse;
 import com.dnd.moddo.domain.memberExpense.service.CommandMemberExpenseService;
 
 @ExtendWith(MockitoExtension.class)
@@ -55,8 +56,6 @@ class CommandExpenseServiceTest {
 	void createExpense() {
 		//given
 		Long groupId = mockGroup.getId();
-
-		//when(expenseReader.findMaxOrderForGroup(eq(groupId))).thenReturn(0);
 
 		ExpenseRequest expenseRequest1 = new ExpenseRequest(20000L, "투썸플레이스", LocalDate.of(2025, 02, 03),
 			new ArrayList<>());
@@ -90,14 +89,19 @@ class CommandExpenseServiceTest {
 		ExpenseRequest expenseRequest = mock(ExpenseRequest.class);
 		ExpenseResponse expectedResponse = ExpenseResponse.of(mockExpense);
 
+		MemberExpenseResponse memberExpenseResponse1 = mock(MemberExpenseResponse.class);
+		MemberExpenseResponse memberExpenseResponse2 = mock(MemberExpenseResponse.class);
+
 		when(expenseUpdater.update(eq(expenseId), eq(expenseRequest))).thenReturn(mockExpense);
+		when(commandMemberExpenseService.update(eq(expenseId), any())).thenReturn(
+			List.of(memberExpenseResponse1, memberExpenseResponse2));
 		// when
 		ExpenseResponse response = commandExpenseService.update(expenseId, expenseRequest);
 
 		//then
 		assertThat(response).isNotNull();
-		assertThat(response).isEqualTo(expectedResponse);
-
+		assertThat(response.content()).isEqualTo("투썸플레이스");
+		assertThat(response.memberExpenses().size()).isEqualTo(2);
 		verify(expenseUpdater, times(1)).update(expenseId, expenseRequest);
 	}
 

--- a/src/test/java/com/dnd/moddo/domain/expense/service/QueryExpenseServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/expense/service/QueryExpenseServiceTest.java
@@ -49,8 +49,8 @@ class QueryExpenseServiceTest {
 		//given
 		Long groupId = mockGroup.getId();
 		List<Expense> mockExpenses = List.of(
-			new Expense(mockGroup, 20000L, "투썸플레이스", 0, LocalDate.of(2025, 02, 03)),
-			new Expense(mockGroup, 35000L, "보드게임카페", 1, LocalDate.of(2025, 02, 03))
+			new Expense(mockGroup, 20000L, "투썸플레이스", LocalDate.of(2025, 02, 03)),
+			new Expense(mockGroup, 35000L, "보드게임카페", LocalDate.of(2025, 02, 03))
 		);
 
 		when(expenseReader.findAllByGroupId(eq(groupId))).thenReturn(mockExpenses);
@@ -84,7 +84,7 @@ class QueryExpenseServiceTest {
 	void findOneByExpenseIdSuccess() {
 		//given
 		Long groupId = mockGroup.getId(), expenseId = 1L;
-		Expense mockExpense = new Expense(mockGroup, 20000L, "투썸플레이스", 0, LocalDate.of(2025, 02, 03));
+		Expense mockExpense = new Expense(mockGroup, 20000L, "투썸플레이스", LocalDate.of(2025, 02, 03));
 
 		when(expenseReader.findOneByExpenseId(eq(expenseId))).thenReturn(mockExpense);
 

--- a/src/test/java/com/dnd/moddo/domain/expense/service/QueryExpenseServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/expense/service/QueryExpenseServiceTest.java
@@ -6,7 +6,6 @@ import static org.mockito.Mockito.*;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -22,24 +21,15 @@ import com.dnd.moddo.domain.expense.entity.Expense;
 import com.dnd.moddo.domain.expense.exception.ExpenseNotFoundException;
 import com.dnd.moddo.domain.expense.service.implementation.ExpenseReader;
 import com.dnd.moddo.domain.group.entity.Group;
-import com.dnd.moddo.domain.groupMember.dto.response.GroupMembersExpenseResponse;
-import com.dnd.moddo.domain.groupMember.entity.GroupMember;
 import com.dnd.moddo.domain.groupMember.entity.type.ExpenseRole;
-import com.dnd.moddo.domain.groupMember.service.implementation.GroupMemberReader;
 import com.dnd.moddo.domain.memberExpense.dto.response.MemberExpenseResponse;
-import com.dnd.moddo.domain.memberExpense.entity.MemberExpense;
 import com.dnd.moddo.domain.memberExpense.service.QueryMemberExpenseService;
-import com.dnd.moddo.domain.memberExpense.service.implementation.MemberExpenseReader;
 
 @ExtendWith(MockitoExtension.class)
 class QueryExpenseServiceTest {
 
 	@Mock
 	private ExpenseReader expenseReader;
-	@Mock
-	private GroupMemberReader groupMemberReader;
-	@Mock
-	private MemberExpenseReader memberExpenseReader;
 	@Mock
 	private QueryMemberExpenseService queryMemberExpenseService;
 	@InjectMocks
@@ -124,51 +114,4 @@ class QueryExpenseServiceTest {
 		}).hasMessage("해당 지출내역을 찾을 수 없습니다. (Expense ID: " + expenseId + ")");
 	}
 
-	@DisplayName("모임이 유효할 때 참여자별 정산내역 조회에 성공한다.")
-	@Test
-	void findSettlementsByGroupId_Success() {
-		//given
-		Long groupId = 1L;
-		GroupMember groupMember1 = mock(GroupMember.class);
-		GroupMember groupMember2 = mock(GroupMember.class);
-
-		when(groupMember1.getId()).thenReturn(1L);
-		when(groupMember2.getId()).thenReturn(2L);
-
-		List<GroupMember> groupMembers = List.of(groupMember1, groupMember2);
-
-		MemberExpense memberExpense1 = mock(MemberExpense.class);
-		MemberExpense memberExpense2 = mock(MemberExpense.class);
-		when(memberExpense1.getExpenseId()).thenReturn(1L);
-		when(memberExpense1.getAmount()).thenReturn(10000L);
-
-		when(memberExpense2.getExpenseId()).thenReturn(2L);
-		when(memberExpense2.getAmount()).thenReturn(15000L);
-
-		Expense expense1 = mock(Expense.class);
-		Expense expense2 = mock(Expense.class);
-		when(expense1.getId()).thenReturn(1L);
-		when(expense2.getId()).thenReturn(2L);
-
-		when(groupMemberReader.findAllByGroupId(eq(groupId))).thenReturn(groupMembers);
-
-		when(memberExpenseReader.findAllByGroupMemberIds(List.of(1L, 2L)))
-			.thenReturn(Map.of(
-				1L, List.of(memberExpense1),
-				2L, List.of(memberExpense2)
-			));
-
-		when(expenseReader.findAllByGroupId(any())).thenReturn(List.of(expense1, expense2));
-
-		// when
-		GroupMembersExpenseResponse response = queryExpenseService.findSettlementsByGroupId(groupId);
-
-		// then
-		assertThat(response).isNotNull();
-		assertThat(response.memberExpenses().size()).isEqualTo(2);
-
-		verify(groupMemberReader, times(1)).findAllByGroupId(groupId);
-		verify(memberExpenseReader, times(1)).findAllByGroupMemberIds(anyList());
-		verify(expenseReader, times(1)).findAllByGroupId(groupId);
-	}
 }

--- a/src/test/java/com/dnd/moddo/domain/expense/service/QueryExpenseServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/expense/service/QueryExpenseServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.*;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -21,15 +22,24 @@ import com.dnd.moddo.domain.expense.entity.Expense;
 import com.dnd.moddo.domain.expense.exception.ExpenseNotFoundException;
 import com.dnd.moddo.domain.expense.service.implementation.ExpenseReader;
 import com.dnd.moddo.domain.group.entity.Group;
+import com.dnd.moddo.domain.groupMember.dto.response.GroupMembersExpenseResponse;
+import com.dnd.moddo.domain.groupMember.entity.GroupMember;
 import com.dnd.moddo.domain.groupMember.entity.type.ExpenseRole;
+import com.dnd.moddo.domain.groupMember.service.implementation.GroupMemberReader;
 import com.dnd.moddo.domain.memberExpense.dto.response.MemberExpenseResponse;
+import com.dnd.moddo.domain.memberExpense.entity.MemberExpense;
 import com.dnd.moddo.domain.memberExpense.service.QueryMemberExpenseService;
+import com.dnd.moddo.domain.memberExpense.service.implementation.MemberExpenseReader;
 
 @ExtendWith(MockitoExtension.class)
 class QueryExpenseServiceTest {
 
 	@Mock
 	private ExpenseReader expenseReader;
+	@Mock
+	private GroupMemberReader groupMemberReader;
+	@Mock
+	private MemberExpenseReader memberExpenseReader;
 	@Mock
 	private QueryMemberExpenseService queryMemberExpenseService;
 	@InjectMocks
@@ -112,5 +122,53 @@ class QueryExpenseServiceTest {
 		assertThatThrownBy(() -> {
 			queryExpenseService.findOneByExpenseId(expenseId);
 		}).hasMessage("해당 지출내역을 찾을 수 없습니다. (Expense ID: " + expenseId + ")");
+	}
+
+	@DisplayName("모임이 유효할 때 참여자별 정산내역 조회에 성공한다.")
+	@Test
+	void findSettlementByGroupId_Success() {
+		//given
+		Long groupId = 1L;
+		GroupMember groupMember1 = mock(GroupMember.class);
+		GroupMember groupMember2 = mock(GroupMember.class);
+
+		when(groupMember1.getId()).thenReturn(1L);
+		when(groupMember2.getId()).thenReturn(2L);
+
+		List<GroupMember> groupMembers = List.of(groupMember1, groupMember2);
+
+		MemberExpense memberExpense1 = mock(MemberExpense.class);
+		MemberExpense memberExpense2 = mock(MemberExpense.class);
+		when(memberExpense1.getExpenseId()).thenReturn(1L);
+		when(memberExpense1.getAmount()).thenReturn(10000L);
+
+		when(memberExpense2.getExpenseId()).thenReturn(2L);
+		when(memberExpense2.getAmount()).thenReturn(15000L);
+
+		Expense expense1 = mock(Expense.class);
+		Expense expense2 = mock(Expense.class);
+		when(expense1.getId()).thenReturn(1L);
+		when(expense2.getId()).thenReturn(2L);
+
+		when(groupMemberReader.findAllByGroupId(eq(groupId))).thenReturn(groupMembers);
+
+		when(memberExpenseReader.findAllByGroupMemberIds(List.of(1L, 2L)))
+			.thenReturn(Map.of(
+				1L, List.of(memberExpense1),
+				2L, List.of(memberExpense2)
+			));
+
+		when(expenseReader.findAllByGroupId(any())).thenReturn(List.of(expense1, expense2));
+
+		// when
+		GroupMembersExpenseResponse response = queryExpenseService.findSettlementByGroupId(groupId);
+
+		// then
+		assertThat(response).isNotNull();
+		assertThat(response.memberExpenses().size()).isEqualTo(2);
+
+		verify(groupMemberReader, times(1)).findAllByGroupId(groupId);
+		verify(memberExpenseReader, times(1)).findAllByGroupMemberIds(anyList());
+		verify(expenseReader, times(1)).findAllByGroupId(groupId);
 	}
 }

--- a/src/test/java/com/dnd/moddo/domain/expense/service/QueryExpenseServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/expense/service/QueryExpenseServiceTest.java
@@ -126,7 +126,7 @@ class QueryExpenseServiceTest {
 
 	@DisplayName("모임이 유효할 때 참여자별 정산내역 조회에 성공한다.")
 	@Test
-	void findSettlementByGroupId_Success() {
+	void findSettlementsByGroupId_Success() {
 		//given
 		Long groupId = 1L;
 		GroupMember groupMember1 = mock(GroupMember.class);
@@ -161,7 +161,7 @@ class QueryExpenseServiceTest {
 		when(expenseReader.findAllByGroupId(any())).thenReturn(List.of(expense1, expense2));
 
 		// when
-		GroupMembersExpenseResponse response = queryExpenseService.findSettlementByGroupId(groupId);
+		GroupMembersExpenseResponse response = queryExpenseService.findSettlementsByGroupId(groupId);
 
 		// then
 		assertThat(response).isNotNull();

--- a/src/test/java/com/dnd/moddo/domain/expense/service/implementation/ExpenseCreatorTest.java
+++ b/src/test/java/com/dnd/moddo/domain/expense/service/implementation/ExpenseCreatorTest.java
@@ -49,11 +49,11 @@ class ExpenseCreatorTest {
 		when(groupRepository.getById(eq(groupId))).thenReturn(mockGroup);
 		ExpenseRequest request = mock(ExpenseRequest.class);
 
-		Expense mockExpense = new Expense(mockGroup, 20000L, "투썸플레이스", 1, LocalDate.of(2025, 02, 03));
+		Expense mockExpense = new Expense(mockGroup, 20000L, "투썸플레이스", LocalDate.of(2025, 02, 03));
 		when(expenseRepository.save(any())).thenReturn(mockExpense);
 		doNothing().when(memberExpenseValidator).validateMembersArePartOfGroup(groupId, new ArrayList<>());
 		//when
-		Expense result = expenseCreator.create(groupId, 2, request);
+		Expense result = expenseCreator.create(groupId, request);
 
 		//then
 		assertThat(result).isNotNull();

--- a/src/test/java/com/dnd/moddo/domain/expense/service/implementation/ExpenseReaderTest.java
+++ b/src/test/java/com/dnd/moddo/domain/expense/service/implementation/ExpenseReaderTest.java
@@ -42,11 +42,11 @@ class ExpenseReaderTest {
 		//given
 		Long groupId = mockGroup.getId();
 		List<Expense> mockExpenses = List.of(
-			new Expense(mockGroup, 20000L, "투썸플레이스", 0, LocalDate.of(2025, 02, 03)),
-			new Expense(mockGroup, 35000L, "보드게임카페", 1, LocalDate.of(2025, 02, 03))
+			new Expense(mockGroup, 20000L, "투썸플레이스", LocalDate.of(2025, 02, 03)),
+			new Expense(mockGroup, 35000L, "보드게임카페", LocalDate.of(2025, 02, 03))
 		);
 
-		when(expenseRepository.findByGroupIdOrderByOrderAsc(eq(groupId))).thenReturn(mockExpenses);
+		when(expenseRepository.findByGroupIdOrderByDateAsc(eq(groupId))).thenReturn(mockExpenses);
 
 		//when
 		List<Expense> result = expenseReader.findAllByGroupId(groupId);
@@ -56,7 +56,7 @@ class ExpenseReaderTest {
 		assertThat(result.get(0).getContent()).isEqualTo("투썸플레이스");
 
 		//then
-		verify(expenseRepository, times(1)).findByGroupIdOrderByOrderAsc(eq(groupId));
+		verify(expenseRepository, times(1)).findByGroupIdOrderByDateAsc(eq(groupId));
 	}
 
 	@DisplayName("지출내역이 존재하면 해당 지출내역을 조회할 수 있다.")
@@ -64,7 +64,7 @@ class ExpenseReaderTest {
 	void findOneByExpenseIdSuccess() {
 		//given
 		Long expenseId = 1L;
-		Expense mockExpense = new Expense(mockGroup, 20000L, "투썸플레이스", 0, LocalDate.of(2025, 02, 03));
+		Expense mockExpense = new Expense(mockGroup, 20000L, "투썸플레이스", LocalDate.of(2025, 02, 03));
 
 		when(expenseRepository.getById(eq(expenseId))).thenReturn(mockExpense);
 		//when

--- a/src/test/java/com/dnd/moddo/domain/expense/service/implementation/ExpenseUpdaterTest.java
+++ b/src/test/java/com/dnd/moddo/domain/expense/service/implementation/ExpenseUpdaterTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.AssertionsForClassTypes.*;
 import static org.mockito.Mockito.*;
 
 import java.time.LocalDate;
-import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -14,12 +13,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.dnd.moddo.domain.expense.dto.request.ExpenseRequest;
-import com.dnd.moddo.domain.expense.dto.request.ExpenseUpdateOrderRequest;
-import com.dnd.moddo.domain.expense.dto.request.ExpensesUpdateOrderRequest;
 import com.dnd.moddo.domain.expense.entity.Expense;
 import com.dnd.moddo.domain.expense.exception.ExpenseNotFoundException;
 import com.dnd.moddo.domain.expense.repository.ExpenseRepository;
-import com.dnd.moddo.domain.group.entity.Group;
 
 @ExtendWith(MockitoExtension.class)
 class ExpenseUpdaterTest {
@@ -63,28 +59,4 @@ class ExpenseUpdaterTest {
 		}).hasMessage("해당 지출내역을 찾을 수 없습니다. (Expense ID: " + expenseId + ")");
 	}
 
-	@DisplayName("요청이 유효하게 들어오면 지출 내역의 순서를 변경할 수 있다.")
-	@Test
-	void upateOrder_Success() {
-		//given
-		ExpensesUpdateOrderRequest request = new ExpensesUpdateOrderRequest(
-			List.of(new ExpenseUpdateOrderRequest(2, 1L),
-				new ExpenseUpdateOrderRequest(1, 2L)
-			)
-		);
-		Group group = mock(Group.class);
-		Expense expense1 = new Expense(group, 20000L, "expense 1", 1, LocalDate.of(2025, 02, 03));
-		Expense expense2 = new Expense(group, 15000L, "expense 2", 2, LocalDate.of(2025, 02, 03));
-
-		when(expenseRepository.getById(any()))
-			.thenReturn(expense1)
-			.thenReturn(expense2);
-
-		//when
-		expenseUpdater.updateOrder(request);
-
-		//then
-		assertThat(expense1.getOrder()).isEqualTo(2);
-		assertThat(expense2.getOrder()).isEqualTo(1);
-	}
 }

--- a/src/test/java/com/dnd/moddo/domain/groupMember/service/CommandGroupMemberServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/groupMember/service/CommandGroupMemberServiceTest.java
@@ -18,6 +18,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.dnd.moddo.domain.group.entity.Group;
 import com.dnd.moddo.domain.groupMember.dto.request.GroupMemberSaveRequest;
 import com.dnd.moddo.domain.groupMember.dto.request.GroupMembersSaveRequest;
+import com.dnd.moddo.domain.groupMember.dto.request.PaymentStatusUpdateRequest;
 import com.dnd.moddo.domain.groupMember.dto.response.GroupMemberResponse;
 import com.dnd.moddo.domain.groupMember.dto.response.GroupMembersResponse;
 import com.dnd.moddo.domain.groupMember.entity.GroupMember;
@@ -77,11 +78,32 @@ public class CommandGroupMemberServiceTest {
 		when(groupMemberUpdater.addToGroup(eq(groupId), any(GroupMemberSaveRequest.class))).thenReturn(expectedMember);
 
 		//when
-		GroupMemberResponse result = commandGroupMemberService.addGroupMember(groupId, request);
+		GroupMemberResponse response = commandGroupMemberService.addGroupMember(groupId, request);
 
 		//then
-		assertThat(result).isNotNull();
-		assertThat(result.name()).isEqualTo("김반숙");
+		assertThat(response).isNotNull();
+		assertThat(response.name()).isEqualTo("김반숙");
 		verify(groupMemberUpdater, times(1)).addToGroup(eq(groupId), any(GroupMemberSaveRequest.class));
+	}
+
+	@DisplayName("참여자 입금 내역을 업데이트 할 수 있다.")
+	@Test
+	void updatePaymentStatus_Success() {
+		//given
+		GroupMember expectedGroupMember = new GroupMember("김반숙", mockGroup, true, ExpenseRole.PARTICIPANT);
+		PaymentStatusUpdateRequest request = new PaymentStatusUpdateRequest(true);
+		when(groupMemberUpdater.updatePaymentStatus(any(), eq(request))).thenReturn(expectedGroupMember);
+
+		//then
+		GroupMemberResponse response = commandGroupMemberService.updatePaymentStatus(1L, request);
+
+		//then
+		assertThat(response).isNotNull();
+		assertThat(response.name()).isEqualTo("김반숙");
+		assertThat(response.role()).isEqualTo(ExpenseRole.PARTICIPANT);
+		assertThat(response.isPaid()).isTrue();
+
+		verify(groupMemberUpdater, times(1)).updatePaymentStatus(any(), eq(request));
+
 	}
 }

--- a/src/test/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberCreatorTest.java
+++ b/src/test/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberCreatorTest.java
@@ -17,7 +17,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.dnd.moddo.domain.group.entity.Group;
-import com.dnd.moddo.domain.group.repository.GroupRepository;
+import com.dnd.moddo.domain.group.service.implementation.GroupReader;
 import com.dnd.moddo.domain.groupMember.dto.request.GroupMembersSaveRequest;
 import com.dnd.moddo.domain.groupMember.entity.GroupMember;
 import com.dnd.moddo.domain.groupMember.entity.type.ExpenseRole;
@@ -32,7 +32,7 @@ public class GroupMemberCreatorTest {
 	@Mock
 	private GroupMemberValidator groupMemberValidator;
 	@Mock
-	private GroupRepository groupRepository;
+	private GroupReader groupReader;
 	@InjectMocks
 	private GroupMemberCreator groupMemberCreator;
 
@@ -53,7 +53,7 @@ public class GroupMemberCreatorTest {
 		//given
 		Long groupId = mockGroup.getId();
 
-		when(groupRepository.getById(eq(groupId))).thenReturn(mockGroup);
+		when(groupReader.read(eq(groupId))).thenReturn(mockGroup);
 		doNothing().when(groupMemberValidator).validateManagerExists(any());
 		doNothing().when(groupMemberValidator).validateMemberNamesNotDuplicate(any());
 
@@ -83,7 +83,7 @@ public class GroupMemberCreatorTest {
 		Long groupId = mockGroup.getId();
 		List<GroupMember> groupMembers = new ArrayList<>();
 
-		when(groupRepository.getById(eq(groupId))).thenReturn(mockGroup);
+		when(groupReader.read(eq(groupId))).thenReturn(mockGroup);
 
 		doThrow(new GroupMemberDuplicateNameException()).when(groupMemberValidator)
 			.validateMemberNamesNotDuplicate(any());
@@ -103,7 +103,7 @@ public class GroupMemberCreatorTest {
 		Long groupId = mockGroup.getId();
 		List<GroupMember> groupMembers = new ArrayList<>();
 
-		when(groupRepository.getById(eq(groupId))).thenReturn(mockGroup);
+		when(groupReader.read(eq(groupId))).thenReturn(mockGroup);
 
 		doThrow(new InvalidExpenseParticipantsException()).when(groupMemberValidator)
 			.validateManagerExists(any());

--- a/src/test/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberUpdaterTest.java
+++ b/src/test/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberUpdaterTest.java
@@ -19,6 +19,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.dnd.moddo.domain.group.entity.Group;
 import com.dnd.moddo.domain.group.repository.GroupRepository;
 import com.dnd.moddo.domain.groupMember.dto.request.GroupMemberSaveRequest;
+import com.dnd.moddo.domain.groupMember.dto.request.PaymentStatusUpdateRequest;
 import com.dnd.moddo.domain.groupMember.entity.GroupMember;
 import com.dnd.moddo.domain.groupMember.entity.type.ExpenseRole;
 import com.dnd.moddo.domain.groupMember.exception.GroupMemberDuplicateNameException;
@@ -90,5 +91,22 @@ class GroupMemberUpdaterTest {
 		assertThatThrownBy(() -> {
 			groupMemberUpdater.addToGroup(groupId, request);
 		}).hasMessage("중복된 참여자의 이름은 저장할 수 없습니다.");
+	}
+
+	@DisplayName("참여자가 유효할 때 참여자의 입금 상태를 변경할 수 있다.")
+	@Test
+	void updatePaymentStatus_Success() {
+		//given
+		GroupMember groupMember = new GroupMember("김반숙", mockGroup, ExpenseRole.PARTICIPANT);
+		PaymentStatusUpdateRequest request = new PaymentStatusUpdateRequest(true);
+
+		when(groupMemberRepository.getById(any())).thenReturn(groupMember);
+
+		//then
+		GroupMember result = groupMemberUpdater.updatePaymentStatus(1L, request);
+
+		//then
+		assertThat(result).isNotNull();
+		assertThat(result.isPaid()).isTrue();
 	}
 }

--- a/src/test/java/com/dnd/moddo/domain/memberExpense/service/CommandMemberExpenseServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/memberExpense/service/CommandMemberExpenseServiceTest.java
@@ -1,0 +1,205 @@
+package com.dnd.moddo.domain.memberExpense.service;
+
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.dnd.moddo.domain.group.entity.Group;
+import com.dnd.moddo.domain.groupMember.entity.GroupMember;
+import com.dnd.moddo.domain.groupMember.service.implementation.GroupMemberReader;
+import com.dnd.moddo.domain.memberExpense.dto.request.MemberExpenseRequest;
+import com.dnd.moddo.domain.memberExpense.dto.response.MemberExpenseResponse;
+import com.dnd.moddo.domain.memberExpense.entity.MemberExpense;
+import com.dnd.moddo.domain.memberExpense.service.implementation.MemberExpenseCreator;
+import com.dnd.moddo.domain.memberExpense.service.implementation.MemberExpenseDeleter;
+import com.dnd.moddo.domain.memberExpense.service.implementation.MemberExpenseReader;
+import com.dnd.moddo.domain.memberExpense.service.implementation.MemberExpenseUpdater;
+
+@ExtendWith(MockitoExtension.class)
+class CommandMemberExpenseServiceTest {
+	@Mock
+	private GroupMemberReader groupMemberReader;
+	@Mock
+	private MemberExpenseCreator memberExpenseCreator;
+	@Mock
+	private MemberExpenseReader memberExpenseReader;
+	@Mock
+	private MemberExpenseUpdater memberExpenseUpdater;
+	@Mock
+	private MemberExpenseDeleter memberExpenseDeleter;
+	@InjectMocks
+	private CommandMemberExpenseService commandMemberExpenseService;
+
+	private Group mockGroup = mock(Group.class);
+
+	@DisplayName("참여자별 지출내역으르 생성할 때 모든 정보가 유효할 때 참여자별 지출내역 생성에 성공한다.")
+	@Test
+	void create_Success_MemberExpenses() {
+		//given
+		Long expenseId = 1L;
+		MemberExpenseRequest request1 = new MemberExpenseRequest(1L, 5000L);
+		MemberExpenseRequest request2 = new MemberExpenseRequest(2L, 10000L);
+		List<MemberExpenseRequest> requests = List.of(request1, request2);
+
+		GroupMember groupMember1 = mock(GroupMember.class);
+		GroupMember groupMember2 = mock(GroupMember.class);
+
+		when(groupMember1.getId()).thenReturn(1L);
+		when(groupMember2.getId()).thenReturn(2L);
+
+		when(groupMemberReader.findByGroupMemberId(any()))
+			.thenReturn(groupMember1)
+			.thenReturn(groupMember2);
+
+		MemberExpense memberExpense1 = mock(MemberExpense.class);
+		MemberExpense memberExpense2 = mock(MemberExpense.class);
+
+		when(memberExpense1.getGroupMember()).thenReturn(groupMember1);
+		when(memberExpense2.getGroupMember()).thenReturn(groupMember2);
+
+		when(memberExpenseCreator.create(eq(expenseId), eq(groupMember1), eq(request1)))
+			.thenReturn(memberExpense1);
+		when(memberExpenseCreator.create(eq(expenseId), eq(groupMember2), eq(request2)))
+			.thenReturn(memberExpense2);
+
+		//when
+		List<MemberExpenseResponse> responses = commandMemberExpenseService.create(expenseId, requests);
+
+		//then
+		assertThat(!responses.isEmpty()).isTrue();
+		assertThat(responses.size()).isEqualTo(2);
+
+		verify(memberExpenseCreator, times(2)).create(eq(expenseId), any(GroupMember.class),
+			any(MemberExpenseRequest.class));
+	}
+
+	@DisplayName("지출내역이 수정될때 모든 참여자별 지출내역이 존재했던 정보일 때 참여자별 지출내역 수정에 성공한다.")
+	@Test
+	void update_Success_MemberExpenses() {
+		//given
+		Long expenseId = 1L;
+		MemberExpenseRequest request1 = new MemberExpenseRequest(1L, 20000L);
+		MemberExpenseRequest request2 = new MemberExpenseRequest(2L, 30000L);
+		List<MemberExpenseRequest> requests = List.of(request1, request2);
+
+		GroupMember groupMember1 = mock(GroupMember.class);
+		GroupMember groupMember2 = mock(GroupMember.class);
+
+		when(groupMember1.getId()).thenReturn(1L);
+		when(groupMember2.getId()).thenReturn(2L);
+
+		MemberExpense existingMemberExpense1 = mock(MemberExpense.class);
+		MemberExpense existingMemberExpense2 = mock(MemberExpense.class);
+
+		when(existingMemberExpense1.getGroupMember()).thenReturn(groupMember1);
+		when(existingMemberExpense2.getGroupMember()).thenReturn(groupMember2);
+
+		when(memberExpenseReader.findAllByExpenseId(eq(expenseId))).thenReturn(
+			List.of(existingMemberExpense1, existingMemberExpense2));
+
+		doNothing().when(memberExpenseUpdater).update(existingMemberExpense1, request1);
+		doNothing().when(memberExpenseUpdater).update(existingMemberExpense2, request2);
+
+		//when
+		List<MemberExpenseResponse> responses = commandMemberExpenseService.update(expenseId, requests);
+
+		//then
+		assertThat(responses.isEmpty()).isFalse();
+		assertThat(responses.size()).isEqualTo(2);
+
+		verify(memberExpenseUpdater, times(2)).update(any(MemberExpense.class), any(MemberExpenseRequest.class));
+	}
+
+	@DisplayName("지출내역이 수정될때 일부 참여자의 지출내역이 추가되었을때 참여자별 지출내역 추가 및 수정에 성공한다.")
+	@Test
+	void addAndUpdate_Success_eMemberExpenses() {
+		//given
+		Long expenseId = 1L;
+		MemberExpenseRequest request1 = new MemberExpenseRequest(1L, 20000L);
+		MemberExpenseRequest request2 = new MemberExpenseRequest(2L, 15000L);
+		MemberExpenseRequest request3 = new MemberExpenseRequest(3L, 30000L);
+		List<MemberExpenseRequest> requests = List.of(request1, request2, request3);
+
+		GroupMember groupMember1 = mock(GroupMember.class);
+		GroupMember groupMember2 = mock(GroupMember.class);
+		GroupMember expectedGroupMember = mock(GroupMember.class);
+
+		when(groupMember1.getId()).thenReturn(1L);
+		when(groupMember2.getId()).thenReturn(2L);
+		when(expectedGroupMember.getId()).thenReturn(3L);
+
+		MemberExpense existingMemberExpense1 = mock(MemberExpense.class);
+		MemberExpense existingMemberExpense2 = mock(MemberExpense.class);
+
+		when(existingMemberExpense1.getGroupMember()).thenReturn(groupMember1);
+		when(existingMemberExpense2.getGroupMember()).thenReturn(groupMember2);
+
+		MemberExpense expectedMemberExpense = new MemberExpense(expenseId, expectedGroupMember, 30000L);
+
+		when(memberExpenseReader.findAllByExpenseId(eq(expenseId))).thenReturn(
+			List.of(existingMemberExpense1, existingMemberExpense2));
+		when(groupMemberReader.findByGroupMemberId(3L)).thenReturn(expectedGroupMember);
+
+		doNothing().when(memberExpenseUpdater).update(existingMemberExpense1, request1);
+		doNothing().when(memberExpenseUpdater).update(existingMemberExpense2, request2);
+		when(memberExpenseCreator.create(eq(expenseId), any(GroupMember.class), eq(request3))).thenReturn(
+			expectedMemberExpense);
+
+		// when
+		List<MemberExpenseResponse> responses = commandMemberExpenseService.update(expenseId, requests);
+
+		//then
+		assertThat(responses.isEmpty()).isFalse();
+		assertThat(responses.size()).isEqualTo(3);
+
+		verify(memberExpenseUpdater, times(2)).update(any(MemberExpense.class), any(MemberExpenseRequest.class));
+		verify(memberExpenseCreator, times(1)).create(eq(expenseId), any(GroupMember.class),
+			any(MemberExpenseRequest.class));
+	}
+
+	@DisplayName("원래 참여자별 지출내역에 존재하지만 수정 요청에 참여자id와 금액이 포함되어있지 않다면 참여자 지출내역에서 삭제하고 이외의 요청에 대해서 수정에 성공한다.")
+	@Test
+	void deleteAndUpdate_Success_MemberExpenses() {
+		//given
+		Long expenseId = 1L;
+		MemberExpenseRequest request1 = new MemberExpenseRequest(1L, 20000L);
+		List<MemberExpenseRequest> requests = List.of(request1);
+
+		GroupMember groupMember1 = mock(GroupMember.class);
+		GroupMember groupMember2 = mock(GroupMember.class);
+
+		when(groupMember1.getId()).thenReturn(1L);
+		when(groupMember2.getId()).thenReturn(2L);
+
+		MemberExpense existingMemberExpense1 = mock(MemberExpense.class);
+		MemberExpense existingMemberExpense2 = mock(MemberExpense.class);
+
+		when(existingMemberExpense1.getGroupMember()).thenReturn(groupMember1);
+		when(existingMemberExpense2.getGroupMember()).thenReturn(groupMember2);
+		when(existingMemberExpense1.getAmount()).thenReturn(5000L);
+
+		when(memberExpenseReader.findAllByExpenseId(eq(expenseId))).thenReturn(
+			List.of(existingMemberExpense1, existingMemberExpense2));
+
+		doNothing().when(memberExpenseUpdater).update(existingMemberExpense1, request1);
+		doNothing().when(memberExpenseDeleter).deleteByMemberExpenses(any());
+
+		//when
+		List<MemberExpenseResponse> responses = commandMemberExpenseService.update(expenseId, requests);
+
+		//then
+		assertThat(!responses.isEmpty()).isTrue();
+		assertThat(responses.size()).isEqualTo(1);
+
+		verify(memberExpenseUpdater, times(1)).update(any(MemberExpense.class), any(MemberExpenseRequest.class));
+		verify(memberExpenseDeleter, times(1)).deleteByMemberExpenses(any());
+	}
+}

--- a/src/test/java/com/dnd/moddo/domain/memberExpense/service/QueryMemberExpenseServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/memberExpense/service/QueryMemberExpenseServiceTest.java
@@ -37,7 +37,7 @@ class QueryMemberExpenseServiceTest {
 	void setUp() {
 		mockGroup = new Group("group 1", 1L, "1234", LocalDateTime.now(), LocalDateTime.now().plusMinutes(1),
 			"은행", "계좌");
-		mockExpense = new Expense(mockGroup, 20000L, "투썸플레이스", 0, LocalDate.of(2025, 02, 03));
+		mockExpense = new Expense(mockGroup, 20000L, "투썸플레이스", LocalDate.of(2025, 02, 03));
 
 	}
 

--- a/src/test/java/com/dnd/moddo/domain/memberExpense/service/QueryMemberExpenseServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/memberExpense/service/QueryMemberExpenseServiceTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.*;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -14,9 +15,13 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.dnd.moddo.domain.expense.entity.Expense;
+import com.dnd.moddo.domain.expense.service.implementation.ExpenseReader;
 import com.dnd.moddo.domain.group.entity.Group;
+import com.dnd.moddo.domain.groupMember.dto.response.GroupMembersExpenseResponse;
 import com.dnd.moddo.domain.groupMember.entity.GroupMember;
 import com.dnd.moddo.domain.groupMember.entity.type.ExpenseRole;
+import com.dnd.moddo.domain.groupMember.service.implementation.GroupMemberReader;
 import com.dnd.moddo.domain.memberExpense.dto.response.MemberExpenseResponse;
 import com.dnd.moddo.domain.memberExpense.entity.MemberExpense;
 import com.dnd.moddo.domain.memberExpense.service.implementation.MemberExpenseReader;
@@ -25,6 +30,10 @@ import com.dnd.moddo.domain.memberExpense.service.implementation.MemberExpenseRe
 class QueryMemberExpenseServiceTest {
 	@Mock
 	private MemberExpenseReader memberExpenseReader;
+	@Mock
+	private ExpenseReader expenseReader;
+	@Mock
+	private GroupMemberReader groupMemberReader;
 	@InjectMocks
 	private QueryMemberExpenseService queryMemberExpenseService;
 
@@ -60,7 +69,53 @@ class QueryMemberExpenseServiceTest {
 		assertThat(responses.size()).isEqualTo(2);
 		assertThat(responses.get(0).name()).isEqualTo("김모또");
 		assertThat(responses.get(0).amount()).isEqualTo(15000L);
-
 	}
 
+	@DisplayName("모임이 유효할 때 참여자별 정산내역 조회에 성공한다.")
+	@Test
+	void findMemberExpenseDetailsByGroupId_Success() {
+		//given
+		Long groupId = 1L;
+		GroupMember groupMember1 = mock(GroupMember.class);
+		GroupMember groupMember2 = mock(GroupMember.class);
+
+		when(groupMember1.getId()).thenReturn(1L);
+		when(groupMember2.getId()).thenReturn(2L);
+
+		List<GroupMember> groupMembers = List.of(groupMember1, groupMember2);
+
+		MemberExpense memberExpense1 = mock(MemberExpense.class);
+		MemberExpense memberExpense2 = mock(MemberExpense.class);
+		when(memberExpense1.getExpenseId()).thenReturn(1L);
+		when(memberExpense1.getAmount()).thenReturn(10000L);
+
+		when(memberExpense2.getExpenseId()).thenReturn(2L);
+		when(memberExpense2.getAmount()).thenReturn(15000L);
+
+		Expense expense1 = mock(Expense.class);
+		Expense expense2 = mock(Expense.class);
+		when(expense1.getId()).thenReturn(1L);
+		when(expense2.getId()).thenReturn(2L);
+
+		when(groupMemberReader.findAllByGroupId(eq(groupId))).thenReturn(groupMembers);
+
+		when(memberExpenseReader.findAllByGroupMemberIds(List.of(1L, 2L)))
+			.thenReturn(Map.of(
+				1L, List.of(memberExpense1),
+				2L, List.of(memberExpense2)
+			));
+
+		when(expenseReader.findAllByGroupId(any())).thenReturn(List.of(expense1, expense2));
+
+		// when
+		GroupMembersExpenseResponse response = queryMemberExpenseService.findMemberExpenseDetailsByGroupId(groupId);
+
+		// then
+		assertThat(response).isNotNull();
+		assertThat(response.memberExpenses().size()).isEqualTo(2);
+
+		verify(groupMemberReader, times(1)).findAllByGroupId(groupId);
+		verify(memberExpenseReader, times(1)).findAllByGroupMemberIds(anyList());
+		verify(expenseReader, times(1)).findAllByGroupId(groupId);
+	}
 }

--- a/src/test/java/com/dnd/moddo/domain/memberExpense/service/QueryMemberExpenseServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/memberExpense/service/QueryMemberExpenseServiceTest.java
@@ -3,7 +3,6 @@ package com.dnd.moddo.domain.memberExpense.service;
 import static org.assertj.core.api.AssertionsForClassTypes.*;
 import static org.mockito.Mockito.*;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -15,7 +14,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import com.dnd.moddo.domain.expense.entity.Expense;
 import com.dnd.moddo.domain.group.entity.Group;
 import com.dnd.moddo.domain.groupMember.entity.GroupMember;
 import com.dnd.moddo.domain.groupMember.entity.type.ExpenseRole;
@@ -31,13 +29,11 @@ class QueryMemberExpenseServiceTest {
 	private QueryMemberExpenseService queryMemberExpenseService;
 
 	private Group mockGroup;
-	private Expense mockExpense;
 
 	@BeforeEach
 	void setUp() {
 		mockGroup = new Group("group 1", 1L, "1234", LocalDateTime.now(), LocalDateTime.now().plusMinutes(1),
 			"은행", "계좌");
-		mockExpense = new Expense(mockGroup, 20000L, "투썸플레이스", LocalDate.of(2025, 02, 03));
 
 	}
 
@@ -50,8 +46,8 @@ class QueryMemberExpenseServiceTest {
 		GroupMember mockGroupMember2 = new GroupMember("박완숙", mockGroup, ExpenseRole.PARTICIPANT);
 
 		List<MemberExpense> expectedMemberExpense = List.of(
-			new MemberExpense(mockExpense, mockGroupMember1, 15000L),
-			new MemberExpense(mockExpense, mockGroupMember2, 5000L)
+			new MemberExpense(expenseId, mockGroupMember1, 15000L),
+			new MemberExpense(expenseId, mockGroupMember2, 5000L)
 		);
 
 		when(memberExpenseReader.findAllByExpenseId(eq(expenseId))).thenReturn(expectedMemberExpense);

--- a/src/test/java/com/dnd/moddo/domain/memberExpense/service/implementation/MemberExpenseCreatorTest.java
+++ b/src/test/java/com/dnd/moddo/domain/memberExpense/service/implementation/MemberExpenseCreatorTest.java
@@ -3,7 +3,6 @@ package com.dnd.moddo.domain.memberExpense.service.implementation;
 import static org.assertj.core.api.AssertionsForClassTypes.*;
 import static org.mockito.Mockito.*;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -14,7 +13,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import com.dnd.moddo.domain.expense.entity.Expense;
 import com.dnd.moddo.domain.group.entity.Group;
 import com.dnd.moddo.domain.groupMember.entity.GroupMember;
 import com.dnd.moddo.domain.groupMember.entity.type.ExpenseRole;
@@ -30,7 +28,6 @@ class MemberExpenseCreatorTest {
 	private MemberExpenseCreator memberExpenseCreator;
 
 	private Group mockGroup;
-	private Expense mockExpense;
 	private GroupMember mockGroupMember;
 	private MemberExpenseRequest mockMemberExpenseRequest;
 
@@ -38,7 +35,7 @@ class MemberExpenseCreatorTest {
 	void setUp() {
 		mockGroup = new Group("group 1", 1L, "1234", LocalDateTime.now(), LocalDateTime.now().plusMinutes(1),
 			"은행", "계좌");
-		mockExpense = new Expense(mockGroup, 20000L, "투썸플레이스", LocalDate.of(2025, 02, 03));
+
 		mockGroupMember = new GroupMember("박완수", mockGroup, ExpenseRole.MANAGER);
 		mockMemberExpenseRequest = mock(MemberExpenseRequest.class);
 	}
@@ -47,13 +44,14 @@ class MemberExpenseCreatorTest {
 	@Test
 	void createMemberExpenseSuccess() {
 		//given
-		MemberExpense mockMemberExpense = new MemberExpense(mockExpense, mockGroupMember,
+		Long expenseId = 1L;
+		MemberExpense mockMemberExpense = new MemberExpense(expenseId, mockGroupMember,
 			mockMemberExpenseRequest.amount());
-		when(mockMemberExpenseRequest.toEntity(mockExpense, mockGroupMember)).thenReturn(mockMemberExpense);
+		when(mockMemberExpenseRequest.toEntity(expenseId, mockGroupMember)).thenReturn(mockMemberExpense);
 		when(memberExpenseRepository.save(any(MemberExpense.class))).thenReturn(mockMemberExpense);
 
 		//when
-		MemberExpense result = memberExpenseCreator.create(mockExpense, mockGroupMember, mockMemberExpenseRequest);
+		MemberExpense result = memberExpenseCreator.create(expenseId, mockGroupMember, mockMemberExpenseRequest);
 
 		//then
 		assertThat(result).isEqualTo(mockMemberExpense);

--- a/src/test/java/com/dnd/moddo/domain/memberExpense/service/implementation/MemberExpenseCreatorTest.java
+++ b/src/test/java/com/dnd/moddo/domain/memberExpense/service/implementation/MemberExpenseCreatorTest.java
@@ -38,7 +38,7 @@ class MemberExpenseCreatorTest {
 	void setUp() {
 		mockGroup = new Group("group 1", 1L, "1234", LocalDateTime.now(), LocalDateTime.now().plusMinutes(1),
 			"은행", "계좌");
-		mockExpense = new Expense(mockGroup, 20000L, "투썸플레이스", 1, LocalDate.of(2025, 02, 03));
+		mockExpense = new Expense(mockGroup, 20000L, "투썸플레이스", LocalDate.of(2025, 02, 03));
 		mockGroupMember = new GroupMember("박완수", mockGroup, ExpenseRole.MANAGER);
 		mockMemberExpenseRequest = mock(MemberExpenseRequest.class);
 	}

--- a/src/test/java/com/dnd/moddo/domain/memberExpense/service/implementation/MemberExpenseDeleterTest.java
+++ b/src/test/java/com/dnd/moddo/domain/memberExpense/service/implementation/MemberExpenseDeleterTest.java
@@ -1,10 +1,17 @@
 package com.dnd.moddo.domain.memberExpense.service.implementation;
 
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.dnd.moddo.domain.memberExpense.entity.MemberExpense;
 import com.dnd.moddo.domain.memberExpense.repotiroy.MemberExpenseRepository;
 
 @ExtendWith(MockitoExtension.class)
@@ -14,4 +21,53 @@ class MemberExpenseDeleterTest {
 	@InjectMocks
 	private MemberExpenseDeleter memberExpenseDeleter;
 
+	@DisplayName("지출내역 id가 유효할때 지출내역과 연관되어있는 참여자 지출내역 모두를 삭제할 수 있다.")
+	@Test
+	void deleteAllByExpenseId_Success() {
+		//given
+		Long expenseId = 1L;
+		MemberExpense memberExpense1 = mock(MemberExpense.class);
+		MemberExpense memberExpense2 = mock(MemberExpense.class);
+		List<MemberExpense> memberExpenses = List.of(memberExpense1, memberExpense2);
+
+		when(memberExpenseRepository.findByExpenseId(eq(expenseId))).thenReturn(memberExpenses);
+		doNothing().when(memberExpenseRepository).deleteAll(memberExpenses);
+
+		//when
+		memberExpenseDeleter.deleteAllByExpenseId(expenseId);
+
+		//then
+		verify(memberExpenseRepository, times(1)).findByExpenseId(eq(expenseId));
+		verify(memberExpenseRepository, times(1)).deleteAll(memberExpenses);
+	}
+
+	@DisplayName("참여자별 지출내역을 하나씩 삭제할 수 있다.")
+	@Test
+	void deleteByMemberExpense_Success() {
+		//given
+		MemberExpense memberExpense = mock(MemberExpense.class);
+		doNothing().when(memberExpenseRepository).delete(memberExpense);
+
+		//when
+		memberExpenseDeleter.deleteByMemberExpense(memberExpense);
+
+		//then
+		verify(memberExpenseRepository, times(1)).delete(any());
+	}
+
+	@DisplayName("참여자별 지출내역이 여러개 들어올때 한번에 삭제할 수 있다.")
+	@Test
+	void deleteByMemberExpenses_Success() {
+		//given
+		MemberExpense memberExpense1 = mock(MemberExpense.class);
+		MemberExpense memberExpense2 = mock(MemberExpense.class);
+		List<MemberExpense> memberExpenses = List.of(memberExpense1, memberExpense2);
+		doNothing().when(memberExpenseRepository).deleteAll(memberExpenses);
+
+		//when
+		memberExpenseDeleter.deleteByMemberExpenses(memberExpenses);
+
+		//then
+		verify(memberExpenseRepository, times(1)).deleteAll(any());
+	}
 }

--- a/src/test/java/com/dnd/moddo/domain/memberExpense/service/implementation/MemberExpenseDeleterTest.java
+++ b/src/test/java/com/dnd/moddo/domain/memberExpense/service/implementation/MemberExpenseDeleterTest.java
@@ -1,0 +1,17 @@
+package com.dnd.moddo.domain.memberExpense.service.implementation;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.dnd.moddo.domain.memberExpense.repotiroy.MemberExpenseRepository;
+
+@ExtendWith(MockitoExtension.class)
+class MemberExpenseDeleterTest {
+	@Mock
+	private MemberExpenseRepository memberExpenseRepository;
+	@InjectMocks
+	private MemberExpenseDeleter memberExpenseDeleter;
+
+}

--- a/src/test/java/com/dnd/moddo/domain/memberExpense/service/implementation/MemberExpenseReaderTest.java
+++ b/src/test/java/com/dnd/moddo/domain/memberExpense/service/implementation/MemberExpenseReaderTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.*;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -55,5 +56,38 @@ class MemberExpenseReaderTest {
 		assertThat(result.get(0).getGroupMember()).isEqualTo(mockGroupMember);
 
 		verify(memberExpenseRepository, times(1)).findByExpenseId(eq(expenseId));
+	}
+
+	@DisplayName("참여자별 지출내역을 참여자id, 지출내역 map으로 변환하여 조회할 수 있다.")
+	@Test
+	public void findAllByGroupMemberIds_Success() {
+		//given
+		GroupMember groupMember1 = mock(GroupMember.class);
+		GroupMember groupMember2 = mock(GroupMember.class);
+		when(groupMember1.getId()).thenReturn(1L);
+		when(groupMember2.getId()).thenReturn(2L);
+
+		List<MemberExpense> mockExpenses = List.of(
+			new MemberExpense(1L, groupMember1, 1000L),
+			new MemberExpense(2L, groupMember1, 2000L),
+			new MemberExpense(1L, groupMember2, 3000L)
+		);
+
+		List<Long> groupMemberIds = List.of(1L, 2L);
+
+		when(memberExpenseRepository.findAllByGroupMemberIds(groupMemberIds)).thenReturn(mockExpenses);
+
+		//when
+		Map<Long, List<MemberExpense>> result = memberExpenseReader.findAllByGroupMemberIds(groupMemberIds);
+
+		//then
+		assertThat(result).isNotNull();
+		assertThat(result.size()).isEqualTo(2);
+
+		assertThat(result.get(1L).get(0).getAmount()).isEqualTo(1000L);
+		assertThat(result.get(1L).get(1).getAmount()).isEqualTo(2000L);
+		assertThat(result.get(2L).get(0).getAmount()).isEqualTo(3000L);
+
+		verify(memberExpenseRepository, times(1)).findAllByGroupMemberIds(groupMemberIds);
 	}
 }

--- a/src/test/java/com/dnd/moddo/domain/memberExpense/service/implementation/MemberExpenseReaderTest.java
+++ b/src/test/java/com/dnd/moddo/domain/memberExpense/service/implementation/MemberExpenseReaderTest.java
@@ -3,7 +3,6 @@ package com.dnd.moddo.domain.memberExpense.service.implementation;
 import static org.assertj.core.api.AssertionsForClassTypes.*;
 import static org.mockito.Mockito.*;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -15,7 +14,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import com.dnd.moddo.domain.expense.entity.Expense;
 import com.dnd.moddo.domain.group.entity.Group;
 import com.dnd.moddo.domain.groupMember.entity.GroupMember;
 import com.dnd.moddo.domain.groupMember.entity.type.ExpenseRole;
@@ -30,17 +28,13 @@ class MemberExpenseReaderTest {
 	private MemberExpenseReader memberExpenseReader;
 
 	private Group mockGroup;
-	private Expense mockExpense;
 	private GroupMember mockGroupMember;
 
 	@BeforeEach
 	void setUp() {
 		mockGroup = new Group("group 1", 1L, "1234", LocalDateTime.now(), LocalDateTime.now().plusMinutes(1),
 			"은행", "계좌");
-		mockExpense = new Expense(mockGroup, 20000L, "투썸플레이스", LocalDate.of(2025, 02, 03));
-
 		mockGroupMember = new GroupMember("박완숙", mockGroup, ExpenseRole.MANAGER);
-
 	}
 
 	@DisplayName("지출내역이 존재하면 해당 지출내역의 참여자별 지출내역을 조회에 성공한다.")
@@ -48,7 +42,7 @@ class MemberExpenseReaderTest {
 	void findAllByExpenseIdS() {
 		//given
 		Long expenseId = 1L;
-		List<MemberExpense> expectedMemberExpense = List.of(new MemberExpense(mockExpense, mockGroupMember, 15000L));
+		List<MemberExpense> expectedMemberExpense = List.of(new MemberExpense(expenseId, mockGroupMember, 15000L));
 
 		when(memberExpenseRepository.findByExpenseId(eq(expenseId))).thenReturn(expectedMemberExpense);
 

--- a/src/test/java/com/dnd/moddo/domain/memberExpense/service/implementation/MemberExpenseReaderTest.java
+++ b/src/test/java/com/dnd/moddo/domain/memberExpense/service/implementation/MemberExpenseReaderTest.java
@@ -37,7 +37,7 @@ class MemberExpenseReaderTest {
 	void setUp() {
 		mockGroup = new Group("group 1", 1L, "1234", LocalDateTime.now(), LocalDateTime.now().plusMinutes(1),
 			"은행", "계좌");
-		mockExpense = new Expense(mockGroup, 20000L, "투썸플레이스", 0, LocalDate.of(2025, 02, 03));
+		mockExpense = new Expense(mockGroup, 20000L, "투썸플레이스", LocalDate.of(2025, 02, 03));
 
 		mockGroupMember = new GroupMember("박완숙", mockGroup, ExpenseRole.MANAGER);
 

--- a/src/test/java/com/dnd/moddo/domain/memberExpense/service/implementation/MemberExpenseUpdaterTest.java
+++ b/src/test/java/com/dnd/moddo/domain/memberExpense/service/implementation/MemberExpenseUpdaterTest.java
@@ -1,0 +1,43 @@
+package com.dnd.moddo.domain.memberExpense.service.implementation;
+
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.dnd.moddo.domain.groupMember.entity.GroupMember;
+import com.dnd.moddo.domain.memberExpense.dto.request.MemberExpenseRequest;
+import com.dnd.moddo.domain.memberExpense.entity.MemberExpense;
+import com.dnd.moddo.domain.memberExpense.repotiroy.MemberExpenseRepository;
+
+@ExtendWith(MockitoExtension.class)
+class MemberExpenseUpdaterTest {
+	@Mock
+	private MemberExpenseRepository memberExpenseRepository;
+	@InjectMocks
+	private MemberExpenseUpdater memberExpenseUpdater;
+
+	@DisplayName("지출 내역 수정 시 유효한 값이 들어오면 지출 내역 수정에 성공한다.")
+	@Test
+	void update_Success() {
+		//given
+		Long expectedAmount = 5000L;
+
+		MemberExpense memberExpense = new MemberExpense(1L, mock(GroupMember.class), 15000L);
+		MemberExpenseRequest request = new MemberExpenseRequest(1L, expectedAmount);
+
+		when(memberExpenseRepository.save(memberExpense)).thenReturn(any(MemberExpense.class));
+		//when
+		memberExpenseUpdater.update(memberExpense, request);
+
+		//then
+		assertThat(memberExpense.getAmount()).isEqualTo(expectedAmount);
+		verify(memberExpenseRepository, times(1)).save(memberExpense);
+	}
+
+}


### PR DESCRIPTION
### #️⃣연관된 이슈
#44 , #45 

### 🔀반영 브랜치
feat/#45-find-groupmember-settlement -> develop

### 🔧변경 사항
- 참여자별 정산 내역 조회에 대한 기능을 추가하였습니다.
  - 참여자별 정산 내역 조회 정렬을 역할, 입금여부, 이름순으로 정렬하도록 하였습니다.  
- 지출내역 수정 시 참여자 지출내역도 함께 수정하도록 추가하였습니다
  - 참여자 지출내역 업데이트 요청에서 기존 참여자 지출내역에 없는 `groupMemberId`가 추가되면 새로운 참여자 지출내역을 생성합니다.
  - 기존 참여자 지출내역에는 있는 `groupMemberId`이지만 참여자 지출내역 요청에 없으면  기존 참여자 지출내역을 삭제합니다.
  - 기존 참여자 지출내역에도 있고 요청에도 존재하는 `groupMemberId`이면 `amount`만 업데이트하여 저장합니다.
- MemberExpese와 Expense의 단방향 객체 참조방식에서 식별자기반 참조 방식으로 변경하였습니다.
- Expense에 있던 `order` 필드를 삭제하고 관련 기능 및 DTO파일들을 삭제하였습니다.
- `ExpenseReader`의 `findAllByGroupId`를 순서 정렬방식에서 날짜 오름찿순으로 정렬하도록 변경하였습니다.


 ### 💬리뷰 요구사항(선택)
1. 참여자별 정산내역 조회를 `findSettlementByGroupId`와 같이 `settlement`라는 단어를 활용했는데 단어가 어색한거 같아서 다른 좋은 단어가 있을까요? 뭔가 정산내역이라고 해서 찾아보니 이정도 밖에 없더라구요.