### PR TITLE
지출내역별 이미지 업로드

### DIFF
--- a/src/main/java/com/dnd/moddo/domain/expense/controller/ExpenseController.java
+++ b/src/main/java/com/dnd/moddo/domain/expense/controller/ExpenseController.java
@@ -1,5 +1,7 @@
 package com.dnd.moddo.domain.expense.controller;
 
+import com.dnd.moddo.domain.expense.dto.request.ExpenseImageRequest;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -32,8 +34,8 @@ public class ExpenseController {
 
 	@PostMapping
 	public ResponseEntity<ExpensesResponse> saveExpenses(
-		@RequestParam("groupToken") String groupToken,
-		@RequestBody ExpensesRequest request) {
+			@RequestParam("groupToken") String groupToken,
+			@RequestBody ExpensesRequest request) {
 		Long groupId = jwtService.getGroupId(groupToken);
 		ExpensesResponse response = commandExpenseService.createExpenses(groupId, request);
 		return ResponseEntity.ok(response);
@@ -55,7 +57,7 @@ public class ExpenseController {
 
 	@PutMapping("/{expenseId}")
 	public ResponseEntity<ExpenseResponse> updateByExpenseId(@PathVariable("expenseId") Long expenseId,
-		@RequestBody ExpenseRequest request) {
+															 @RequestBody ExpenseRequest request) {
 		ExpenseResponse response = commandExpenseService.update(expenseId, request);
 		return ResponseEntity.ok(response);
 
@@ -67,4 +69,13 @@ public class ExpenseController {
 		return ResponseEntity.noContent().build();
 	}
 
+	@PutMapping("/img/{expenseId}")
+	public void updateImgUrl(HttpServletRequest request,
+							 @RequestParam("groupToken") String groupToken,
+							 @PathVariable("expenseId") Long expenseId,
+							 @RequestBody ExpenseImageRequest expenseImageRequest) {
+		Long userId = jwtService.getUserId(request);
+		Long groupId = jwtService.getGroupId(groupToken);
+		commandExpenseService.updateImgUrl(userId, groupId, expenseId, expenseImageRequest);
+	}
 }

--- a/src/main/java/com/dnd/moddo/domain/expense/dto/request/ExpenseImageRequest.java
+++ b/src/main/java/com/dnd/moddo/domain/expense/dto/request/ExpenseImageRequest.java
@@ -1,0 +1,11 @@
+package com.dnd.moddo.domain.expense.dto.request;
+
+import jakarta.validation.constraints.NotEmpty;
+
+import java.util.List;
+
+public record ExpenseImageRequest(
+        @NotEmpty
+        List<String> images
+) {
+}

--- a/src/main/java/com/dnd/moddo/domain/expense/entity/Expense.java
+++ b/src/main/java/com/dnd/moddo/domain/expense/entity/Expense.java
@@ -3,17 +3,13 @@ package com.dnd.moddo.domain.expense.entity;
 import java.time.LocalDate;
 import java.util.List;
 
+import ch.qos.logback.core.testUtil.StringListAppender;
+import com.dnd.moddo.domain.expense.dto.request.ExpenseImageRequest;
 import com.dnd.moddo.domain.group.entity.Group;
+import com.dnd.moddo.global.converter.StringListConverter;
 import com.fasterxml.jackson.annotation.JsonFormat;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -39,7 +35,7 @@ public class Expense {
 	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
 	private LocalDate date;
 
-	//TODO List 직렬화 @Convert 추가하기
+	@Convert(converter = StringListConverter.class)
 	private List<String> images;
 
 	public Expense(Group group, Long amount, String content, LocalDate date) {
@@ -59,5 +55,9 @@ public class Expense {
 		this.amount = amount;
 		this.content = content;
 		this.date = date;
+	}
+
+	public void updateImgUrl(List<String> images) {
+		this.images = images;
 	}
 }

--- a/src/main/java/com/dnd/moddo/domain/expense/service/CommandExpenseService.java
+++ b/src/main/java/com/dnd/moddo/domain/expense/service/CommandExpenseService.java
@@ -2,6 +2,10 @@ package com.dnd.moddo.domain.expense.service;
 
 import java.util.List;
 
+import com.dnd.moddo.domain.expense.dto.request.ExpenseImageRequest;
+import com.dnd.moddo.domain.group.entity.Group;
+import com.dnd.moddo.domain.group.service.implementation.GroupReader;
+import com.dnd.moddo.domain.group.service.implementation.GroupValidator;
 import org.springframework.stereotype.Service;
 
 import com.dnd.moddo.domain.expense.dto.request.ExpenseRequest;
@@ -24,6 +28,8 @@ public class CommandExpenseService {
 	private final ExpenseUpdater expenseUpdater;
 	private final ExpenseDeleter expenseDeleter;
 	private final CommandMemberExpenseService commandMemberExpenseService;
+	private final GroupReader groupReader;
+	private final GroupValidator groupValidator;
 
 	public ExpensesResponse createExpenses(Long groupId, ExpensesRequest request) {
 		List<ExpenseResponse> expenses = request.expenses()
@@ -48,6 +54,13 @@ public class CommandExpenseService {
 		return ExpenseResponse.of(expense, memberExpenseResponses);
 
 	}
+
+	public void updateImgUrl(Long userId, Long groupId, Long expenseId, ExpenseImageRequest request) {
+		Group group = groupReader.read(groupId);
+		groupValidator.checkGroupAuthor(group, userId);
+		expenseUpdater.updateImgUrl(expenseId, request);
+	}
+
 
 	public void delete(Long expenseId) {
 		//TODO 삭제하는 사람이 정산자인지 확인 로직 필요

--- a/src/main/java/com/dnd/moddo/domain/expense/service/implementation/ExpenseUpdater.java
+++ b/src/main/java/com/dnd/moddo/domain/expense/service/implementation/ExpenseUpdater.java
@@ -1,5 +1,6 @@
 package com.dnd.moddo.domain.expense.service.implementation;
 
+import com.dnd.moddo.domain.expense.dto.request.ExpenseImageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,6 +19,12 @@ public class ExpenseUpdater {
 	public Expense update(Long expenseId, ExpenseRequest request) {
 		Expense expense = expenseRepository.getById(expenseId);
 		expense.update(request.amount(), request.content(), request.date());
+		return expense;
+	}
+
+	public Expense updateImgUrl(Long expenseId, ExpenseImageRequest request) {
+		Expense expense = expenseRepository.getById(expenseId);
+		expense.updateImgUrl(request.images());
 		return expense;
 	}
 }

--- a/src/main/java/com/dnd/moddo/domain/image/controller/ImageController.java
+++ b/src/main/java/com/dnd/moddo/domain/image/controller/ImageController.java
@@ -8,6 +8,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/api/v1/images")
 @RequiredArgsConstructor
@@ -15,14 +17,14 @@ public class ImageController {
     private final CommandImageService commandImageService;
 
     @PostMapping("/temp")
-    public ResponseEntity<TempImageResponse> saveTempImage(@RequestParam("file") MultipartFile file) {
-        TempImageResponse uniqueKey = commandImageService.uploadTempImage(file);
+    public ResponseEntity<TempImageResponse> saveTempImage(@RequestParam("file") List<MultipartFile> files) {
+        TempImageResponse uniqueKey = commandImageService.uploadTempImage(files);
         return ResponseEntity.ok(uniqueKey);
     }
 
     @PostMapping("/update")
-    public ResponseEntity<ImageResponse> updateImage(@RequestParam("uniqueKey") String uniqueKey) {
-        ImageResponse finalImagePath = commandImageService.uploadFinalImage(uniqueKey);
+    public ResponseEntity<ImageResponse> updateImage(@RequestParam("uniqueKey") List<String> uniqueKeys) {
+        ImageResponse finalImagePath = commandImageService.uploadFinalImage(uniqueKeys);
         return ResponseEntity.ok(finalImagePath);
     }
 }

--- a/src/main/java/com/dnd/moddo/domain/image/dto/ImageResponse.java
+++ b/src/main/java/com/dnd/moddo/domain/image/dto/ImageResponse.java
@@ -1,9 +1,11 @@
 package com.dnd.moddo.domain.image.dto;
 
+import java.util.List;
+
 public record ImageResponse(
-        String path
+        List<String> paths
 ) {
-    public static ImageResponse from(String path) {
-        return new ImageResponse(path);
+    public static ImageResponse from(List<String> paths) {
+        return new ImageResponse(paths);
     }
 }

--- a/src/main/java/com/dnd/moddo/domain/image/dto/TempImageResponse.java
+++ b/src/main/java/com/dnd/moddo/domain/image/dto/TempImageResponse.java
@@ -1,9 +1,11 @@
 package com.dnd.moddo.domain.image.dto;
 
+import java.util.List;
+
 public record TempImageResponse(
-        String uniqueKey
+        List<String> uniqueKeys
 ) {
-    public static TempImageResponse from(String uniqueKey) {
-        return new TempImageResponse(uniqueKey);
+    public static TempImageResponse from(List<String> uniqueKeys) {
+        return new TempImageResponse(uniqueKeys);
     }
 }

--- a/src/main/java/com/dnd/moddo/domain/image/repository/ImageRepository.java
+++ b/src/main/java/com/dnd/moddo/domain/image/repository/ImageRepository.java
@@ -3,8 +3,8 @@ package com.dnd.moddo.domain.image.repository;
 import com.dnd.moddo.domain.image.entity.Image;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Optional;
+import java.util.List;
 
 public interface ImageRepository extends JpaRepository<Image, Long> {
-    Optional<Image> findByUniqueKey(String uniqueKey);
+    List<Image> findByUniqueKeyIn(List<String> uniqueKeys);
 }

--- a/src/main/java/com/dnd/moddo/global/converter/StringListConverter.java
+++ b/src/main/java/com/dnd/moddo/global/converter/StringListConverter.java
@@ -1,0 +1,19 @@
+package com.dnd.moddo.global.converter;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import java.util.Arrays;
+import java.util.List;
+
+@Converter
+public class StringListConverter implements AttributeConverter<List<String>, String> {
+    @Override
+    public String convertToDatabaseColumn(List<String> attribute) {
+        return attribute == null ? null : String.join(",", attribute);
+    }
+
+    @Override
+    public List<String> convertToEntityAttribute(String dbData) {
+        return dbData == null || dbData.isEmpty() ? null : Arrays.asList(dbData.split(","));
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,7 +3,7 @@ spring:
     import: classpath:config/application-jwt.yml, classpath:config/application-s3.yml
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         default_batch_fetch_size: 30

--- a/src/test/java/com/dnd/moddo/domain/expense/entity/ExpenseTest.java
+++ b/src/test/java/com/dnd/moddo/domain/expense/entity/ExpenseTest.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.AssertionsForClassTypes.*;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -39,5 +41,23 @@ class ExpenseTest {
 		assertThat(expense.getAmount()).isEqualTo(newAmount);
 		assertThat(expense.getContent()).isEqualTo(newContent);
 		assertThat(expense.getDate()).isEqualTo(newDate);
+	}
+
+	@Test
+	void updateImgUrl() {
+		// given
+		Long initAmount = 20000L;
+		String initContent = "old content";
+		LocalDate initDate = LocalDate.of(2025, 02, 03);
+		Expense expense = new Expense(mockGroup, initAmount, initContent, initDate);
+		List<String> images = List.of("image1.jpg", "image2.jpg");
+		expense.updateImgUrl(images);
+
+		// when
+		List<String> newImages = List.of("new_image1.jpg", "new_image2.jpg", "new_image3.jpg");
+		expense.updateImgUrl(newImages);
+
+		// then
+		assertThat(expense.getImages()).isEqualTo(newImages);
 	}
 }

--- a/src/test/java/com/dnd/moddo/domain/expense/service/CommandExpenseServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/expense/service/CommandExpenseServiceTest.java
@@ -8,6 +8,9 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.dnd.moddo.domain.expense.dto.request.ExpenseImageRequest;
+import com.dnd.moddo.domain.group.service.implementation.GroupReader;
+import com.dnd.moddo.domain.group.service.implementation.GroupValidator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -38,6 +41,10 @@ class CommandExpenseServiceTest {
 	private ExpenseUpdater expenseUpdater;
 	@Mock
 	private ExpenseDeleter expenseDeleter;
+	@Mock
+	private GroupReader groupReader;
+	@Mock
+	private GroupValidator groupValidator;
 	@Mock
 	private CommandMemberExpenseService commandMemberExpenseService;
 	@InjectMocks
@@ -145,4 +152,26 @@ class CommandExpenseServiceTest {
 		}).hasMessage("해당 지출내역을 찾을 수 없습니다. (Expense ID: " + expenseId + ")");
 
 	}
+
+	@DisplayName("지출 내역의 이미지 URL을 업데이트할 수 있다.")
+	@Test
+	void updateImgUrlSuccess() {
+		// given
+		Long userId = mockGroup.getWriter(), groupId = mockGroup.getId(), expenseId = 1L;
+		ExpenseImageRequest request = mock(ExpenseImageRequest.class);
+		Group mockGroup = mock(Group.class);
+
+		when(groupReader.read(groupId)).thenReturn(mockGroup);
+		doNothing().when(groupValidator).checkGroupAuthor(mockGroup, userId);
+
+		// when
+		commandExpenseService.updateImgUrl(userId, groupId, expenseId, request);
+
+		// then
+		verify(groupReader, times(1)).read(groupId);
+		verify(groupValidator, times(1)).checkGroupAuthor(mockGroup, userId);
+		verify(expenseUpdater, times(1)).updateImgUrl(expenseId, request);
+	}
+
+
 }

--- a/src/test/java/com/dnd/moddo/domain/expense/service/implementation/ExpenseUpdaterTest.java
+++ b/src/test/java/com/dnd/moddo/domain/expense/service/implementation/ExpenseUpdaterTest.java
@@ -4,7 +4,9 @@ import static org.assertj.core.api.AssertionsForClassTypes.*;
 import static org.mockito.Mockito.*;
 
 import java.time.LocalDate;
+import java.util.List;
 
+import com.dnd.moddo.domain.expense.dto.request.ExpenseImageRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -43,6 +45,26 @@ class ExpenseUpdaterTest {
 
 		//then
 		verify(oldExpense, times(1)).update(any(), any(), any());
+	}
+
+	@DisplayName("지출내역이 존재하면 이미지 URL 목록을 업데이트할 수 있다.")
+	@Test
+	void updateImgUrlSuccess() {
+		//given
+		Long expenseId = 1L;
+		Expense oldExpense = mock(Expense.class);
+		List<String> newImages = List.of("image1.jpg", "image2.jpg", "image3.jpg");
+
+		when(expenseRepository.getById(eq(expenseId))).thenReturn(oldExpense);
+
+		ExpenseImageRequest request = mock(ExpenseImageRequest.class);
+		when(request.images()).thenReturn(newImages);
+
+		//when
+		Expense updatedExpense = expenseUpdater.updateImgUrl(expenseId, request);
+
+		//then
+		verify(oldExpense, times(1)).updateImgUrl(eq(newImages));
 	}
 
 	@DisplayName("지출내역이 존재하지 않으면 해당 지출내역을 수정하려할 때 예외가 발생한다.")


### PR DESCRIPTION
### #️⃣연관된 이슈
#56 

### 🔀반영 브랜치
feat/#56-save-image -> develop

### 🔧변경 사항
- imgUrl만 나오는 response를 만들기엔 비효율적인 것 같아 반환타입을 void로 설정했습니다.
- 이미지를 수정하는 기능이지만, 지출내역 안에있는 이미지이다보니 image가 아닌 expense에서 개발했습니다.

### 💬리뷰 요구사항(선택)