### PR TITLE
지출 내역 생성, 참여자 추가, 참여자별 지출 내역 생성에 대한 입력값 검증 추가

### DIFF
--- a/src/main/java/com/dnd/moddo/domain/expense/controller/ExpenseController.java
+++ b/src/main/java/com/dnd/moddo/domain/expense/controller/ExpenseController.java
@@ -20,6 +20,7 @@ import com.dnd.moddo.domain.expense.service.CommandExpenseService;
 import com.dnd.moddo.domain.expense.service.QueryExpenseService;
 import com.dnd.moddo.global.jwt.service.JwtService;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -34,7 +35,7 @@ public class ExpenseController {
 	@PostMapping
 	public ResponseEntity<ExpensesResponse> saveExpenses(
 		@RequestParam("groupToken") String groupToken,
-		@RequestBody ExpensesRequest request) {
+		@Valid @RequestBody ExpensesRequest request) {
 		Long groupId = jwtService.getGroupId(groupToken);
 		ExpensesResponse response = commandExpenseService.createExpenses(groupId, request);
 		return ResponseEntity.ok(response);

--- a/src/main/java/com/dnd/moddo/domain/expense/dto/request/ExpenseRequest.java
+++ b/src/main/java/com/dnd/moddo/domain/expense/dto/request/ExpenseRequest.java
@@ -8,12 +8,21 @@ import com.dnd.moddo.domain.group.entity.Group;
 import com.dnd.moddo.domain.memberExpense.dto.request.MemberExpenseRequest;
 import com.fasterxml.jackson.annotation.JsonFormat;
 
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
+
 public record ExpenseRequest(
+	@Positive(message = "지출내역 값은 양수여야 합니다.")
+	@Max(value = 5_000_000, message = "지출내역 값은 최대 500만원까지 입력할 수 있습니다.")
 	Long amount,
+
+	@NotBlank(message = "지출 장소 및 내용은 필수 입력값 입니다.")
 	String content,
 	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
 	LocalDate date,
-	List<MemberExpenseRequest> memberExpenses
+	@Valid List<MemberExpenseRequest> memberExpenses
 
 ) {
 

--- a/src/main/java/com/dnd/moddo/domain/expense/dto/request/ExpensesRequest.java
+++ b/src/main/java/com/dnd/moddo/domain/expense/dto/request/ExpensesRequest.java
@@ -5,8 +5,10 @@ import java.util.List;
 import com.dnd.moddo.domain.expense.entity.Expense;
 import com.dnd.moddo.domain.group.entity.Group;
 
+import jakarta.validation.Valid;
+
 public record ExpensesRequest(
-	List<ExpenseRequest> expenses
+	@Valid List<ExpenseRequest> expenses
 ) {
 	public List<Expense> toEntity(Group group) {
 		return expenses.stream()

--- a/src/main/java/com/dnd/moddo/domain/groupMember/dto/request/GroupMemberSaveRequest.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/dto/request/GroupMemberSaveRequest.java
@@ -5,9 +5,11 @@ import com.dnd.moddo.domain.groupMember.entity.GroupMember;
 import com.dnd.moddo.domain.groupMember.entity.type.ExpenseRole;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 
 public record GroupMemberSaveRequest(
-	@NotBlank(message = "참여자 이름으로 공백은 입력할 수 없습니다.")
+	@NotBlank(message = "이름은 필수 입력값 입니다.")
+	@Pattern(regexp = "^[가-힣a-zA-Z]{1,5}$", message = "참여자 이름은 한글과 영어만 포함하여 5자 이내여야 합니다.")
 	String name
 
 ) {

--- a/src/main/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberCreator.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberCreator.java
@@ -33,7 +33,9 @@ public class GroupMemberCreator {
 
 		groupMemberValidator.validateMemberNamesNotDuplicate(requestNames);
 
-		List<GroupMember> newMembers = new ArrayList<>(List.of(createManager(userId, group)));
+		List<GroupMember> newMembers = new ArrayList<>();
+
+		newMembers.add(createManager(userId, group));
 		newMembers.addAll(request.toEntity(group));
 
 		return groupMemberRepository.saveAll(newMembers);
@@ -41,9 +43,9 @@ public class GroupMemberCreator {
 
 	private GroupMember createManager(Long userId, Group group) {
 		User user = userRepository.getById(userId);
-
+		String name = user.getIsMember() ? user.getName() : "김모또";
 		return GroupMember.builder()
-			.name("김모또")        //기본이름: 김모또
+			.name(name)
 			.profileId(null)     //user 프로필 가져오기
 			.group(group)
 			.isPaid(true)

--- a/src/main/java/com/dnd/moddo/domain/memberExpense/dto/request/MemberExpenseRequest.java
+++ b/src/main/java/com/dnd/moddo/domain/memberExpense/dto/request/MemberExpenseRequest.java
@@ -3,7 +3,18 @@ package com.dnd.moddo.domain.memberExpense.dto.request;
 import com.dnd.moddo.domain.groupMember.entity.GroupMember;
 import com.dnd.moddo.domain.memberExpense.entity.MemberExpense;
 
-public record MemberExpenseRequest(Long memberId, Long amount) {
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+public record MemberExpenseRequest(
+	@NotNull(message = "참여자 id는 필수 항목입니다.")
+	@Positive(message = "참여자 id는 양수여야 합니다.")
+	Long memberId,
+
+	@Positive(message = "지출내역 값은 양수여야 합니다.")
+	@Max(value = 5_000_000, message = "지출내역 값은 최대 500만원까지 입력할 수 있습니다.")
+	Long amount) {
 	public MemberExpense toEntity(Long expenseId, GroupMember groupMember) {
 		return MemberExpense.builder()
 			.expenseId(expenseId)

--- a/src/main/java/com/dnd/moddo/domain/memberExpense/service/QueryMemberExpenseService.java
+++ b/src/main/java/com/dnd/moddo/domain/memberExpense/service/QueryMemberExpenseService.java
@@ -110,16 +110,12 @@ public class QueryMemberExpenseService {
 		return memberExpenses.stream()
 			.collect(Collectors.groupingBy(
 				MemberExpense::getExpenseId,
-				Collectors.mapping(
-					me -> {
-						String name = me.getGroupMember().getName();
-						if (me.getGroupMember().isManager()) {
-							return name + "(총무)";
-						}
-						return name;
-					},
-					Collectors.toList()
-				)
+				Collectors.mapping(this::formatMemberName, Collectors.toUnmodifiableList())
 			));
+	}
+
+	private String formatMemberName(MemberExpense me) {
+		String name = me.getGroupMember().getName();
+		return me.getGroupMember().isManager() ? name + "(총무)" : name;
 	}
 }

--- a/src/main/java/com/dnd/moddo/domain/memberExpense/service/QueryMemberExpenseService.java
+++ b/src/main/java/com/dnd/moddo/domain/memberExpense/service/QueryMemberExpenseService.java
@@ -51,10 +51,8 @@ public class QueryMemberExpenseService {
 
 		List<GroupMemberExpenseResponse> responses = groupMemberById.keySet()
 			.stream()
-			.map(key -> {
-					return findMemberExpenseDetailByGroupMember(groupMemberById.get(key), memberExpenses.get(key),
-						expenses);
-				}
+			.map(
+				key -> findMemberExpenseDetailByGroupMember(groupMemberById.get(key), memberExpenses.get(key), expenses)
 			)
 			.filter(Objects::nonNull)
 			.toList();


### PR DESCRIPTION
### #️⃣연관된 이슈
#62 

### 🔀반영 브랜치
feat/#62-check-input-validate -> develop

### 🔧변경 사항
- 참여자 추가 시 이름은 필수 항목이며 한글과 영어를 포함한 최대 5자 이내로 입력값 검증을 추가하였습니다.
- 지출내역 생성 시 필수 항목인 금액, 지출 내용, 장소에 대해 입력값 검증을 추가하였습니다.
- 참여자 정산 내역 생성 시 금액이 500만원 이내로 제한되도록 입력값 검증을 추가하였습니다.
- 비회원의 경우 총무 이름이 "김모또"로 설정되도록 수정하였으며 회원인 경우 총무 이름이 회원의 이름으로 설정되도록 수정하였습니다.
- 그 외에 가독성을 위한 코드 리팩토링을 일부 진행하였습니다.

### 💬리뷰 요구사항(선택)

