### PR TITLE
단건 모임 조회 기능

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.security:spring-security-core'
 
+    implementation 'com.amazonaws:aws-java-sdk-s3:1.12.638'
+
     implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'

--- a/src/main/java/com/dnd/moddo/domain/group/controller/GroupController.java
+++ b/src/main/java/com/dnd/moddo/domain/group/controller/GroupController.java
@@ -2,8 +2,10 @@ package com.dnd.moddo.domain.group.controller;
 
 import com.dnd.moddo.domain.group.dto.request.GroupAccountRequest;
 import com.dnd.moddo.domain.group.dto.request.GroupRequest;
+import com.dnd.moddo.domain.group.dto.response.GroupDetailResponse;
 import com.dnd.moddo.domain.group.dto.response.GroupResponse;
 import com.dnd.moddo.domain.group.service.CommandGroupService;
+import com.dnd.moddo.domain.group.service.QueryGroupService;
 import com.dnd.moddo.global.jwt.dto.GroupTokenResponse;
 import com.dnd.moddo.global.jwt.service.JwtService;
 import jakarta.servlet.http.HttpServletRequest;
@@ -17,6 +19,7 @@ import org.springframework.web.bind.annotation.*;
 public class GroupController {
     private final CommandGroupService commandGroupService;
     private final JwtService jwtService;
+    private final QueryGroupService queryGroupService;
 
     @PostMapping
     public ResponseEntity<GroupTokenResponse> saveGroup(HttpServletRequest request, @RequestBody GroupRequest groupRequest) {
@@ -35,8 +38,17 @@ public class GroupController {
         Long groupId = jwtService.getGroupId(groupToken);
 
         GroupResponse response = commandGroupService.updateAccount(groupAccountRequest, userId, groupId);
-
         return ResponseEntity.ok(response);
     }
 
+    @GetMapping
+    public ResponseEntity<GroupDetailResponse> getGroup(
+            HttpServletRequest request,
+            @RequestParam("groupToken") String groupToken) {
+        Long userId = jwtService.getUserId(request);
+        Long groupId = jwtService.getGroupId(groupToken);
+
+        GroupDetailResponse response = queryGroupService.findOne(groupId, userId);
+        return ResponseEntity.ok(response);
+    }
 }

--- a/src/main/java/com/dnd/moddo/domain/group/dto/response/GroupDetailResponse.java
+++ b/src/main/java/com/dnd/moddo/domain/group/dto/response/GroupDetailResponse.java
@@ -1,0 +1,25 @@
+package com.dnd.moddo.domain.group.dto.response;
+
+import com.dnd.moddo.domain.group.entity.Group;
+import com.dnd.moddo.domain.groupMember.dto.response.GroupMemberResponse;
+import com.dnd.moddo.domain.groupMember.entity.GroupMember;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public record GroupDetailResponse(
+        Long id,
+        String groupName,
+        List<GroupMemberResponse> members
+) {
+    public static GroupDetailResponse of(Group group, List<GroupMember> members) {
+        List<GroupMemberResponse> memberResponses = members.stream()
+                .map(GroupMemberResponse::of)
+                .collect(Collectors.toList());
+        return new GroupDetailResponse(
+                group.getId(),
+                group.getName(),
+                memberResponses
+        );
+    }
+}

--- a/src/main/java/com/dnd/moddo/domain/group/repository/GroupRepository.java
+++ b/src/main/java/com/dnd/moddo/domain/group/repository/GroupRepository.java
@@ -4,8 +4,6 @@ import com.dnd.moddo.domain.group.entity.Group;
 import com.dnd.moddo.domain.group.exception.GroupNotFoundException;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
-
 public interface GroupRepository extends JpaRepository<Group, Long> {
     default Group getById(Long groupId) {
         return findById(groupId).orElseThrow(() -> new GroupNotFoundException(groupId));

--- a/src/main/java/com/dnd/moddo/domain/group/repository/GroupRepository.java
+++ b/src/main/java/com/dnd/moddo/domain/group/repository/GroupRepository.java
@@ -4,8 +4,10 @@ import com.dnd.moddo.domain.group.entity.Group;
 import com.dnd.moddo.domain.group.exception.GroupNotFoundException;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface GroupRepository extends JpaRepository<Group, Long> {
-    default Group getById(Long id) {
-        return findById(id).orElseThrow(() -> new GroupNotFoundException(id));
+    default Group getById(Long groupId) {
+        return findById(groupId).orElseThrow(() -> new GroupNotFoundException(groupId));
     }
 }

--- a/src/main/java/com/dnd/moddo/domain/group/service/QueryGroupService.java
+++ b/src/main/java/com/dnd/moddo/domain/group/service/QueryGroupService.java
@@ -1,0 +1,27 @@
+package com.dnd.moddo.domain.group.service;
+
+import com.dnd.moddo.domain.group.dto.response.GroupDetailResponse;
+import com.dnd.moddo.domain.group.entity.Group;
+import com.dnd.moddo.domain.group.service.implementation.GroupReader;
+import com.dnd.moddo.domain.group.service.implementation.GroupValidator;
+import com.dnd.moddo.domain.groupMember.dto.response.GroupMemberResponse;
+import com.dnd.moddo.domain.groupMember.entity.GroupMember;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class QueryGroupService {
+    private final GroupReader groupReader;
+    private final GroupValidator groupValidator;
+
+    public GroupDetailResponse findOne(Long groupId, Long userId) {
+        Group group = groupReader.read(groupId);
+        groupValidator.checkGroupAuthor(group, userId);
+        List<GroupMember> members = groupReader.findByGroup(group);
+        return GroupDetailResponse.of(group, members);
+    }
+}

--- a/src/main/java/com/dnd/moddo/domain/group/service/QueryGroupService.java
+++ b/src/main/java/com/dnd/moddo/domain/group/service/QueryGroupService.java
@@ -19,7 +19,7 @@ public class QueryGroupService {
     public GroupDetailResponse findOne(Long groupId, Long userId) {
         Group group = groupReader.read(groupId);
         groupValidator.checkGroupAuthor(group, userId);
-        List<GroupMember> members = groupReader.findByGroup(group);
+        List<GroupMember> members = groupReader.findByGroup(groupId);
         return GroupDetailResponse.of(group, members);
     }
 }

--- a/src/main/java/com/dnd/moddo/domain/group/service/QueryGroupService.java
+++ b/src/main/java/com/dnd/moddo/domain/group/service/QueryGroupService.java
@@ -4,13 +4,11 @@ import com.dnd.moddo.domain.group.dto.response.GroupDetailResponse;
 import com.dnd.moddo.domain.group.entity.Group;
 import com.dnd.moddo.domain.group.service.implementation.GroupReader;
 import com.dnd.moddo.domain.group.service.implementation.GroupValidator;
-import com.dnd.moddo.domain.groupMember.dto.response.GroupMemberResponse;
 import com.dnd.moddo.domain.groupMember.entity.GroupMember;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/dnd/moddo/domain/group/service/implementation/GroupReader.java
+++ b/src/main/java/com/dnd/moddo/domain/group/service/implementation/GroupReader.java
@@ -19,7 +19,7 @@ public class GroupReader {
         return groupRepository.getById(groupId);
     }
 
-    public List<GroupMember> findByGroup(Group group) {
-        return groupMemberRepository.findByGroupId(group.getId());
+    public List<GroupMember> findByGroup(Long groupId) {
+        return groupMemberRepository.findByGroupId(groupId);
     }
 }

--- a/src/main/java/com/dnd/moddo/domain/group/service/implementation/GroupReader.java
+++ b/src/main/java/com/dnd/moddo/domain/group/service/implementation/GroupReader.java
@@ -2,16 +2,24 @@ package com.dnd.moddo.domain.group.service.implementation;
 
 import com.dnd.moddo.domain.group.entity.Group;
 import com.dnd.moddo.domain.group.repository.GroupRepository;
+import com.dnd.moddo.domain.groupMember.entity.GroupMember;
+import com.dnd.moddo.domain.groupMember.repository.GroupMemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class GroupReader {
     private final GroupRepository groupRepository;
+    private final GroupMemberRepository groupMemberRepository;
 
     public Group read(Long groupId) {
         return groupRepository.getById(groupId);
     }
 
+    public List<GroupMember> findByGroup(Group group) {
+        return groupMemberRepository.findByGroupId(group.getId());
+    }
 }

--- a/src/test/java/com/dnd/moddo/domain/group/service/QueryGroupServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/group/service/QueryGroupServiceTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.*;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
 
 @ExtendWith(MockitoExtension.class)
 class QueryGroupServiceTest {
@@ -41,6 +42,8 @@ class QueryGroupServiceTest {
         // Given
         group = new Group("groupName", 1L, "password", null, null, null, null);
         groupMember = new GroupMember(1L, "김완숙", 1, group, false, ExpenseRole.MANAGER);
+
+        setField(group, "id", 1L);
     }
 
     @Test
@@ -52,7 +55,7 @@ class QueryGroupServiceTest {
         doNothing().when(groupValidator).checkGroupAuthor(group, 1L);
 
         // When
-        GroupDetailResponse response = queryGroupService.findOne(1L, 1L);
+        GroupDetailResponse response = queryGroupService.findOne(group.getId(), 1L);
 
         // Then
         assertThat(response).isNotNull();

--- a/src/test/java/com/dnd/moddo/domain/group/service/QueryGroupServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/group/service/QueryGroupServiceTest.java
@@ -48,7 +48,7 @@ class QueryGroupServiceTest {
     void testFindOne_Success() {
         // Given
         when(groupReader.read(anyLong())).thenReturn(group);
-        when(groupReader.findByGroup(group)).thenReturn(List.of(groupMember));
+        when(groupReader.findByGroup(group.getId())).thenReturn(List.of(groupMember));
         doNothing().when(groupValidator).checkGroupAuthor(group, 1L);
 
         // When
@@ -62,7 +62,7 @@ class QueryGroupServiceTest {
         assertThat(response.members().get(0).name()).isEqualTo(groupMember.getName());
 
         verify(groupReader, times(1)).read(1L);
-        verify(groupReader, times(1)).findByGroup(group);
+        verify(groupReader, times(1)).findByGroup(group.getId());
         verify(groupValidator, times(1)).checkGroupAuthor(group, 1L);
     }
 

--- a/src/test/java/com/dnd/moddo/domain/group/service/QueryGroupServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/group/service/QueryGroupServiceTest.java
@@ -1,0 +1,98 @@
+package com.dnd.moddo.domain.group.service;
+
+import com.dnd.moddo.domain.group.dto.response.GroupDetailResponse;
+import com.dnd.moddo.domain.group.entity.Group;
+import com.dnd.moddo.domain.groupMember.entity.GroupMember;
+import com.dnd.moddo.domain.groupMember.entity.type.ExpenseRole;
+import com.dnd.moddo.domain.group.service.implementation.GroupReader;
+import com.dnd.moddo.domain.group.service.implementation.GroupValidator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class QueryGroupServiceTest {
+
+    @InjectMocks
+    private QueryGroupService queryGroupService;
+
+    @Mock
+    private GroupReader groupReader;
+
+    @Mock
+    private GroupValidator groupValidator;
+
+    private Group group;
+    private GroupMember groupMember;
+
+    @BeforeEach
+    void setUp() {
+        // Given
+        group = new Group("groupName", 1L, "password", null, null, null, null);
+        groupMember = new GroupMember(1L, "김완숙", 1, group, false, ExpenseRole.MANAGER);
+    }
+
+    @Test
+    @DisplayName("그룹 상세 정보를 정상적으로 조회할 수 있다.")
+    void testFindOne_Success() {
+        // Given
+        when(groupReader.read(anyLong())).thenReturn(group);
+        when(groupReader.findByGroup(group)).thenReturn(List.of(groupMember));
+        doNothing().when(groupValidator).checkGroupAuthor(group, 1L);
+
+        // When
+        GroupDetailResponse response = queryGroupService.findOne(1L, 1L);
+
+        // Then
+        assertThat(response).isNotNull();
+        assertThat(response.id()).isEqualTo(group.getId());
+        assertThat(response.groupName()).isEqualTo(group.getName());
+        assertThat(response.members()).hasSize(1);
+        assertThat(response.members().get(0).name()).isEqualTo(groupMember.getName());
+
+        verify(groupReader, times(1)).read(1L);
+        verify(groupReader, times(1)).findByGroup(group);
+        verify(groupValidator, times(1)).checkGroupAuthor(group, 1L);
+    }
+
+    @Test
+    @DisplayName("그룹 작성자가 아닐 경우 예외가 발생한다.")
+    void testFindOne_Failure_WhenNotGroupAuthor() {
+        // Given
+        when(groupReader.read(anyLong())).thenReturn(group);
+        doThrow(new RuntimeException("Not an author")).when(groupValidator).checkGroupAuthor(group, 2L);
+
+        // When & Then
+        assertThatThrownBy(() -> queryGroupService.findOne(1L, 2L))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("Not an author");
+
+        verify(groupReader, times(1)).read(1L);
+        verify(groupValidator, times(1)).checkGroupAuthor(group, 2L);
+    }
+
+    @Test
+    @DisplayName("그룹을 찾을 수 없을 경우 예외가 발생한다.")
+    void testFindOne_Failure_WhenGroupNotFound() {
+        // Given
+        when(groupReader.read(anyLong())).thenThrow(new RuntimeException("Group not found"));
+
+        // When & Then
+        assertThatThrownBy(() -> queryGroupService.findOne(1L, 1L))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("Group not found");
+
+        verify(groupReader, times(1)).read(1L);
+    }
+}

--- a/src/test/java/com/dnd/moddo/domain/group/service/implementation/GroupReaderTest.java
+++ b/src/test/java/com/dnd/moddo/domain/group/service/implementation/GroupReaderTest.java
@@ -2,12 +2,16 @@ package com.dnd.moddo.domain.group.service.implementation;
 
 import com.dnd.moddo.domain.group.entity.Group;
 import com.dnd.moddo.domain.group.repository.GroupRepository;
+import com.dnd.moddo.domain.groupMember.entity.GroupMember;
+import com.dnd.moddo.domain.groupMember.repository.GroupMemberRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -18,6 +22,9 @@ class GroupReaderTest {
 
     @Mock
     private GroupRepository groupRepository;
+
+    @Mock
+    private GroupMemberRepository groupMemberRepository;
 
     @InjectMocks
     private GroupReader groupReader;
@@ -37,5 +44,23 @@ class GroupReaderTest {
         // Then
         assertThat(result).isNotNull();
         verify(groupRepository, times(1)).getById(groupId);
+    }
+
+    @Test
+    @DisplayName("그룹을 통해 그룹 멤버 목록을 정상적으로 조회할 수 있다.")
+    void findByGroup_Success() {
+        // Given
+        Group mockGroup = mock(Group.class);
+        when(mockGroup.getId()).thenReturn(1L);
+        List<GroupMember> mockMembers = List.of(mock(GroupMember.class), mock(GroupMember.class));
+
+        when(groupMemberRepository.findByGroupId(anyLong())).thenReturn(mockMembers);
+
+        // When
+        List<GroupMember> result = groupReader.findByGroup(mockGroup);
+
+        // Then
+        assertThat(result).hasSize(2);
+        verify(groupMemberRepository, times(1)).findByGroupId(mockGroup.getId());
     }
 }

--- a/src/test/java/com/dnd/moddo/domain/group/service/implementation/GroupReaderTest.java
+++ b/src/test/java/com/dnd/moddo/domain/group/service/implementation/GroupReaderTest.java
@@ -57,7 +57,7 @@ class GroupReaderTest {
         when(groupMemberRepository.findByGroupId(anyLong())).thenReturn(mockMembers);
 
         // When
-        List<GroupMember> result = groupReader.findByGroup(mockGroup);
+        List<GroupMember> result = groupReader.findByGroup(mockGroup.getId());
 
         // Then
         assertThat(result).hasSize(2);


### PR DESCRIPTION
### #️⃣연관된 이슈
#52 

### 🔀반영 브랜치
feat/#52-get-group -> develop

### 🔧변경 사항
- GroupDetailResponse에서 Group 엔티티와 GroupMember 리스트를 받아, GroupMemberResponse 리스트로 변환하여 사용했습니다.

### 💬리뷰 요구사항(선택)
