### PR TITLE
이미지 저장 기능

### DIFF
--- a/src/main/java/com/dnd/moddo/domain/image/controller/ImageController.java
+++ b/src/main/java/com/dnd/moddo/domain/image/controller/ImageController.java
@@ -1,0 +1,29 @@
+package com.dnd.moddo.domain.image.controller;
+
+import com.dnd.moddo.domain.image.dto.ImageResponse;
+import com.dnd.moddo.domain.image.dto.TempImageResponse;
+import com.dnd.moddo.domain.image.service.CommandImageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/api/v1/images")
+@RequiredArgsConstructor
+public class ImageController {
+    private final CommandImageService commandImageService;
+
+    @PostMapping("/temp")
+    public ResponseEntity<TempImageResponse> saveTempImage(@RequestParam("file") MultipartFile file) {
+        TempImageResponse uniqueKey = commandImageService.uploadTempImage(file);
+        return ResponseEntity.ok(uniqueKey);
+    }
+
+    @PostMapping("/update")
+    public ResponseEntity<ImageResponse> updateImage(@RequestParam("uniqueKey") String uniqueKey) {
+        ImageResponse finalImagePath = commandImageService.finalizeImage(uniqueKey);
+        return ResponseEntity.ok(finalImagePath);
+    }
+}
+

--- a/src/main/java/com/dnd/moddo/domain/image/controller/ImageController.java
+++ b/src/main/java/com/dnd/moddo/domain/image/controller/ImageController.java
@@ -22,7 +22,7 @@ public class ImageController {
 
     @PostMapping("/update")
     public ResponseEntity<ImageResponse> updateImage(@RequestParam("uniqueKey") String uniqueKey) {
-        ImageResponse finalImagePath = commandImageService.finalizeImage(uniqueKey);
+        ImageResponse finalImagePath = commandImageService.uploadFinalImage(uniqueKey);
         return ResponseEntity.ok(finalImagePath);
     }
 }

--- a/src/main/java/com/dnd/moddo/domain/image/dto/ImageResponse.java
+++ b/src/main/java/com/dnd/moddo/domain/image/dto/ImageResponse.java
@@ -1,0 +1,9 @@
+package com.dnd.moddo.domain.image.dto;
+
+public record ImageResponse(
+        String path
+) {
+    public static ImageResponse from(String path) {
+        return new ImageResponse(path);
+    }
+}

--- a/src/main/java/com/dnd/moddo/domain/image/dto/TempImageResponse.java
+++ b/src/main/java/com/dnd/moddo/domain/image/dto/TempImageResponse.java
@@ -1,0 +1,9 @@
+package com.dnd.moddo.domain.image.dto;
+
+public record TempImageResponse(
+        String uniqueKey
+) {
+    public static TempImageResponse from(String uniqueKey) {
+        return new TempImageResponse(uniqueKey);
+    }
+}

--- a/src/main/java/com/dnd/moddo/domain/image/entity/Image.java
+++ b/src/main/java/com/dnd/moddo/domain/image/entity/Image.java
@@ -1,0 +1,29 @@
+package com.dnd.moddo.domain.image.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.*;
+
+@Entity
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Image {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String uniqueKey;
+
+    private String path;
+
+    @Builder
+    public Image(String uniqueKey, String path) {
+        this.uniqueKey = uniqueKey;
+        this.path = path;
+    }
+
+}

--- a/src/main/java/com/dnd/moddo/domain/image/exception/InvalidUniqueKeyException.java
+++ b/src/main/java/com/dnd/moddo/domain/image/exception/InvalidUniqueKeyException.java
@@ -1,0 +1,8 @@
+package com.dnd.moddo.domain.image.exception;
+
+import com.dnd.moddo.global.exception.ModdoException;
+import org.springframework.http.HttpStatus;
+
+public class InvalidUniqueKeyException extends ModdoException {
+    public InvalidUniqueKeyException() { super(HttpStatus.UNAUTHORIZED, "유효하지 않는 uniqueKey입니다.");}
+}

--- a/src/main/java/com/dnd/moddo/domain/image/exception/S3SaveException.java
+++ b/src/main/java/com/dnd/moddo/domain/image/exception/S3SaveException.java
@@ -1,0 +1,10 @@
+package com.dnd.moddo.domain.image.exception;
+
+import com.dnd.moddo.global.exception.ModdoException;
+import org.springframework.http.HttpStatus;
+
+public class S3SaveException extends ModdoException {
+    public S3SaveException() {
+        super(HttpStatus.INTERNAL_SERVER_ERROR, "사진을 저장하던 중 에러가 발생했습니다.");
+    }
+}

