### PR TITLE
전체 지출내역 조회 기능 추가

### DIFF
--- a/src/main/java/com/dnd/moddo/domain/expense/controller/ExpenseController.java
+++ b/src/main/java/com/dnd/moddo/domain/expense/controller/ExpenseController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.dnd.moddo.domain.expense.dto.request.ExpenseRequest;
 import com.dnd.moddo.domain.expense.dto.request.ExpensesRequest;
+import com.dnd.moddo.domain.expense.dto.response.ExpenseDetailsResponse;
 import com.dnd.moddo.domain.expense.dto.response.ExpenseResponse;
 import com.dnd.moddo.domain.expense.dto.response.ExpensesResponse;
 import com.dnd.moddo.domain.expense.service.CommandExpenseService;
@@ -51,6 +52,14 @@ public class ExpenseController {
 		ExpenseResponse response = queryExpenseService.findOneByExpenseId(expenseId);
 		return ResponseEntity.ok(response);
 
+	}
+
+	@GetMapping("/details")
+	public ResponseEntity<ExpenseDetailsResponse> getExpenseDetailsByGroupId(
+		@RequestParam("groupToken") String groupToken) {
+		Long groupId = jwtService.getGroupId(groupToken);
+		ExpenseDetailsResponse response = queryExpenseService.findAllExpenseDetailsByGroupId(groupId);
+		return ResponseEntity.ok(response);
 	}
 
 	@PutMapping("/{expenseId}")

--- a/src/main/java/com/dnd/moddo/domain/expense/dto/response/ExpenseDetailResponse.java
+++ b/src/main/java/com/dnd/moddo/domain/expense/dto/response/ExpenseDetailResponse.java
@@ -1,0 +1,28 @@
+package com.dnd.moddo.domain.expense.dto.response;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import com.dnd.moddo.domain.expense.entity.Expense;
+
+import lombok.Builder;
+
+@Builder
+public record ExpenseDetailResponse(
+	Long id,
+	LocalDate date,
+	String content,
+	Long totalAmount,
+	List<String> groupMembers
+) {
+	public static ExpenseDetailResponse of(Expense expense, List<String> groupMembers) {
+		return ExpenseDetailResponse.builder()
+			.id(expense.getId())
+			.date(expense.getDate())
+			.content(expense.getContent())
+			.totalAmount(expense.getAmount())
+			.groupMembers(groupMembers)
+			.build();
+	}
+
+}

--- a/src/main/java/com/dnd/moddo/domain/expense/dto/response/ExpenseDetailsResponse.java
+++ b/src/main/java/com/dnd/moddo/domain/expense/dto/response/ExpenseDetailsResponse.java
@@ -1,0 +1,8 @@
+package com.dnd.moddo.domain.expense.dto.response;
+
+import java.util.List;
+
+public record ExpenseDetailsResponse(
+	List<ExpenseDetailResponse> expenses
+) {
+}

--- a/src/main/java/com/dnd/moddo/domain/expense/service/CommandExpenseService.java
+++ b/src/main/java/com/dnd/moddo/domain/expense/service/CommandExpenseService.java
@@ -51,6 +51,7 @@ public class CommandExpenseService {
 
 	public void delete(Long expenseId) {
 		//TODO 삭제하는 사람이 정산자인지 확인 로직 필요
+		commandMemberExpenseService.deleteAllByExpenseId(expenseId);
 		expenseDeleter.delete(expenseId);
 	}
 }

--- a/src/main/java/com/dnd/moddo/domain/expense/service/CommandExpenseService.java
+++ b/src/main/java/com/dnd/moddo/domain/expense/service/CommandExpenseService.java
@@ -11,6 +11,7 @@ import com.dnd.moddo.domain.expense.dto.response.ExpensesResponse;
 import com.dnd.moddo.domain.expense.entity.Expense;
 import com.dnd.moddo.domain.expense.service.implementation.ExpenseCreator;
 import com.dnd.moddo.domain.expense.service.implementation.ExpenseDeleter;
+import com.dnd.moddo.domain.expense.service.implementation.ExpenseReader;
 import com.dnd.moddo.domain.expense.service.implementation.ExpenseUpdater;
 import com.dnd.moddo.domain.memberExpense.dto.response.MemberExpenseResponse;
 import com.dnd.moddo.domain.memberExpense.service.CommandMemberExpenseService;
@@ -20,6 +21,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @Service
 public class CommandExpenseService {
+	private final ExpenseReader expenseReader;
 	private final ExpenseCreator expenseCreator;
 	private final ExpenseUpdater expenseUpdater;
 	private final ExpenseDeleter expenseDeleter;
@@ -50,8 +52,9 @@ public class CommandExpenseService {
 	}
 
 	public void delete(Long expenseId) {
+		Expense expense = expenseReader.findByExpenseId(expenseId);
 		//TODO 삭제하는 사람이 정산자인지 확인 로직 필요
 		commandMemberExpenseService.deleteAllByExpenseId(expenseId);
-		expenseDeleter.delete(expenseId);
+		expenseDeleter.delete(expense);
 	}
 }

