### PR TITLE
백엔드에서 총무(정산담당자)생성하도록 로직 수정

### DIFF
--- a/src/main/java/com/dnd/moddo/domain/groupMember/controller/GroupMemberController.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/controller/GroupMemberController.java
@@ -20,6 +20,7 @@ import com.dnd.moddo.domain.groupMember.service.CommandGroupMemberService;
 import com.dnd.moddo.domain.groupMember.service.QueryGroupMemberService;
 import com.dnd.moddo.global.jwt.service.JwtService;
 
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -33,11 +34,13 @@ public class GroupMemberController {
 
 	@PostMapping
 	public ResponseEntity<GroupMembersResponse> saveGroupMembers(
+		HttpServletRequest httpRequest,
 		@RequestParam("groupToken") String groupToken,
 		@Valid @RequestBody GroupMembersSaveRequest request
 	) {
+		Long userId = jwtService.getUserId(httpRequest);
 		Long groupId = jwtService.getGroupId(groupToken);
-		GroupMembersResponse response = commandGroupMemberService.create(groupId, request);
+		GroupMembersResponse response = commandGroupMemberService.create(groupId, userId, request);
 		return ResponseEntity.ok(response);
 	}
 

--- a/src/main/java/com/dnd/moddo/domain/groupMember/dto/request/GroupMemberSaveRequest.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/dto/request/GroupMemberSaveRequest.java
@@ -8,14 +8,10 @@ import jakarta.validation.constraints.NotBlank;
 
 public record GroupMemberSaveRequest(
 	@NotBlank(message = "참여자 이름으로 공백은 입력할 수 없습니다.")
-	String name,
-	String role
+	String name
+
 ) {
 	public GroupMember toEntity(Group group, ExpenseRole role) {
-		boolean isPaid = false;
-		if (ExpenseRole.MANAGER.equals(role)) {
-			isPaid = true;
-		}
-		return new GroupMember(name(), group, isPaid, role);
+		return new GroupMember(name(), group, role);
 	}
 }

--- a/src/main/java/com/dnd/moddo/domain/groupMember/dto/request/GroupMembersSaveRequest.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/dto/request/GroupMembersSaveRequest.java
@@ -7,12 +7,18 @@ import java.util.List;
 import com.dnd.moddo.domain.group.entity.Group;
 import com.dnd.moddo.domain.groupMember.entity.GroupMember;
 
+import jakarta.validation.Valid;
+
 public record GroupMembersSaveRequest(
-	List<GroupMemberSaveRequest> members
+	@Valid List<GroupMemberSaveRequest> members
 ) {
 	public List<GroupMember> toEntity(Group group) {
 		return members.stream()
-			.map(m -> m.toEntity(group, getRoleByString(m.role())))
+			.map(m -> m.toEntity(group, PARTICIPANT))
 			.toList();
+	}
+
+	public List<String> extractNames() {
+		return members().stream().map(GroupMemberSaveRequest::name).toList();
 	}
 }

--- a/src/main/java/com/dnd/moddo/domain/groupMember/entity/GroupMember.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/entity/GroupMember.java
@@ -17,6 +17,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -50,19 +51,19 @@ public class GroupMember {
 	private ExpenseRole role;
 
 	public GroupMember(String name, Group group, ExpenseRole role) {
-		this(null, name, null, group, false, role);
+		this(name, null, group, false, role);
 	}
 
 	public GroupMember(String name, Group group, boolean isPaid, ExpenseRole role) {
-		this(null, name, null, group, isPaid, role);
+		this(name, null, group, isPaid, role);
 	}
 
 	public GroupMember(String name, Integer profileId, Group group, ExpenseRole role) {
-		this(null, name, profileId, group, false, role);
+		this(name, profileId, group, false, role);
 	}
 
-	public GroupMember(Long id, String name, Integer profileId, Group group, boolean isPaid, ExpenseRole role) {
-		this.id = id;
+	@Builder
+	public GroupMember(String name, Integer profileId, Group group, boolean isPaid, ExpenseRole role) {
 		this.name = name;
 		this.profileId = profileId;
 		this.group = group;

--- a/src/main/java/com/dnd/moddo/domain/groupMember/service/CommandGroupMemberService.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/service/CommandGroupMemberService.java
@@ -23,8 +23,8 @@ public class CommandGroupMemberService {
 	private final GroupMemberUpdater groupMemberUpdater;
 	private final GroupMemberDeleter groupMemberDeleter;
 
-	public GroupMembersResponse create(Long groupId, GroupMembersSaveRequest request) {
-		List<GroupMember> members = groupMemberCreator.create(groupId, request);
+	public GroupMembersResponse create(Long groupId, Long userId, GroupMembersSaveRequest request) {
+		List<GroupMember> members = groupMemberCreator.create(groupId, userId, request);
 		return GroupMembersResponse.of(members);
 	}
 

--- a/src/main/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberCreator.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberCreator.java
@@ -1,5 +1,6 @@
 package com.dnd.moddo.domain.groupMember.service.implementation;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
@@ -7,10 +8,12 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.dnd.moddo.domain.group.entity.Group;
 import com.dnd.moddo.domain.group.service.implementation.GroupReader;
-import com.dnd.moddo.domain.groupMember.dto.request.GroupMemberSaveRequest;
 import com.dnd.moddo.domain.groupMember.dto.request.GroupMembersSaveRequest;
 import com.dnd.moddo.domain.groupMember.entity.GroupMember;
+import com.dnd.moddo.domain.groupMember.entity.type.ExpenseRole;
 import com.dnd.moddo.domain.groupMember.repository.GroupMemberRepository;
+import com.dnd.moddo.domain.user.entity.User;
+import com.dnd.moddo.domain.user.repository.UserRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -21,16 +24,31 @@ public class GroupMemberCreator {
 	private final GroupMemberRepository groupMemberRepository;
 	private final GroupMemberValidator groupMemberValidator;
 	private final GroupReader groupReader;
+	private final UserRepository userRepository;
 
-	public List<GroupMember> create(Long groupId, GroupMembersSaveRequest request) {
+	public List<GroupMember> create(Long groupId, Long userId, GroupMembersSaveRequest request) {
 		Group group = groupReader.read(groupId);
 
-		List<String> requestNames = request.members().stream().map(GroupMemberSaveRequest::name).toList();
+		List<String> requestNames = request.extractNames();
 
-		groupMemberValidator.validateManagerExists(request.members());
 		groupMemberValidator.validateMemberNamesNotDuplicate(requestNames);
 
-		List<GroupMember> newMembers = request.toEntity(group);
+		List<GroupMember> newMembers = new ArrayList<>(List.of(createManager(userId, group)));
+		newMembers.addAll(request.toEntity(group));
+
 		return groupMemberRepository.saveAll(newMembers);
+	}
+
+	private GroupMember createManager(Long userId, Group group) {
+		User user = userRepository.getById(userId);
+
+		return GroupMember.builder()
+			.name("김모또")        //기본이름: 김모또
+			.profileId(null)     //user 프로필 가져오기
+			.group(group)
+			.isPaid(true)
+			.role(ExpenseRole.MANAGER)
+			.build();
+
 	}
 }

--- a/src/main/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberValidator.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberValidator.java
@@ -6,10 +6,7 @@ import java.util.Set;
 
 import org.springframework.stereotype.Service;
 
-import com.dnd.moddo.domain.groupMember.dto.request.GroupMemberSaveRequest;
-import com.dnd.moddo.domain.groupMember.entity.type.ExpenseRole;
 import com.dnd.moddo.domain.groupMember.exception.GroupMemberDuplicateNameException;
-import com.dnd.moddo.domain.groupMember.exception.InvalidExpenseParticipantsException;
 
 import lombok.RequiredArgsConstructor;
 
@@ -27,13 +24,5 @@ public class GroupMemberValidator {
 		Set<String> uniqueNames = new HashSet<>(names);
 		return uniqueNames.size() != names.size();
 	}
-
-	public void validateManagerExists(List<GroupMemberSaveRequest> members) {
-		boolean hasManager = members.stream()
-			.anyMatch(member -> ExpenseRole.getRoleByString(member.role()).equals(ExpenseRole.MANAGER));
-
-		if (!hasManager) {
-			throw new InvalidExpenseParticipantsException();
-		}
-	}
+	
 }

--- a/src/main/java/com/dnd/moddo/domain/memberExpense/service/QueryMemberExpenseService.java
+++ b/src/main/java/com/dnd/moddo/domain/memberExpense/service/QueryMemberExpenseService.java
@@ -111,7 +111,13 @@ public class QueryMemberExpenseService {
 			.collect(Collectors.groupingBy(
 				MemberExpense::getExpenseId,
 				Collectors.mapping(
-					me -> me.getGroupMember().getName(),
+					me -> {
+						String name = me.getGroupMember().getName();
+						if (me.getGroupMember().isManager()) {
+							return name + "(총무)";
+						}
+						return name;
+					},
 					Collectors.toList()
 				)
 			));

--- a/src/test/java/com/dnd/moddo/domain/group/service/QueryGroupServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/group/service/QueryGroupServiceTest.java
@@ -1,11 +1,12 @@
 package com.dnd.moddo.domain.group.service;
 
-import com.dnd.moddo.domain.group.dto.response.GroupDetailResponse;
-import com.dnd.moddo.domain.group.entity.Group;
-import com.dnd.moddo.domain.groupMember.entity.GroupMember;
-import com.dnd.moddo.domain.groupMember.entity.type.ExpenseRole;
-import com.dnd.moddo.domain.group.service.implementation.GroupReader;
-import com.dnd.moddo.domain.group.service.implementation.GroupValidator;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.util.ReflectionTestUtils.*;
+
+import java.util.List;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -14,88 +15,87 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.*;
-import static org.springframework.test.util.ReflectionTestUtils.setField;
+import com.dnd.moddo.domain.group.dto.response.GroupDetailResponse;
+import com.dnd.moddo.domain.group.entity.Group;
+import com.dnd.moddo.domain.group.service.implementation.GroupReader;
+import com.dnd.moddo.domain.group.service.implementation.GroupValidator;
+import com.dnd.moddo.domain.groupMember.entity.GroupMember;
+import com.dnd.moddo.domain.groupMember.entity.type.ExpenseRole;
 
 @ExtendWith(MockitoExtension.class)
 class QueryGroupServiceTest {
 
-    @InjectMocks
-    private QueryGroupService queryGroupService;
+	@InjectMocks
+	private QueryGroupService queryGroupService;
 
-    @Mock
-    private GroupReader groupReader;
+	@Mock
+	private GroupReader groupReader;
 
-    @Mock
-    private GroupValidator groupValidator;
+	@Mock
+	private GroupValidator groupValidator;
 
-    private Group group;
-    private GroupMember groupMember;
+	private Group group;
+	private GroupMember groupMember;
 
-    @BeforeEach
-    void setUp() {
-        // Given
-        group = new Group("groupName", 1L, "password", null, null, null, null);
-        groupMember = new GroupMember(1L, "김완숙", 1, group, false, ExpenseRole.MANAGER);
+	@BeforeEach
+	void setUp() {
+		// Given
+		group = new Group("groupName", 1L, "password", null, null, null, null);
+		groupMember = new GroupMember("김완숙", 1, group, false, ExpenseRole.MANAGER);
 
-        setField(group, "id", 1L);
-    }
+		setField(group, "id", 1L);
+	}
 
-    @Test
-    @DisplayName("그룹 상세 정보를 정상적으로 조회할 수 있다.")
-    void testFindOne_Success() {
-        // Given
-        when(groupReader.read(anyLong())).thenReturn(group);
-        when(groupReader.findByGroup(group.getId())).thenReturn(List.of(groupMember));
-        doNothing().when(groupValidator).checkGroupAuthor(group, 1L);
+	@Test
+	@DisplayName("그룹 상세 정보를 정상적으로 조회할 수 있다.")
+	void testFindOne_Success() {
+		// Given
+		when(groupReader.read(anyLong())).thenReturn(group);
+		when(groupReader.findByGroup(group.getId())).thenReturn(List.of(groupMember));
+		doNothing().when(groupValidator).checkGroupAuthor(group, 1L);
 
-        // When
-        GroupDetailResponse response = queryGroupService.findOne(group.getId(), 1L);
+		// When
+		GroupDetailResponse response = queryGroupService.findOne(group.getId(), 1L);
 
-        // Then
-        assertThat(response).isNotNull();
-        assertThat(response.id()).isEqualTo(group.getId());
-        assertThat(response.groupName()).isEqualTo(group.getName());
-        assertThat(response.members()).hasSize(1);
-        assertThat(response.members().get(0).name()).isEqualTo(groupMember.getName());
+		// Then
+		assertThat(response).isNotNull();
+		assertThat(response.id()).isEqualTo(group.getId());
+		assertThat(response.groupName()).isEqualTo(group.getName());
+		assertThat(response.members()).hasSize(1);
+		assertThat(response.members().get(0).name()).isEqualTo(groupMember.getName());
 
-        verify(groupReader, times(1)).read(1L);
-        verify(groupReader, times(1)).findByGroup(group.getId());
-        verify(groupValidator, times(1)).checkGroupAuthor(group, 1L);
-    }
+		verify(groupReader, times(1)).read(1L);
+		verify(groupReader, times(1)).findByGroup(group.getId());
+		verify(groupValidator, times(1)).checkGroupAuthor(group, 1L);
+	}
 
-    @Test
-    @DisplayName("그룹 작성자가 아닐 경우 예외가 발생한다.")
-    void testFindOne_Failure_WhenNotGroupAuthor() {
-        // Given
-        when(groupReader.read(anyLong())).thenReturn(group);
-        doThrow(new RuntimeException("Not an author")).when(groupValidator).checkGroupAuthor(group, 2L);
+	@Test
+	@DisplayName("그룹 작성자가 아닐 경우 예외가 발생한다.")
+	void testFindOne_Failure_WhenNotGroupAuthor() {
+		// Given
+		when(groupReader.read(anyLong())).thenReturn(group);
+		doThrow(new RuntimeException("Not an author")).when(groupValidator).checkGroupAuthor(group, 2L);
 
-        // When & Then
-        assertThatThrownBy(() -> queryGroupService.findOne(1L, 2L))
-                .isInstanceOf(RuntimeException.class)
-                .hasMessageContaining("Not an author");
+		// When & Then
+		assertThatThrownBy(() -> queryGroupService.findOne(1L, 2L))
+			.isInstanceOf(RuntimeException.class)
+			.hasMessageContaining("Not an author");
 
-        verify(groupReader, times(1)).read(1L);
-        verify(groupValidator, times(1)).checkGroupAuthor(group, 2L);
-    }
+		verify(groupReader, times(1)).read(1L);
+		verify(groupValidator, times(1)).checkGroupAuthor(group, 2L);
+	}
 
-    @Test
-    @DisplayName("그룹을 찾을 수 없을 경우 예외가 발생한다.")
-    void testFindOne_Failure_WhenGroupNotFound() {
-        // Given
-        when(groupReader.read(anyLong())).thenThrow(new RuntimeException("Group not found"));
+	@Test
+	@DisplayName("그룹을 찾을 수 없을 경우 예외가 발생한다.")
+	void testFindOne_Failure_WhenGroupNotFound() {
+		// Given
+		when(groupReader.read(anyLong())).thenThrow(new RuntimeException("Group not found"));
 
-        // When & Then
-        assertThatThrownBy(() -> queryGroupService.findOne(1L, 1L))
-                .isInstanceOf(RuntimeException.class)
-                .hasMessageContaining("Group not found");
+		// When & Then
+		assertThatThrownBy(() -> queryGroupService.findOne(1L, 1L))
+			.isInstanceOf(RuntimeException.class)
+			.hasMessageContaining("Group not found");
 
-        verify(groupReader, times(1)).read(1L);
-    }
+		verify(groupReader, times(1)).read(1L);
+	}
 }

--- a/src/test/java/com/dnd/moddo/domain/groupMember/service/CommandGroupMemberServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/groupMember/service/CommandGroupMemberServiceTest.java
@@ -47,24 +47,24 @@ public class CommandGroupMemberServiceTest {
 	@Test
 	void createSuccess() {
 		//given
-		Long groupId = mockGroup.getId();
+		Long groupId = mockGroup.getId(), userId = 1L;
 		GroupMembersSaveRequest request = new GroupMembersSaveRequest(new ArrayList<>());
 		List<GroupMember> expectedMembers = List.of(
 			new GroupMember("김모또", 1, mockGroup, ExpenseRole.MANAGER),
 			new GroupMember("김반숙", 2, mockGroup, ExpenseRole.PARTICIPANT)
 		);
 
-		when(groupMemberCreator.create(eq(groupId), eq(request))).thenReturn(expectedMembers);
+		when(groupMemberCreator.create(eq(groupId), any(), eq(request))).thenReturn(expectedMembers);
 
 		// when
-		GroupMembersResponse response = commandGroupMemberService.create(groupId, request);
+		GroupMembersResponse response = commandGroupMemberService.create(groupId, userId, request);
 
 		//then
 		assertThat(response).isNotNull();
 		assertThat(response.members().size()).isEqualTo(2);
 		assertThat(response.members().get(0).name()).isEqualTo("김모또");
 		assertThat(response.members().get(0).role()).isEqualTo(ExpenseRole.MANAGER);
-		verify(groupMemberCreator, times(1)).create(eq(groupId), eq(request));
+		verify(groupMemberCreator, times(1)).create(eq(groupId), any(), eq(request));
 	}
 
 	@DisplayName("모든 정보가 유효할때 기존 모임의 참여자 추가가 성공한다.")

--- a/src/test/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberValidatorTest.java
+++ b/src/test/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberValidatorTest.java
@@ -7,8 +7,6 @@ import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import com.dnd.moddo.domain.groupMember.dto.request.GroupMemberSaveRequest;
-
 class GroupMemberValidatorTest {
 	private final GroupMemberValidator groupMemberValidator = new GroupMemberValidator();
 
@@ -31,26 +29,5 @@ class GroupMemberValidatorTest {
 			groupMemberValidator.validateMemberNamesNotDuplicate(names);
 		}).hasMessage("중복된 참여자의 이름은 저장할 수 없습니다.");
 	}
-
-	@DisplayName("참여자 역할에 정산담당자가 존재하면 성공한다.")
-	@Test
-	void validateParticipant_Success() {
-		List<GroupMemberSaveRequest> members = List.of(new GroupMemberSaveRequest("김모또", "MANAGER"),
-			new GroupMemberSaveRequest("김반숙", "PARTICIPANT"));
-
-		assertThatCode(() -> {
-			groupMemberValidator.validateManagerExists(members);
-		}).doesNotThrowAnyException();
-	}
-
-	@DisplayName("참여자 역할에 정산담당자가 존재하지 않으면 예외가 발생한다.")
-	@Test
-	void validateParticipant_ThrowException_WhenNoManagerPresent() {
-		List<GroupMemberSaveRequest> members = List.of(new GroupMemberSaveRequest("김모또", "PARTICIPANT"),
-			new GroupMemberSaveRequest("김반숙", "PARTICIPANT"));
-
-		assertThatThrownBy(() -> {
-			groupMemberValidator.validateManagerExists(members);
-		}).hasMessage("총무(MANAGER)는 한 명 있어야 합니다.");
-	}
+	
 }

--- a/src/test/java/com/dnd/moddo/domain/memberExpense/service/QueryMemberExpenseServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/memberExpense/service/QueryMemberExpenseServiceTest.java
@@ -128,6 +128,9 @@ class QueryMemberExpenseServiceTest {
 		when(groupMember1.getName()).thenReturn("김모또");
 		when(groupMember2.getName()).thenReturn("김반숙");
 
+		when(groupMember1.isManager()).thenReturn(true);
+		when(groupMember2.isManager()).thenReturn(false);
+
 		List<Long> expenseIds = List.of(1L, 2L);
 
 		List<MemberExpense> mockExpenses = List.of(
@@ -145,9 +148,9 @@ class QueryMemberExpenseServiceTest {
 		assertThat(result).isNotEmpty();
 		assertThat(result).hasSize(2);
 		assertThat(result.get(1L)).hasSize(2);
-		assertThat(result.get(1L).get(0)).isEqualTo("김모또");
+		assertThat(result.get(1L).get(0)).endsWith("(총무)");
+		assertThat(result.get(1L).get(1)).isEqualTo("김반숙");
 		assertThat(result.get(2L)).hasSize(1);
-		assertThat(result.get(2L).get(0)).isEqualTo("김모또");
 
 		verify(memberExpenseReader, times(1)).findAllByExpenseIds(eq(expenseIds));
 	}


### PR DESCRIPTION
### #️⃣연관된 이슈
#60 

### 🔀반영 브랜치
feat/#60-create-manager -> develop

### 🔧변경 사항
- 참여자별 정산 내역 조회시 아래와 같이 나오던 것을
``` json
{
    "id": 1,
    "date": "2025-02-03",
    "content": "하이디라오",
    "totalAmount": 100000,
    "groupMembers": [
        "김모또",
        "김반숙"
    ]
}
```
이런식으로 총무의 이름옆에는 "(총무)"를 붙여서 나오도록 수정하였습니다.
``` json
{
    "id": 1,
    "date": "2025-02-03",
    "content": "하이디라오",
    "totalAmount": 100000,
    "groupMembers": [
        "김모또(총무)",
        "김반숙"
    ]
}
```
- 총무 생성을 request에 역할을 받아서 생성하던 방식에서 백엔드에서 모임을 만드는 사용자로 생성 할 수 있도록 수정하였습니다. (기본적으로 사용자의 이름을 김모또라고 해야할지? 추후에 회원 사용자의 이름에 따라 변경되어야하는 값인지.. 모르겠어서 일단은 김모또라고 고정해놨습니다)

### 💬리뷰 요구사항(선택)