--- a/src/main/java/com/dnd/moddo/domain/image/repository/ImageRepository.java
+++ b/src/main/java/com/dnd/moddo/domain/image/repository/ImageRepository.java
@@ -1,0 +1,10 @@
+package com.dnd.moddo.domain.image.repository;
+
+import com.dnd.moddo.domain.image.entity.Image;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ImageRepository extends JpaRepository<Image, Long> {
+    Optional<Image> findByUniqueKey(String uniqueKey);
+}

--- a/src/main/java/com/dnd/moddo/domain/image/service/CommandImageService.java
+++ b/src/main/java/com/dnd/moddo/domain/image/service/CommandImageService.java
@@ -29,7 +29,7 @@ public class CommandImageService {
         return TempImageResponse.from(uniqueKey);
     }
 
-    public ImageResponse finalizeImage(String uniqueKey) {
+    public ImageResponse uploadFinalImage(String uniqueKey) {
         Image tempImage = imageRepository.findByUniqueKey(uniqueKey)
                 .orElseThrow(() -> new InvalidUniqueKeyException());
 

--- a/src/main/java/com/dnd/moddo/domain/image/service/CommandImageService.java
+++ b/src/main/java/com/dnd/moddo/domain/image/service/CommandImageService.java
@@ -33,7 +33,7 @@ public class CommandImageService {
         Image tempImage = imageRepository.findByUniqueKey(uniqueKey)
                 .orElseThrow(() -> new InvalidUniqueKeyException());
 
-        String finalImagePath = imageUpdater.moveToPermanentStorage(tempImage.getPath());
+        String finalImagePath = imageUpdater.moveToBucket(tempImage.getPath());
         imageRepository.delete(tempImage);
 
         return ImageResponse.from(finalImagePath);

--- a/src/main/java/com/dnd/moddo/domain/image/service/CommandImageService.java
+++ b/src/main/java/com/dnd/moddo/domain/image/service/CommandImageService.java
@@ -1,0 +1,41 @@
+package com.dnd.moddo.domain.image.service;
+
+import com.dnd.moddo.domain.image.dto.ImageResponse;
+import com.dnd.moddo.domain.image.dto.TempImageResponse;
+import com.dnd.moddo.domain.image.entity.Image;
+import com.dnd.moddo.domain.image.exception.InvalidUniqueKeyException;
+import com.dnd.moddo.domain.image.repository.ImageRepository;
+import com.dnd.moddo.domain.image.service.implementation.ImageCreator;
+import com.dnd.moddo.domain.image.service.implementation.ImageUpdater;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class CommandImageService {
+    private final ImageCreator imageCreator;
+    private final ImageUpdater imageUpdater;
+    private final ImageRepository imageRepository;
+
+    public TempImageResponse uploadTempImage(MultipartFile file) {
+        String uniqueKey = UUID.randomUUID().toString();
+        String tempPath = imageCreator.createTempImage(file);
+
+        imageRepository.save(new Image(uniqueKey, tempPath));
+
+        return TempImageResponse.from(uniqueKey);
+    }
+
+    public ImageResponse finalizeImage(String uniqueKey) {
+        Image tempImage = imageRepository.findByUniqueKey(uniqueKey)
+                .orElseThrow(() -> new InvalidUniqueKeyException());
+
+        String finalImagePath = imageUpdater.moveToPermanentStorage(tempImage.getPath());
+        imageRepository.delete(tempImage);
+
+        return ImageResponse.from(finalImagePath);
+    }
+}

--- a/src/main/java/com/dnd/moddo/domain/image/service/implementation/ImageCreator.java
+++ b/src/main/java/com/dnd/moddo/domain/image/service/implementation/ImageCreator.java
@@ -1,0 +1,51 @@
+package com.dnd.moddo.domain.image.service.implementation;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.dnd.moddo.domain.image.exception.S3SaveException;
+import com.dnd.moddo.global.config.S3Bucket;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ImageCreator {
+    private final S3Bucket s3Bucket;
+    private final AmazonS3 amazonS3;
+
+    public String createTempImage(MultipartFile multipartFile) {
+        String fileName = createFileName(multipartFile, "temp");
+
+        try {
+            PutObjectRequest request = new PutObjectRequest(
+                    s3Bucket.getS3Bucket(),
+                    fileName,
+                    multipartFile.getInputStream(),
+                    getMetadata(multipartFile)
+            );
+            amazonS3.putObject(request);
+        } catch (IOException e) {
+            throw new S3SaveException();
+        }
+
+        return fileName;
+    }
+
+    private String createFileName(MultipartFile multipartFile, String folderPath) {
+        return folderPath + "/" + UUID.randomUUID() + "-" + multipartFile.getOriginalFilename();
+    }
+
+    private ObjectMetadata getMetadata(MultipartFile file) {
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentLength(file.getSize());
+        metadata.setContentType(file.getContentType());
+        return metadata;
+    }
+}

--- a/src/main/java/com/dnd/moddo/domain/image/service/implementation/ImageUpdater.java
+++ b/src/main/java/com/dnd/moddo/domain/image/service/implementation/ImageUpdater.java
@@ -1,0 +1,24 @@
+package com.dnd.moddo.domain.image.service.implementation;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.dnd.moddo.global.config.S3Bucket;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ImageUpdater {
+    private final S3Bucket s3Bucket;
+    private final AmazonS3 amazonS3;
+
+    public String moveToPermanentStorage(String tempPath) {
+        String finalPath = tempPath.replace("temp/", "permanent/");
+
+        amazonS3.copyObject(s3Bucket.getS3Bucket(), tempPath, s3Bucket.getS3Bucket(), finalPath);
+        amazonS3.deleteObject(s3Bucket.getS3Bucket(), tempPath);
+
+        return s3Bucket.getS3Url() + finalPath;
+    }
+}

--- a/src/main/java/com/dnd/moddo/domain/image/service/implementation/ImageUpdater.java
+++ b/src/main/java/com/dnd/moddo/domain/image/service/implementation/ImageUpdater.java
@@ -13,7 +13,7 @@ public class ImageUpdater {
     private final S3Bucket s3Bucket;
     private final AmazonS3 amazonS3;
 
-    public String moveToPermanentStorage(String tempPath) {
+    public String moveToBucket(String tempPath) {
         String finalPath = tempPath.replace("temp/", "permanent/");
 
         amazonS3.copyObject(s3Bucket.getS3Bucket(), tempPath, s3Bucket.getS3Bucket(), finalPath);

--- a/src/main/java/com/dnd/moddo/global/config/S3Bucket.java
+++ b/src/main/java/com/dnd/moddo/global/config/S3Bucket.java
@@ -1,0 +1,12 @@
+package com.dnd.moddo.global.config;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+@Getter
+@Configuration
+public class S3Bucket {
+    @Value("${aws.s3.bucket}")
+    private String s3Bucket;
+}

--- a/src/main/java/com/dnd/moddo/global/config/S3Bucket.java
+++ b/src/main/java/com/dnd/moddo/global/config/S3Bucket.java
@@ -9,4 +9,8 @@ import org.springframework.context.annotation.Configuration;
 public class S3Bucket {
     @Value("${aws.s3.bucket}")
     private String s3Bucket;
+
+    public String getS3Url() {
+        return "https://" + s3Bucket + ".s3.amazonaws.com/";
+    }
 }

--- a/src/main/java/com/dnd/moddo/global/config/S3Config.java
+++ b/src/main/java/com/dnd/moddo/global/config/S3Config.java
@@ -1,0 +1,30 @@
+package com.dnd.moddo.global.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+class S3Config {
+
+    @Value("${aws.s3.access-key}")
+    private String accessKey;
+
+    @Value("${aws.s3.secret-key}")
+    private String secretKey;
+
+    @Bean
+    AmazonS3 amazonS3Client() {
+        return AmazonS3ClientBuilder.standard()
+                .withCredentials(
+                        new AWSStaticCredentialsProvider(new BasicAWSCredentials(accessKey, secretKey))
+                )
+                .withRegion(Regions.AP_NORTHEAST_2)
+                .build();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   config:
-    import: classpath:config/application-jwt.yml
+    import: classpath:config/application-jwt.yml, classpath:config/application-s3.yml
   jpa:
     hibernate:
       ddl-auto: create

--- a/src/test/java/com/dnd/moddo/domain/image/entity/ImageTest.java
+++ b/src/test/java/com/dnd/moddo/domain/image/entity/ImageTest.java
@@ -1,0 +1,28 @@
+package com.dnd.moddo.domain.image.entity;
+
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ImageTest {
+
+    private Image image;
+
+    @BeforeEach
+    void setUp() {
+        // given
+        image = new Image("uniqueKey", "/images/path/to/image.jpg");
+    }
+
+    @Test
+    void createImage() {
+        // when
+        String uniqueKey = image.getUniqueKey();
+        String path = image.getPath();
+
+        // then
+        assertThat(uniqueKey).isEqualTo("uniqueKey");
+        assertThat(path).isEqualTo("/images/path/to/image.jpg");
+    }
+}

--- a/src/test/java/com/dnd/moddo/domain/image/service/CommandImageServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/image/service/CommandImageServiceTest.java
@@ -1,9 +1,11 @@
 package com.dnd.moddo.domain.image.service;
 
 import com.dnd.moddo.domain.image.dto.ImageResponse;
+import com.dnd.moddo.domain.image.dto.TempImageResponse;
 import com.dnd.moddo.domain.image.entity.Image;
 import com.dnd.moddo.domain.image.exception.InvalidUniqueKeyException;
 import com.dnd.moddo.domain.image.repository.ImageRepository;
+import com.dnd.moddo.domain.image.service.implementation.ImageCreator;
 import com.dnd.moddo.domain.image.service.implementation.ImageUpdater;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -11,19 +13,28 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.Optional;
+import java.util.UUID;
 
-import static org.mockito.Mockito.*;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
 
 class CommandImageServiceTest {
+
+    @Mock
+    private ImageCreator imageCreator;
 
     @Mock
     private ImageUpdater imageUpdater;
 
     @Mock
     private ImageRepository imageRepository;
+
+    @Mock
+    private MultipartFile multipartFile;
 
     @InjectMocks
     private CommandImageService commandImageService;
@@ -34,8 +45,26 @@ class CommandImageServiceTest {
     }
 
     @Test
+    @DisplayName("임시 이미지 업로드 성공 시 uniqueKey 반환")
+    void uploadTempImage_Success() {
+        // given
+        String uniqueKey = UUID.randomUUID().toString();
+        String tempPath = "temp/tempImage.jpg";
+
+        when(imageCreator.createTempImage(multipartFile)).thenReturn(tempPath);
+
+        // when
+        TempImageResponse response = commandImageService.uploadTempImage(multipartFile);
+
+        // then
+        assertThat(response.uniqueKey()).isNotNull();
+        verify(imageCreator, times(1)).createTempImage(multipartFile);
+        verify(imageRepository, times(1)).save(any(Image.class));
+    }
+
+    @Test
     @DisplayName("이미지 최종화 성공 시 이미지 경로 반환")
-    void finalizeImage_Success() {
+    void uploadFinalImage_Success() {
         // given
         String uniqueKey = "uniqueKey";
         String tempPath = "temp/tempImage.jpg";
@@ -53,7 +82,6 @@ class CommandImageServiceTest {
         verify(imageRepository, times(1)).delete(tempImage);
     }
 
-
     @Test
     @DisplayName("잘못된 uniqueKey로 이미지 최종화 시 InvalidUniqueKeyException 발생")
     void finalizeImage_InvalidKey() {
@@ -63,10 +91,9 @@ class CommandImageServiceTest {
         when(imageRepository.findByUniqueKey(uniqueKey)).thenReturn(Optional.empty());
 
         // when & then
-        try {
-            commandImageService.uploadFinalImage(uniqueKey);
-        } catch (InvalidUniqueKeyException e) {
-            assertThat(e).isInstanceOf(InvalidUniqueKeyException.class);
-        }
+        assertThrows(InvalidUniqueKeyException.class, () -> commandImageService.uploadFinalImage(uniqueKey));
+
+        verify(imageRepository, times(1)).findByUniqueKey(uniqueKey);
+        verifyNoMoreInteractions(imageUpdater, imageRepository);
     }
 }

--- a/src/test/java/com/dnd/moddo/domain/image/service/CommandImageServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/image/service/CommandImageServiceTest.java
@@ -1,0 +1,72 @@
+package com.dnd.moddo.domain.image.service;
+
+import com.dnd.moddo.domain.image.dto.ImageResponse;
+import com.dnd.moddo.domain.image.entity.Image;
+import com.dnd.moddo.domain.image.exception.InvalidUniqueKeyException;
+import com.dnd.moddo.domain.image.repository.ImageRepository;
+import com.dnd.moddo.domain.image.service.implementation.ImageUpdater;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Optional;
+
+import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CommandImageServiceTest {
+
+    @Mock
+    private ImageUpdater imageUpdater;
+
+    @Mock
+    private ImageRepository imageRepository;
+
+    @InjectMocks
+    private CommandImageService commandImageService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    @DisplayName("이미지 최종화 성공 시 이미지 경로 반환")
+    void finalizeImage_Success() {
+        // given
+        String uniqueKey = "uniqueKey";
+        String tempPath = "temp/tempImage.jpg";
+        String finalPath = "permanent/finalImage.jpg";
+        Image tempImage = new Image(uniqueKey, tempPath);
+
+        when(imageRepository.findByUniqueKey(uniqueKey)).thenReturn(Optional.of(tempImage));
+        when(imageUpdater.moveToBucket(tempPath)).thenReturn(finalPath);
+
+        // when
+        ImageResponse response = commandImageService.finalizeImage(uniqueKey);
+
+        // then
+        assertThat(response.path()).isEqualTo(finalPath);
+        verify(imageRepository, times(1)).delete(tempImage);
+    }
+
+
+    @Test
+    @DisplayName("잘못된 uniqueKey로 이미지 최종화 시 InvalidUniqueKeyException 발생")
+    void finalizeImage_InvalidKey() {
+        // given
+        String uniqueKey = "invalidKey";
+
+        when(imageRepository.findByUniqueKey(uniqueKey)).thenReturn(Optional.empty());
+
+        // when & then
+        try {
+            commandImageService.finalizeImage(uniqueKey);
+        } catch (InvalidUniqueKeyException e) {
+            assertThat(e).isInstanceOf(InvalidUniqueKeyException.class);
+        }
+    }
+}

--- a/src/test/java/com/dnd/moddo/domain/image/service/CommandImageServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/image/service/CommandImageServiceTest.java
@@ -46,7 +46,7 @@ class CommandImageServiceTest {
         when(imageUpdater.moveToBucket(tempPath)).thenReturn(finalPath);
 
         // when
-        ImageResponse response = commandImageService.finalizeImage(uniqueKey);
+        ImageResponse response = commandImageService.uploadFinalImage(uniqueKey);
 
         // then
         assertThat(response.path()).isEqualTo(finalPath);
@@ -64,7 +64,7 @@ class CommandImageServiceTest {
 
         // when & then
         try {
-            commandImageService.finalizeImage(uniqueKey);
+            commandImageService.uploadFinalImage(uniqueKey);
         } catch (InvalidUniqueKeyException e) {
             assertThat(e).isInstanceOf(InvalidUniqueKeyException.class);
         }

--- a/src/test/java/com/dnd/moddo/domain/image/service/implementation/ImageCreatorTest.java
+++ b/src/test/java/com/dnd/moddo/domain/image/service/implementation/ImageCreatorTest.java
@@ -1,0 +1,82 @@
+package com.dnd.moddo.domain.image.service.implementation;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.dnd.moddo.domain.image.exception.S3SaveException;
+import com.dnd.moddo.global.config.S3Bucket;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+class ImageCreatorTest {
+
+    @Mock
+    private S3Bucket s3Bucket;
+
+    @Mock
+    private AmazonS3 amazonS3;
+
+    @Mock
+    private MultipartFile multipartFile;
+
+    @InjectMocks
+    private ImageCreator imageCreator;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    @DisplayName("파일 업로드 성공 시 파일 이름을 반환한다.")
+    void createTempImage() throws IOException {
+        // given
+        String originalFileName = "testImage.jpg";
+        InputStream inputStream = mock(InputStream.class);
+        ObjectMetadata metadata = new ObjectMetadata();
+
+        metadata.setContentLength(100L);
+        metadata.setContentType("image/jpeg");
+
+        when(multipartFile.getOriginalFilename()).thenReturn(originalFileName);
+        when(multipartFile.getInputStream()).thenReturn(inputStream);
+        when(multipartFile.getSize()).thenReturn(100L);
+        when(multipartFile.getContentType()).thenReturn("image/jpeg");
+        when(s3Bucket.getS3Bucket()).thenReturn("test-bucket");
+
+        // when
+        String fileName = imageCreator.createTempImage(multipartFile);
+
+        // then
+        verify(amazonS3).putObject(any(PutObjectRequest.class));
+        assertThat(fileName).startsWith("temp/");
+        assertThat(fileName).endsWith(originalFileName);
+    }
+
+    @Test
+    @DisplayName("IOException 발생 시 S3SaveException을 던진다.")
+    void createTempImage_WhenIOExceptionOccurs() throws IOException {
+        // given
+        when(multipartFile.getOriginalFilename()).thenReturn("testImage.jpg");
+        when(multipartFile.getInputStream()).thenThrow(new IOException("S3 upload failed"));
+
+        // when & then
+        try {
+            imageCreator.createTempImage(multipartFile);
+        } catch (S3SaveException e) {
+            assertThat(e).isInstanceOf(S3SaveException.class);
+        }
+    }
+}

--- a/src/test/java/com/dnd/moddo/domain/image/service/implementation/ImageUpdaterTest.java
+++ b/src/test/java/com/dnd/moddo/domain/image/service/implementation/ImageUpdaterTest.java
@@ -1,0 +1,66 @@
+package com.dnd.moddo.domain.image.service.implementation;
+
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.dnd.moddo.global.config.S3Bucket;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ImageUpdaterTest {
+
+    @Mock
+    private S3Bucket s3Bucket;
+
+    @Mock
+    private AmazonS3 amazonS3;
+
+    @InjectMocks
+    private ImageUpdater imageUpdater;
+
+    private String tempPath;
+    private String permanentPath;
+
+    @BeforeEach
+    void setUp() {
+        tempPath = "temp/testImage.jpg";
+        permanentPath = "permanent/testImage.jpg";
+
+        lenient().when(s3Bucket.getS3Bucket()).thenReturn("test-bucket");
+        lenient().when(s3Bucket.getS3Url()).thenReturn("https://s3.amazonaws.com/test-bucket/");
+    }
+
+    @DisplayName("파일을 영구 저장소로 이동시키면 올바른 URL을 반환한다.")
+    @Test
+    void moveToBucket() {
+        // when
+        String resultUrl = imageUpdater.moveToBucket(tempPath);
+
+        // then
+        verify(amazonS3, times(1)).copyObject(eq("test-bucket"), eq(tempPath), eq("test-bucket"), eq(permanentPath));
+        verify(amazonS3, times(1)).deleteObject(eq("test-bucket"), eq(tempPath));
+        assertThat(resultUrl).isEqualTo("https://s3.amazonaws.com/test-bucket/permanent/testImage.jpg");
+    }
+
+    @DisplayName("파일 경로가 잘못되었을 경우 S3에서 객체 이동을 시도하고 예외가 발생한다.")
+    @Test
+    void moveToBucket_exception() {
+        // given
+        doThrow(new RuntimeException("S3 copy failed")).when(amazonS3).copyObject(any(), any(), any(), any());
+
+        // when & then
+        try {
+            imageUpdater.moveToBucket(tempPath);
+        } catch (RuntimeException e) {
+            assertThat(e).hasMessageContaining("S3 copy failed");
+        }
+    }
+}

--- a/src/test/java/com/dnd/moddo/domain/user/entity/UserTest.java
+++ b/src/test/java/com/dnd/moddo/domain/user/entity/UserTest.java
@@ -7,9 +7,11 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 
@@ -18,8 +20,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @ExtendWith(SpringExtension.class)
-@ContextConfiguration(classes = ModdoApplication.class)
-@SpringBootTest
+@DataJpaTest
 public class UserTest {
 
     @Autowired

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -23,3 +23,11 @@ jwt:
   secret-key: secretKeysecretKeysecretKeysecretKeysecretKeysecretKey
   access-expiration: 1
   refresh-expiration: 1
+
+aws:
+  s3:
+    bucket: test-bucket
+    access-key: accessKeyaccessKeyaccessKeyaccessKeyaccessKeyaccessKey
+    secret-key: secretKeysecretKeysecretKeysecretKeysecretKeysecretKey
+  region:
+    static: ap-northeast-2


### PR DESCRIPTION
### #️⃣연관된 이슈
#56 

### 🔀반영 브랜치
feat/#56-save-image -> develop

### 🔧변경 사항
- `ImageController`에서 임시저장을 `saveTempImage`, S3에 이미지 업데이트를 `updateImage`로 구현했습니다.
- `CommandImageService`에서 이미지 임시저장을 `uploadTempImage`, 최종 저장을 `finalizeImage`로 구현했습니다.
- `ImageUpdater`에서 임시저장 -> 최종저장을 위해 `moveToBucket`를 구현했습니다.
- AWS S3 연동을 위한 S3Config를 추가했습니다.

### 💬리뷰 요구사항(선택)
- update와 create로 통일하기엔 어색한 느낌이 있어 `uploadTempImage`, `finalizeImage`, `moveToBucket`로 설정했는데 혹시 더 나은 이름이 있을까요?