--- a/src/main/java/com/dnd/moddo/domain/expense/service/QueryExpenseService.java
+++ b/src/main/java/com/dnd/moddo/domain/expense/service/QueryExpenseService.java
@@ -11,7 +11,6 @@ import com.dnd.moddo.domain.expense.dto.response.ExpenseResponse;
 import com.dnd.moddo.domain.expense.dto.response.ExpensesResponse;
 import com.dnd.moddo.domain.expense.entity.Expense;
 import com.dnd.moddo.domain.expense.service.implementation.ExpenseReader;
-import com.dnd.moddo.domain.groupMember.service.QueryGroupMemberService;
 import com.dnd.moddo.domain.memberExpense.service.QueryMemberExpenseService;
 
 import lombok.RequiredArgsConstructor;
@@ -21,7 +20,6 @@ import lombok.RequiredArgsConstructor;
 public class QueryExpenseService {
 	private final ExpenseReader expenseReader;
 	private final QueryMemberExpenseService queryMemberExpenseService;
-	private final QueryGroupMemberService queryGroupMemberService;
 
 	public ExpensesResponse findAllByGroupId(Long groupId) {
 		List<Expense> expenses = expenseReader.findAllByGroupId(groupId);

--- a/src/main/java/com/dnd/moddo/domain/expense/service/QueryExpenseService.java
+++ b/src/main/java/com/dnd/moddo/domain/expense/service/QueryExpenseService.java
@@ -1,13 +1,17 @@
 package com.dnd.moddo.domain.expense.service;
 
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.stereotype.Service;
 
+import com.dnd.moddo.domain.expense.dto.response.ExpenseDetailResponse;
+import com.dnd.moddo.domain.expense.dto.response.ExpenseDetailsResponse;
 import com.dnd.moddo.domain.expense.dto.response.ExpenseResponse;
 import com.dnd.moddo.domain.expense.dto.response.ExpensesResponse;
 import com.dnd.moddo.domain.expense.entity.Expense;
 import com.dnd.moddo.domain.expense.service.implementation.ExpenseReader;
+import com.dnd.moddo.domain.groupMember.service.QueryGroupMemberService;
 import com.dnd.moddo.domain.memberExpense.service.QueryMemberExpenseService;
 
 import lombok.RequiredArgsConstructor;
@@ -17,6 +21,7 @@ import lombok.RequiredArgsConstructor;
 public class QueryExpenseService {
 	private final ExpenseReader expenseReader;
 	private final QueryMemberExpenseService queryMemberExpenseService;
+	private final QueryGroupMemberService queryGroupMemberService;
 
 	public ExpensesResponse findAllByGroupId(Long groupId) {
 		List<Expense> expenses = expenseReader.findAllByGroupId(groupId);
@@ -33,4 +38,19 @@ public class QueryExpenseService {
 		return ExpenseResponse.of(expense);
 	}
 
+	public ExpenseDetailsResponse findAllExpenseDetailsByGroupId(Long groupId) {
+
+		List<Expense> expenses = expenseReader.findAllByGroupId(groupId);
+		List<Long> expenseIds = expenses.stream().map(Expense::getId).toList();
+
+		Map<Long, List<String>> memberNameByExpenseId = queryMemberExpenseService.getMemberNamesByExpenseIds(
+			expenseIds);
+
+		return new ExpenseDetailsResponse(
+			expenses.stream()
+				.map(expense ->
+					ExpenseDetailResponse.of(expense, memberNameByExpenseId.get(expense.getId()))
+				).toList()
+		);
+	}
 }

--- a/src/main/java/com/dnd/moddo/domain/expense/service/QueryExpenseService.java
+++ b/src/main/java/com/dnd/moddo/domain/expense/service/QueryExpenseService.java
@@ -32,7 +32,7 @@ public class QueryExpenseService {
 	}
 
 	public ExpenseResponse findOneByExpenseId(Long expenseId) {
-		Expense expense = expenseReader.findOneByExpenseId(expenseId);
+		Expense expense = expenseReader.findByExpenseId(expenseId);
 		return ExpenseResponse.of(expense);
 	}
 

--- a/src/main/java/com/dnd/moddo/domain/expense/service/implementation/ExpenseDeleter.java
+++ b/src/main/java/com/dnd/moddo/domain/expense/service/implementation/ExpenseDeleter.java
@@ -15,8 +15,7 @@ public class ExpenseDeleter {
 
 	private final ExpenseRepository expenseRepository;
 
-	public void delete(Long expenseId) {
-		Expense expense = expenseRepository.getById(expenseId);
+	public void delete(Expense expense) {
 		expenseRepository.delete(expense);
 	}
 }

--- a/src/main/java/com/dnd/moddo/domain/expense/service/implementation/ExpenseReader.java
+++ b/src/main/java/com/dnd/moddo/domain/expense/service/implementation/ExpenseReader.java
@@ -20,7 +20,7 @@ public class ExpenseReader {
 		return expenseRepository.findByGroupIdOrderByDateAsc(groupId);
 	}
 
-	public Expense findOneByExpenseId(Long expenseId) {
+	public Expense findByExpenseId(Long expenseId) {
 		return expenseRepository.getById(expenseId);
 	}
 

--- a/src/main/java/com/dnd/moddo/domain/groupMember/dto/response/GroupMemberExpenseResponse.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/dto/response/GroupMemberExpenseResponse.java
@@ -14,15 +14,18 @@ public record GroupMemberExpenseResponse(
 	Long id,
 	ExpenseRole role,
 	String name,
+	Long totalAmount,
 	boolean isPaid,
 	LocalDateTime paidAt,
 	List<MemberExpenseDetailResponse> expenses
 ) {
-	public static GroupMemberExpenseResponse of(GroupMember groupMember, List<MemberExpenseDetailResponse> expenses) {
+	public static GroupMemberExpenseResponse of(GroupMember groupMember, Long totalAmount,
+		List<MemberExpenseDetailResponse> expenses) {
 		return GroupMemberExpenseResponse.builder()
 			.id(groupMember.getId())
 			.role(groupMember.getRole())
 			.name(groupMember.getName())
+			.totalAmount(totalAmount)
 			.isPaid(groupMember.isPaid())
 			.paidAt(groupMember.getPaidAt())
 			.expenses(expenses).build();

--- a/src/main/java/com/dnd/moddo/domain/groupMember/service/QueryGroupMemberService.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/service/QueryGroupMemberService.java
@@ -4,11 +4,9 @@ import java.util.List;
 
 import org.springframework.stereotype.Service;
 
-import com.dnd.moddo.domain.expense.service.implementation.ExpenseReader;
 import com.dnd.moddo.domain.groupMember.dto.response.GroupMembersResponse;
 import com.dnd.moddo.domain.groupMember.entity.GroupMember;
 import com.dnd.moddo.domain.groupMember.service.implementation.GroupMemberReader;
-import com.dnd.moddo.domain.memberExpense.service.implementation.MemberExpenseReader;
 
 import lombok.RequiredArgsConstructor;
 
@@ -16,12 +14,9 @@ import lombok.RequiredArgsConstructor;
 @Service
 public class QueryGroupMemberService {
 	private final GroupMemberReader groupMemberReader;
-	private final MemberExpenseReader memberExpenseReader;
-	private final ExpenseReader expenseReader;
 
 	public GroupMembersResponse findAll(Long groupId) {
 		List<GroupMember> members = groupMemberReader.findAllByGroupId(groupId);
 		return GroupMembersResponse.of(members);
 	}
-
 }

--- a/src/main/java/com/dnd/moddo/domain/memberExpense/repotiroy/MemberExpenseRepository.java
+++ b/src/main/java/com/dnd/moddo/domain/memberExpense/repotiroy/MemberExpenseRepository.java
@@ -12,6 +12,9 @@ public interface MemberExpenseRepository extends JpaRepository<MemberExpense, Lo
 	//@EntityGraph(attributePaths = {"groupMember"})
 	List<MemberExpense> findByExpenseId(Long expenseId);
 
+	@Query("select me from MemberExpense me where me.expenseId in :expenseIds")
+	List<MemberExpense> findAllByExpenseIds(@Param("expenseIds") List<Long> expenseIds);
+
 	@Query("select me from MemberExpense me where me.groupMember.id in :groupMemberIds")
 	List<MemberExpense> findAllByGroupMemberIds(@Param("groupMemberIds") List<Long> groupMemberIds);
 }

--- a/src/main/java/com/dnd/moddo/domain/memberExpense/service/CommandMemberExpenseService.java
+++ b/src/main/java/com/dnd/moddo/domain/memberExpense/service/CommandMemberExpenseService.java
@@ -90,4 +90,7 @@ public class CommandMemberExpenseService {
 		memberExpenseDeleter.deleteByMemberExpenses(deleteMemberExpenses);
 	}
 
+	public void deleteAllByExpenseId(Long expenseId) {
+		memberExpenseDeleter.deleteAllByExpenseId(expenseId);
+	}
 }

--- a/src/main/java/com/dnd/moddo/domain/memberExpense/service/QueryMemberExpenseService.java
+++ b/src/main/java/com/dnd/moddo/domain/memberExpense/service/QueryMemberExpenseService.java
@@ -100,4 +100,17 @@ public class QueryMemberExpenseService {
 			.filter(Objects::nonNull)
 			.toList();
 	}
+
+	public Map<Long, List<String>> getMemberNamesByExpenseIds(List<Long> expenseIds) {
+		List<MemberExpense> memberExpenses = memberExpenseReader.findAllByExpenseIds(expenseIds);
+
+		return memberExpenses.stream()
+			.collect(Collectors.groupingBy(
+				MemberExpense::getExpenseId,
+				Collectors.mapping(
+					me -> me.getGroupMember().getName(),
+					Collectors.toList()
+				)
+			));
+	}
 }

--- a/src/main/java/com/dnd/moddo/domain/memberExpense/service/QueryMemberExpenseService.java
+++ b/src/main/java/com/dnd/moddo/domain/memberExpense/service/QueryMemberExpenseService.java
@@ -42,7 +42,10 @@ public class QueryMemberExpenseService {
 		Map<Long, GroupMember> groupMemberById = convertGroupMembersToMap(groupMembers);
 
 		Map<Long, List<MemberExpense>> memberExpenses = memberExpenseReader.findAllByGroupMemberIds(
-			groupMemberById.keySet().stream().toList());
+				groupMemberById.keySet().stream().toList())
+			.stream()
+			.collect(Collectors.groupingBy(me -> me.getGroupMember().getId()));
+		;
 
 		List<Expense> expenses = expenseReader.findAllByGroupId(groupId);
 

--- a/src/main/java/com/dnd/moddo/domain/memberExpense/service/QueryMemberExpenseService.java
+++ b/src/main/java/com/dnd/moddo/domain/memberExpense/service/QueryMemberExpenseService.java
@@ -1,5 +1,6 @@
 package com.dnd.moddo.domain.memberExpense.service;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -48,8 +49,6 @@ public class QueryMemberExpenseService {
 		List<GroupMemberExpenseResponse> responses = groupMemberById.keySet()
 			.stream()
 			.map(key -> {
-					if (memberExpenses.get(key) == null)
-						return null;
 					return findMemberExpenseDetailByGroupMember(groupMemberById.get(key), memberExpenses.get(key),
 						expenses);
 				}
@@ -68,20 +67,37 @@ public class QueryMemberExpenseService {
 			);
 	}
 
-	private GroupMemberExpenseResponse findMemberExpenseDetailByGroupMember(GroupMember groupMember,
+	private GroupMemberExpenseResponse findMemberExpenseDetailByGroupMember(
+		GroupMember groupMember, List<MemberExpense> memberExpenses, List<Expense> expenses) {
+
+		if (memberExpenses == null) {
+			return GroupMemberExpenseResponse.of(groupMember, 0L, new ArrayList<>());
+		}
+
+		List<MemberExpenseDetailResponse> memberExpenseDetails = mapToMemberExpenseDetails(memberExpenses, expenses);
+		Long totalAmount = calculateTotalAmount(memberExpenses);
+
+		return GroupMemberExpenseResponse.of(groupMember, totalAmount, memberExpenseDetails);
+	}
+
+	private Long calculateTotalAmount(List<MemberExpense> memberExpenses) {
+		return memberExpenses.stream()
+			.mapToLong(MemberExpense::getAmount)
+			.sum();
+	}
+
+	private List<MemberExpenseDetailResponse> mapToMemberExpenseDetails(
 		List<MemberExpense> memberExpenses, List<Expense> expenses) {
 
 		Map<Long, MemberExpense> expenseToMemberExpenseMap = memberExpenses.stream()
 			.collect(Collectors.toMap(MemberExpense::getExpenseId, me -> me));
 
-		List<MemberExpenseDetailResponse> memberExpenseDetails = expenses.stream()
+		return expenses.stream()
 			.map(expense -> {
 				MemberExpense memberExpense = expenseToMemberExpenseMap.get(expense.getId());
 				return (memberExpense != null) ? MemberExpenseDetailResponse.of(expense, memberExpense) : null;
 			})
 			.filter(Objects::nonNull)
 			.toList();
-
-		return GroupMemberExpenseResponse.of(groupMember, memberExpenseDetails);
 	}
 }

--- a/src/main/java/com/dnd/moddo/domain/memberExpense/service/implementation/MemberExpenseReader.java
+++ b/src/main/java/com/dnd/moddo/domain/memberExpense/service/implementation/MemberExpenseReader.java
@@ -1,8 +1,6 @@
 package com.dnd.moddo.domain.memberExpense.service.implementation;
 
 import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,10 +20,8 @@ public class MemberExpenseReader {
 		return memberExpenseRepository.findByExpenseId(expenseId);
 	}
 
-	public Map<Long, List<MemberExpense>> findAllByGroupMemberIds(List<Long> groupMemberIds) {
-		return memberExpenseRepository.findAllByGroupMemberIds(groupMemberIds)
-			.stream()
-			.collect(Collectors.groupingBy(me -> me.getGroupMember().getId()));
+	public List<MemberExpense> findAllByGroupMemberIds(List<Long> groupMemberIds) {
+		return memberExpenseRepository.findAllByGroupMemberIds(groupMemberIds);
 	}
 
 	public List<MemberExpense> findAllByExpenseIds(List<Long> expenseIds) {

--- a/src/main/java/com/dnd/moddo/domain/memberExpense/service/implementation/MemberExpenseReader.java
+++ b/src/main/java/com/dnd/moddo/domain/memberExpense/service/implementation/MemberExpenseReader.java
@@ -27,4 +27,8 @@ public class MemberExpenseReader {
 			.stream()
 			.collect(Collectors.groupingBy(me -> me.getGroupMember().getId()));
 	}
+
+	public List<MemberExpense> findAllByExpenseIds(List<Long> expenseIds) {
+		return memberExpenseRepository.findAllByExpenseIds(expenseIds);
+	}
 }

--- a/src/test/java/com/dnd/moddo/domain/expense/service/CommandExpenseServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/expense/service/CommandExpenseServiceTest.java
@@ -1,6 +1,6 @@
 package com.dnd.moddo.domain.expense.service;
 
-import static org.assertj.core.api.AssertionsForClassTypes.*;
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import java.time.LocalDate;
@@ -24,6 +24,7 @@ import com.dnd.moddo.domain.expense.entity.Expense;
 import com.dnd.moddo.domain.expense.exception.ExpenseNotFoundException;
 import com.dnd.moddo.domain.expense.service.implementation.ExpenseCreator;
 import com.dnd.moddo.domain.expense.service.implementation.ExpenseDeleter;
+import com.dnd.moddo.domain.expense.service.implementation.ExpenseReader;
 import com.dnd.moddo.domain.expense.service.implementation.ExpenseUpdater;
 import com.dnd.moddo.domain.group.entity.Group;
 import com.dnd.moddo.domain.memberExpense.dto.response.MemberExpenseResponse;
@@ -32,6 +33,8 @@ import com.dnd.moddo.domain.memberExpense.service.CommandMemberExpenseService;
 @ExtendWith(MockitoExtension.class)
 class CommandExpenseServiceTest {
 
+	@Mock
+	private ExpenseReader expenseReader;
 	@Mock
 	private ExpenseCreator expenseCreator;
 	@Mock
@@ -75,7 +78,7 @@ class CommandExpenseServiceTest {
 
 		// Then
 		assertThat(response).isNotNull();
-		assertThat(response.expenses().size()).isEqualTo(2);
+		assertThat(response.expenses()).hasSize(2);
 		assertThat(response.expenses().get(0).content()).isEqualTo("투썸플레이스");
 		assertThat(response.expenses().get(0).date()).isEqualTo("2025-02-03");
 	}
@@ -126,11 +129,18 @@ class CommandExpenseServiceTest {
 	void deleteSuccess() {
 		//given
 		Long expenseId = 1L;
-		doNothing().when(expenseDeleter).delete(eq(expenseId));
+		Expense mockExpense = mock(Expense.class);
+
+		when(expenseReader.findByExpenseId(eq(expenseId))).thenReturn(mockExpense);
+		doNothing().when(commandMemberExpenseService).deleteAllByExpenseId(eq(expenseId));
+		doNothing().when(expenseDeleter).delete(eq(mockExpense));
+
 		//when
 		commandExpenseService.delete(expenseId);
+
 		//then
-		verify(expenseDeleter, times(1)).delete(eq(expenseId));
+		verify(commandMemberExpenseService, times(1)).deleteAllByExpenseId(eq(expenseId));
+		verify(expenseDeleter, times(1)).delete(eq(mockExpense));
 	}
 
 	@DisplayName("삭제하려는 지출내역이 존재하지 않는다면 예외가 발생한다.")
@@ -138,7 +148,8 @@ class CommandExpenseServiceTest {
 	void deleteNotFound() {
 		//given
 		Long expenseId = 1L;
-		doThrow(new ExpenseNotFoundException(expenseId)).when(expenseDeleter).delete(eq(expenseId));
+		doThrow(new ExpenseNotFoundException(expenseId)).when(expenseReader).findByExpenseId(eq(expenseId));
+
 		//when & then
 		assertThatThrownBy(() -> {
 			commandExpenseService.delete(expenseId);

--- a/src/test/java/com/dnd/moddo/domain/expense/service/QueryExpenseServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/expense/service/QueryExpenseServiceTest.java
@@ -1,11 +1,12 @@
 package com.dnd.moddo.domain.expense.service;
 
-import static org.assertj.core.api.AssertionsForClassTypes.*;
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -15,6 +16,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.dnd.moddo.domain.expense.dto.response.ExpenseDetailsResponse;
 import com.dnd.moddo.domain.expense.dto.response.ExpenseResponse;
 import com.dnd.moddo.domain.expense.dto.response.ExpensesResponse;
 import com.dnd.moddo.domain.expense.entity.Expense;
@@ -114,4 +116,38 @@ class QueryExpenseServiceTest {
 		}).hasMessage("해당 지출내역을 찾을 수 없습니다. (Expense ID: " + expenseId + ")");
 	}
 
+	@DisplayName("모임 id가 유효하면 모임에 속한 전체 지출내역을 조회할 수 있다.")
+	@Test
+	void findAllExpenseDetailsByGroupId_Success() {
+		//given
+		Long groupId = 1L;
+		Expense expense1 = mock(Expense.class);
+		Expense expense2 = mock(Expense.class);
+		Expense expense3 = mock(Expense.class);
+
+		when(expense1.getId()).thenReturn(1L);
+		when(expense2.getId()).thenReturn(2L);
+		when(expense3.getId()).thenReturn(3L);
+
+		List<Expense> mockExpense = List.of(expense1, expense2, expense3);
+
+		when(expenseReader.findAllByGroupId(eq(groupId))).thenReturn(mockExpense);
+
+		when(queryMemberExpenseService.getMemberNamesByExpenseIds(eq(List.of(1L, 2L, 3L)))).thenReturn(Map.of(
+			1L, List.of("김모또", "김반숙"),
+			2L, List.of("김모또", "김반숙", "정에그"),
+			3L, List.of("김모또", "연노른자")
+		));
+
+		//when
+		ExpenseDetailsResponse response = queryExpenseService.findAllExpenseDetailsByGroupId(groupId);
+
+		//then
+		assertThat(response).isNotNull();
+		assertThat(response.expenses()).hasSize(3);
+		assertThat(response.expenses().get(0).groupMembers()).hasSize(2);
+
+		verify(expenseReader, times(1)).findAllByGroupId(eq(groupId));
+		verify(queryMemberExpenseService, times(1)).getMemberNamesByExpenseIds(any());
+	}
 }

--- a/src/test/java/com/dnd/moddo/domain/expense/service/QueryExpenseServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/expense/service/QueryExpenseServiceTest.java
@@ -88,7 +88,7 @@ class QueryExpenseServiceTest {
 		Long groupId = mockGroup.getId(), expenseId = 1L;
 		Expense mockExpense = new Expense(mockGroup, 20000L, "투썸플레이스", LocalDate.of(2025, 02, 03));
 
-		when(expenseReader.findOneByExpenseId(eq(expenseId))).thenReturn(mockExpense);
+		when(expenseReader.findByExpenseId(eq(expenseId))).thenReturn(mockExpense);
 
 		//when
 		ExpenseResponse response = queryExpenseService.findOneByExpenseId(expenseId);
@@ -98,7 +98,7 @@ class QueryExpenseServiceTest {
 		assertThat(response.amount()).isEqualTo(20000L);
 		assertThat(response.content()).isEqualTo("투썸플레이스");
 
-		verify(expenseReader, times(1)).findOneByExpenseId(eq(expenseId));
+		verify(expenseReader, times(1)).findByExpenseId(eq(expenseId));
 
 	}
 
@@ -108,7 +108,7 @@ class QueryExpenseServiceTest {
 		//given
 		Long expenseId = 1L;
 
-		when(expenseReader.findOneByExpenseId(eq(expenseId))).thenThrow(new ExpenseNotFoundException(expenseId));
+		when(expenseReader.findByExpenseId(eq(expenseId))).thenThrow(new ExpenseNotFoundException(expenseId));
 
 		//when & then
 		assertThatThrownBy(() -> {

--- a/src/test/java/com/dnd/moddo/domain/expense/service/implementation/ExpenseDeleterTest.java
+++ b/src/test/java/com/dnd/moddo/domain/expense/service/implementation/ExpenseDeleterTest.java
@@ -1,6 +1,5 @@
 package com.dnd.moddo.domain.expense.service.implementation;
 
-import static org.assertj.core.api.AssertionsForClassTypes.*;
 import static org.mockito.Mockito.*;
 
 import org.junit.jupiter.api.DisplayName;
@@ -11,7 +10,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.dnd.moddo.domain.expense.entity.Expense;
-import com.dnd.moddo.domain.expense.exception.ExpenseNotFoundException;
 import com.dnd.moddo.domain.expense.repository.ExpenseRepository;
 
 @ExtendWith(MockitoExtension.class)
@@ -28,29 +26,12 @@ class ExpenseDeleterTest {
 		Long expenseId = 1L;
 		Expense mockExpense = mock(Expense.class);
 
-		when(expenseRepository.getById(eq(expenseId))).thenReturn(mockExpense);
 		doNothing().when(expenseRepository).delete(eq(mockExpense));
 
 		//when
-		expenseDeleter.delete(expenseId);
+		expenseDeleter.delete(mockExpense);
 
 		//then
-		verify(expenseRepository, times(1)).getById(eq(expenseId));
 		verify(expenseRepository, times(1)).delete(eq(mockExpense));
-	}
-
-	@DisplayName("지출내역이 존재하지 않으면 해당 지출내역을 삭제시 예외가 발생한다.")
-	@Test
-	void deleteNotFoundExpense() {
-		//given
-		Long expenseId = 1L;
-		Expense mockExpense = mock(Expense.class);
-
-		doThrow(new ExpenseNotFoundException(expenseId)).when(expenseRepository).getById(eq(expenseId));
-
-		//when & then
-		assertThatThrownBy(() -> {
-			expenseDeleter.delete(expenseId);
-		}).hasMessage("해당 지출내역을 찾을 수 없습니다. (Expense ID: " + expenseId + ")");
 	}
 }

--- a/src/test/java/com/dnd/moddo/domain/expense/service/implementation/ExpenseReaderTest.java
+++ b/src/test/java/com/dnd/moddo/domain/expense/service/implementation/ExpenseReaderTest.java
@@ -61,14 +61,14 @@ class ExpenseReaderTest {
 
 	@DisplayName("지출내역이 존재하면 해당 지출내역을 조회할 수 있다.")
 	@Test
-	void findOneByExpenseIdSuccess() {
+	void findByExpenseIdSuccess() {
 		//given
 		Long expenseId = 1L;
 		Expense mockExpense = new Expense(mockGroup, 20000L, "투썸플레이스", LocalDate.of(2025, 02, 03));
 
 		when(expenseRepository.getById(eq(expenseId))).thenReturn(mockExpense);
 		//when
-		Expense result = expenseReader.findOneByExpenseId(expenseId);
+		Expense result = expenseReader.findByExpenseId(expenseId);
 		//then
 		assertThat(result.getContent()).isEqualTo("투썸플레이스");
 		assertThat(result.getAmount()).isEqualTo(20000);
@@ -79,14 +79,14 @@ class ExpenseReaderTest {
 
 	@DisplayName("지출내역이 존재하지 않으면 조회시 예외가 발생한다.")
 	@Test
-	void findOneByExpenseIdNotFoundExpense() {
+	void findByExpenseIdNotFoundExpense() {
 		//given
 		Long expenseId = 1L;
 
 		when(expenseRepository.getById(eq(expenseId))).thenThrow(new ExpenseNotFoundException(expenseId));
 		//when & then
 		assertThatThrownBy(() -> {
-			expenseReader.findOneByExpenseId(expenseId);
+			expenseReader.findByExpenseId(expenseId);
 		}).hasMessage("해당 지출내역을 찾을 수 없습니다. (Expense ID: " + expenseId + ")");
 	}
 }

--- a/src/test/java/com/dnd/moddo/domain/memberExpense/service/CommandMemberExpenseServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/memberExpense/service/CommandMemberExpenseServiceTest.java
@@ -1,6 +1,6 @@
 package com.dnd.moddo.domain.memberExpense.service;
 
-import static org.assertj.core.api.AssertionsForClassTypes.*;
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import java.util.List;
@@ -74,8 +74,8 @@ class CommandMemberExpenseServiceTest {
 		List<MemberExpenseResponse> responses = commandMemberExpenseService.create(expenseId, requests);
 
 		//then
-		assertThat(!responses.isEmpty()).isTrue();
-		assertThat(responses.size()).isEqualTo(2);
+		assertThat(responses).isNotEmpty();
+		assertThat(responses).hasSize(2);
 
 		verify(memberExpenseCreator, times(2)).create(eq(expenseId), any(GroupMember.class),
 			any(MemberExpenseRequest.class));
@@ -102,8 +102,10 @@ class CommandMemberExpenseServiceTest {
 		when(existingMemberExpense1.getGroupMember()).thenReturn(groupMember1);
 		when(existingMemberExpense2.getGroupMember()).thenReturn(groupMember2);
 
+		List<MemberExpense> exisitingMemberExpenses = List.of(existingMemberExpense1, existingMemberExpense2);
+
 		when(memberExpenseReader.findAllByExpenseId(eq(expenseId))).thenReturn(
-			List.of(existingMemberExpense1, existingMemberExpense2));
+			exisitingMemberExpenses);
 
 		doNothing().when(memberExpenseUpdater).update(existingMemberExpense1, request1);
 		doNothing().when(memberExpenseUpdater).update(existingMemberExpense2, request2);
@@ -112,8 +114,8 @@ class CommandMemberExpenseServiceTest {
 		List<MemberExpenseResponse> responses = commandMemberExpenseService.update(expenseId, requests);
 
 		//then
-		assertThat(responses.isEmpty()).isFalse();
-		assertThat(responses.size()).isEqualTo(2);
+		assertThat(responses).isNotEmpty();
+		assertThat(responses).hasSize(exisitingMemberExpenses.size());
 
 		verify(memberExpenseUpdater, times(2)).update(any(MemberExpense.class), any(MemberExpenseRequest.class));
 	}
@@ -157,8 +159,8 @@ class CommandMemberExpenseServiceTest {
 		List<MemberExpenseResponse> responses = commandMemberExpenseService.update(expenseId, requests);
 
 		//then
-		assertThat(responses.isEmpty()).isFalse();
-		assertThat(responses.size()).isEqualTo(3);
+		assertThat(responses).isNotEmpty();
+		assertThat(responses).hasSize(3);
 
 		verify(memberExpenseUpdater, times(2)).update(any(MemberExpense.class), any(MemberExpenseRequest.class));
 		verify(memberExpenseCreator, times(1)).create(eq(expenseId), any(GroupMember.class),
@@ -196,8 +198,8 @@ class CommandMemberExpenseServiceTest {
 		List<MemberExpenseResponse> responses = commandMemberExpenseService.update(expenseId, requests);
 
 		//then
-		assertThat(!responses.isEmpty()).isTrue();
-		assertThat(responses.size()).isEqualTo(1);
+		assertThat(responses).isNotEmpty();
+		assertThat(responses).hasSize(1);
 
 		verify(memberExpenseUpdater, times(1)).update(any(MemberExpense.class), any(MemberExpenseRequest.class));
 		verify(memberExpenseDeleter, times(1)).deleteByMemberExpenses(any());

--- a/src/test/java/com/dnd/moddo/domain/memberExpense/service/QueryMemberExpenseServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/memberExpense/service/QueryMemberExpenseServiceTest.java
@@ -5,7 +5,6 @@ import static org.mockito.Mockito.*;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -88,9 +87,11 @@ class QueryMemberExpenseServiceTest {
 		MemberExpense memberExpense2 = mock(MemberExpense.class);
 		when(memberExpense1.getExpenseId()).thenReturn(1L);
 		when(memberExpense1.getAmount()).thenReturn(10000L);
+		when(memberExpense1.getGroupMember()).thenReturn(groupMember1);
 
 		when(memberExpense2.getExpenseId()).thenReturn(2L);
 		when(memberExpense2.getAmount()).thenReturn(15000L);
+		when(memberExpense2.getGroupMember()).thenReturn(groupMember2);
 
 		Expense expense1 = mock(Expense.class);
 		Expense expense2 = mock(Expense.class);
@@ -100,10 +101,7 @@ class QueryMemberExpenseServiceTest {
 		when(groupMemberReader.findAllByGroupId(eq(groupId))).thenReturn(groupMembers);
 
 		when(memberExpenseReader.findAllByGroupMemberIds(List.of(1L, 2L)))
-			.thenReturn(Map.of(
-				1L, List.of(memberExpense1),
-				2L, List.of(memberExpense2)
-			));
+			.thenReturn(List.of(memberExpense1, memberExpense2));
 
 		when(expenseReader.findAllByGroupId(any())).thenReturn(List.of(expense1, expense2));
 

--- a/src/test/java/com/dnd/moddo/domain/memberExpense/service/implementation/MemberExpenseReaderTest.java
+++ b/src/test/java/com/dnd/moddo/domain/memberExpense/service/implementation/MemberExpenseReaderTest.java
@@ -5,7 +5,6 @@ import static org.mockito.Mockito.*;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -78,15 +77,15 @@ class MemberExpenseReaderTest {
 		when(memberExpenseRepository.findAllByGroupMemberIds(groupMemberIds)).thenReturn(mockExpenses);
 
 		//when
-		Map<Long, List<MemberExpense>> result = memberExpenseReader.findAllByGroupMemberIds(groupMemberIds);
+		List<MemberExpense> result = memberExpenseReader.findAllByGroupMemberIds(groupMemberIds);
 
 		//then
 		assertThat(result).isNotNull();
 		assertThat(result.size()).isEqualTo(2);
 
-		assertThat(result.get(1L).get(0).getAmount()).isEqualTo(1000L);
-		assertThat(result.get(1L).get(1).getAmount()).isEqualTo(2000L);
-		assertThat(result.get(2L).get(0).getAmount()).isEqualTo(3000L);
+		assertThat(result.get(0).getAmount()).isEqualTo(1000L);
+		assertThat(result.get(1).getAmount()).isEqualTo(2000L);
+		assertThat(result.get(0).getAmount()).isEqualTo(3000L);
 
 		verify(memberExpenseRepository, times(1)).findAllByGroupMemberIds(groupMemberIds);
 	}

--- a/src/test/java/com/dnd/moddo/domain/memberExpense/service/implementation/MemberExpenseReaderTest.java
+++ b/src/test/java/com/dnd/moddo/domain/memberExpense/service/implementation/MemberExpenseReaderTest.java
@@ -1,6 +1,6 @@
 package com.dnd.moddo.domain.memberExpense.service.implementation;
 
-import static org.assertj.core.api.AssertionsForClassTypes.*;
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import java.time.LocalDateTime;
@@ -50,7 +50,7 @@ class MemberExpenseReaderTest {
 		List<MemberExpense> result = memberExpenseReader.findAllByExpenseId(expenseId);
 
 		//then
-		assertThat(result).isNotNull();
+		assertThat(result).isNotEmpty();
 		assertThat(result.get(0).getAmount()).isEqualTo(15000L);
 		assertThat(result.get(0).getGroupMember()).isEqualTo(mockGroupMember);
 
@@ -63,8 +63,6 @@ class MemberExpenseReaderTest {
 		//given
 		GroupMember groupMember1 = mock(GroupMember.class);
 		GroupMember groupMember2 = mock(GroupMember.class);
-		when(groupMember1.getId()).thenReturn(1L);
-		when(groupMember2.getId()).thenReturn(2L);
 
 		List<MemberExpense> mockExpenses = List.of(
 			new MemberExpense(1L, groupMember1, 1000L),
@@ -80,13 +78,34 @@ class MemberExpenseReaderTest {
 		List<MemberExpense> result = memberExpenseReader.findAllByGroupMemberIds(groupMemberIds);
 
 		//then
-		assertThat(result).isNotNull();
-		assertThat(result.size()).isEqualTo(2);
-
-		assertThat(result.get(0).getAmount()).isEqualTo(1000L);
-		assertThat(result.get(1).getAmount()).isEqualTo(2000L);
-		assertThat(result.get(0).getAmount()).isEqualTo(3000L);
+		assertThat(result).isNotEmpty();
+		assertThat(result).hasSize(mockExpenses.size());
 
 		verify(memberExpenseRepository, times(1)).findAllByGroupMemberIds(groupMemberIds);
+	}
+
+	@DisplayName("지출내역 id들로 모든 참여자별 지출내역을 조회할 수 있다.")
+	@Test
+	void findAllByExpenseIds_Success() {
+		//given
+		GroupMember groupMember1 = mock(GroupMember.class);
+		GroupMember groupMember2 = mock(GroupMember.class);
+
+		List<MemberExpense> mockExpenses = List.of(
+			new MemberExpense(1L, groupMember1, 1000L),
+			new MemberExpense(2L, groupMember1, 2000L),
+			new MemberExpense(1L, groupMember2, 3000L)
+		);
+
+		List<Long> expenseIds = List.of(1L, 2L);
+
+		when(memberExpenseRepository.findAllByExpenseIds(eq(expenseIds))).thenReturn(mockExpenses);
+
+		//then
+		List<MemberExpense> result = memberExpenseReader.findAllByExpenseIds(expenseIds);
+
+		//then
+		assertThat(result).isNotEmpty();
+		assertThat(result).hasSize(mockExpenses.size());
 	}
 }


### PR DESCRIPTION
### #️⃣연관된 이슈
#54 , #57 

### 🔀반영 브랜치
feat/#54-find-all-expenses -> develop

### 🔧변경 사항
- 기존에 참여자별 정산내역 조회시 참여자의 지출내역이 존재하지 않는 경우 아래와 같이 나오던 걸
 ``` json
{
  "memberExpenses": []
}
```
참여자는 있고 지출내역은 없을때 아래와 같이 나올 수 있도록 수정하였습니다.
``` json
{
  "memberExpenses": [
          {
              "id": 1,
              "role": "MANAGER",
              "name": "김모또",
              "totalAmount": 0,
              "isPaid": true,
              "paidAt": null,
              "expenses": []
          }
  ]
}
```

- 전체 지출 내역 조회에 대한 기능을 추가하였습니다.
- 지출 내역 삭제 시 함께 저장된 참여자별 지출내역도 삭제할 수 있도록 기능을 추가하였습니다.

### 💬리뷰 요구사항(선택)
