### PR TITLE
비회원 비밀번호 검증 기능

### DIFF
--- a/src/main/java/com/dnd/moddo/domain/group/controller/GroupController.java
+++ b/src/main/java/com/dnd/moddo/domain/group/controller/GroupController.java
@@ -55,14 +55,14 @@ public class GroupController {
     }
 
     @PostMapping("/password")
-    public ResponseEntity<GroupPasswordResponse> verifyPassword(
+    public ResponseEntity<GroupPasswordResponse> isPasswordMatch(
             HttpServletRequest request,
             @RequestParam("groupToken") String groupToken,
             @RequestBody GroupPasswordRequest groupPasswordRequest) {
         Long userId = jwtService.getUserId(request);
         Long groupId = jwtService.getGroupId(groupToken);
 
-        GroupPasswordResponse response = commandGroupService.verifyPassword(groupId, userId, groupPasswordRequest);
+        GroupPasswordResponse response = commandGroupService.isPasswordMatch(groupId, userId, groupPasswordRequest);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/dnd/moddo/domain/group/controller/GroupController.java
+++ b/src/main/java/com/dnd/moddo/domain/group/controller/GroupController.java
@@ -1,8 +1,10 @@
 package com.dnd.moddo.domain.group.controller;
 
 import com.dnd.moddo.domain.group.dto.request.GroupAccountRequest;
+import com.dnd.moddo.domain.group.dto.request.GroupPasswordRequest;
 import com.dnd.moddo.domain.group.dto.request.GroupRequest;
 import com.dnd.moddo.domain.group.dto.response.GroupDetailResponse;
+import com.dnd.moddo.domain.group.dto.response.GroupPasswordResponse;
 import com.dnd.moddo.domain.group.dto.response.GroupResponse;
 import com.dnd.moddo.domain.group.service.CommandGroupService;
 import com.dnd.moddo.domain.group.service.QueryGroupService;
@@ -49,6 +51,18 @@ public class GroupController {
         Long groupId = jwtService.getGroupId(groupToken);
 
         GroupDetailResponse response = queryGroupService.findOne(groupId, userId);
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/password")
+    public ResponseEntity<GroupPasswordResponse> verifyPassword(
+            HttpServletRequest request,
+            @RequestParam("groupToken") String groupToken,
+            @RequestBody GroupPasswordRequest groupPasswordRequest) {
+        Long userId = jwtService.getUserId(request);
+        Long groupId = jwtService.getGroupId(groupToken);
+
+        GroupPasswordResponse response = commandGroupService.verifyPassword(groupId, userId, groupPasswordRequest);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/dnd/moddo/domain/group/dto/request/GroupPasswordRequest.java
+++ b/src/main/java/com/dnd/moddo/domain/group/dto/request/GroupPasswordRequest.java
@@ -1,0 +1,6 @@
+package com.dnd.moddo.domain.group.dto.request;
+
+public record GroupPasswordRequest(
+        String password
+) {
+}

--- a/src/main/java/com/dnd/moddo/domain/group/dto/response/GroupPasswordResponse.java
+++ b/src/main/java/com/dnd/moddo/domain/group/dto/response/GroupPasswordResponse.java
@@ -1,0 +1,9 @@
+package com.dnd.moddo.domain.group.dto.response;
+
+public record GroupPasswordResponse(
+        String status
+) {
+    public static GroupPasswordResponse from(String status) {
+        return new GroupPasswordResponse(status);
+    }
+}

--- a/src/main/java/com/dnd/moddo/domain/group/exception/InvalidPasswordException.java
+++ b/src/main/java/com/dnd/moddo/domain/group/exception/InvalidPasswordException.java
@@ -1,0 +1,10 @@
+package com.dnd.moddo.domain.group.exception;
+
+import com.dnd.moddo.global.exception.ModdoException;
+import org.springframework.http.HttpStatus;
+
+public class InvalidPasswordException extends ModdoException {
+    public InvalidPasswordException() {
+        super(HttpStatus.BAD_REQUEST, "비밀번호가 틀렸습니다.");
+    }
+}

--- a/src/main/java/com/dnd/moddo/domain/group/service/CommandGroupService.java
+++ b/src/main/java/com/dnd/moddo/domain/group/service/CommandGroupService.java
@@ -1,7 +1,9 @@
 package com.dnd.moddo.domain.group.service;
 
 import com.dnd.moddo.domain.group.dto.request.GroupAccountRequest;
+import com.dnd.moddo.domain.group.dto.request.GroupPasswordRequest;
 import com.dnd.moddo.domain.group.dto.request.GroupRequest;
+import com.dnd.moddo.domain.group.dto.response.GroupPasswordResponse;
 import com.dnd.moddo.domain.group.dto.response.GroupResponse;
 import com.dnd.moddo.domain.group.entity.Group;
 import com.dnd.moddo.domain.group.service.implementation.GroupCreator;
@@ -31,5 +33,12 @@ public class CommandGroupService {
         groupValidator.checkGroupAuthor(group, userId);
         group = groupUpdater.updateAccount(request, group.getId());
         return GroupResponse.of(group);
+    }
+
+    public GroupPasswordResponse verifyPassword(Long groupId, Long userId, GroupPasswordRequest request) {
+        Group group = groupReader.read(groupId);
+        groupValidator.checkGroupAuthor(group, userId);
+        GroupPasswordResponse response = groupValidator.checkGroupPassword(request, group.getPassword());
+        return response;
     }
 }

--- a/src/main/java/com/dnd/moddo/domain/group/service/CommandGroupService.java
+++ b/src/main/java/com/dnd/moddo/domain/group/service/CommandGroupService.java
@@ -35,7 +35,7 @@ public class CommandGroupService {
         return GroupResponse.of(group);
     }
 
-    public GroupPasswordResponse verifyPassword(Long groupId, Long userId, GroupPasswordRequest request) {
+    public GroupPasswordResponse isPasswordMatch(Long groupId, Long userId, GroupPasswordRequest request) {
         Group group = groupReader.read(groupId);
         groupValidator.checkGroupAuthor(group, userId);
         GroupPasswordResponse response = groupValidator.checkGroupPassword(request, group.getPassword());

--- a/src/main/java/com/dnd/moddo/domain/group/service/QueryGroupService.java
+++ b/src/main/java/com/dnd/moddo/domain/group/service/QueryGroupService.java
@@ -1,6 +1,8 @@
 package com.dnd.moddo.domain.group.service;
 
+import com.dnd.moddo.domain.group.dto.request.GroupPasswordRequest;
 import com.dnd.moddo.domain.group.dto.response.GroupDetailResponse;
+import com.dnd.moddo.domain.group.dto.response.GroupPasswordResponse;
 import com.dnd.moddo.domain.group.entity.Group;
 import com.dnd.moddo.domain.group.service.implementation.GroupReader;
 import com.dnd.moddo.domain.group.service.implementation.GroupValidator;

--- a/src/main/java/com/dnd/moddo/domain/group/service/implementation/GroupValidator.java
+++ b/src/main/java/com/dnd/moddo/domain/group/service/implementation/GroupValidator.java
@@ -1,14 +1,36 @@
 package com.dnd.moddo.domain.group.service.implementation;
 
+import com.dnd.moddo.domain.group.dto.request.GroupPasswordRequest;
+import com.dnd.moddo.domain.group.dto.response.GroupPasswordResponse;
 import com.dnd.moddo.domain.group.entity.Group;
 import com.dnd.moddo.domain.group.exception.GroupNotAuthorException;
+import com.dnd.moddo.domain.group.exception.InvalidPasswordException;
+import com.dnd.moddo.domain.group.repository.GroupRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
 public class GroupValidator {
+
+    private final PasswordEncoder passwordEncoder;
+
+    private final GroupRepository groupRepository;
+
     public void checkGroupAuthor(Group group, Long userId) {
         if (!group.isWriter(userId)) {
             throw new GroupNotAuthorException();
         }
+    }
+
+    public GroupPasswordResponse checkGroupPassword(GroupPasswordRequest groupPasswordRequest, String getPassword) {
+        boolean isMatch = passwordEncoder.matches(groupPasswordRequest.password(), getPassword);
+
+        if (!isMatch) {
+            throw new InvalidPasswordException();
+        }
+
+        return GroupPasswordResponse.from("확인되었습니다.");
     }
 }

--- a/src/test/java/com/dnd/moddo/domain/group/service/CommandGroupServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/group/service/CommandGroupServiceTest.java
@@ -107,7 +107,7 @@ class CommandGroupServiceTest {
         when(groupValidator.checkGroupPassword(request, group.getPassword())).thenReturn(expectedResponse);
 
         // When
-        GroupPasswordResponse response = commandGroupService.verifyPassword(group.getId(), 1L, request);
+        GroupPasswordResponse response = commandGroupService.isPasswordMatch(group.getId(), 1L, request);
 
         // Then
         assertThat(response).isNotNull();
@@ -133,7 +133,7 @@ class CommandGroupServiceTest {
                 .when(groupValidator).checkGroupPassword(request, storedPassword);
 
         // When & Then
-        assertThatThrownBy(() -> commandGroupService.verifyPassword(group.getId(), 1L, request))
+        assertThatThrownBy(() -> commandGroupService.isPasswordMatch(group.getId(), 1L, request))
                 .isInstanceOf(RuntimeException.class)
                 .hasMessageContaining("비밀번호가 일치하지 않습니다.");
 

--- a/src/test/java/com/dnd/moddo/domain/group/service/CommandGroupServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/group/service/CommandGroupServiceTest.java
@@ -1,7 +1,9 @@
 package com.dnd.moddo.domain.group.service;
 
 import com.dnd.moddo.domain.group.dto.request.GroupAccountRequest;
+import com.dnd.moddo.domain.group.dto.request.GroupPasswordRequest;
 import com.dnd.moddo.domain.group.dto.request.GroupRequest;
+import com.dnd.moddo.domain.group.dto.response.GroupPasswordResponse;
 import com.dnd.moddo.domain.group.dto.response.GroupResponse;
 import com.dnd.moddo.domain.group.entity.Group;
 import com.dnd.moddo.domain.group.service.implementation.GroupCreator;
@@ -20,6 +22,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.time.LocalDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.*;
@@ -45,7 +48,7 @@ class CommandGroupServiceTest {
     private GroupRequest groupRequest;
     private GroupResponse groupResponse;
     private GroupAccountRequest groupAccountRequest;
-    private Group updatedGroup;
+    private Group group;
     private GroupTokenResponse expectedResponse;
 
     @BeforeEach
@@ -55,7 +58,7 @@ class CommandGroupServiceTest {
         groupAccountRequest = new GroupAccountRequest("newBank", "5678-5678");
         expectedResponse = new GroupTokenResponse("group-token");
 
-        updatedGroup = mock(Group.class);
+        group = mock(Group.class);
     }
 
     @Test
@@ -78,17 +81,64 @@ class CommandGroupServiceTest {
     @DisplayName("그룹의 계좌 정보를 업데이트할 수 있다.")
     void updateGroupAccount() {
         // Given
-        when(groupReader.read(anyLong())).thenReturn(updatedGroup);
-        when(groupUpdater.updateAccount(any(GroupAccountRequest.class), anyLong())).thenReturn(updatedGroup);
+        when(groupReader.read(anyLong())).thenReturn(group);
+        when(groupUpdater.updateAccount(any(GroupAccountRequest.class), anyLong())).thenReturn(group);
         doNothing().when(groupValidator).checkGroupAuthor(any(Group.class), anyLong());
 
         // When
-        GroupResponse result = commandGroupService.updateAccount(groupAccountRequest, updatedGroup.getWriter(), updatedGroup.getId());
+        GroupResponse result = commandGroupService.updateAccount(groupAccountRequest, group.getWriter(), group.getId());
 
         // Then
         assertThat(result).isNotNull();
         verify(groupReader, times(1)).read(anyLong());
         verify(groupValidator, times(1)).checkGroupAuthor(any(Group.class), anyLong());
         verify(groupUpdater, times(1)).updateAccount(any(GroupAccountRequest.class), anyLong());
+    }
+
+    @Test
+    @DisplayName("올바른 비밀번호를 입력하면 확인 메시지를 반환한다.")
+    void VerifyPassword_Success() {
+        // Given
+        GroupPasswordRequest request = new GroupPasswordRequest("correctPassword");
+        GroupPasswordResponse expectedResponse = GroupPasswordResponse.from("확인되었습니다.");
+
+        when(groupReader.read(group.getId())).thenReturn(group);
+        doNothing().when(groupValidator).checkGroupAuthor(group, 1L);
+        when(groupValidator.checkGroupPassword(request, group.getPassword())).thenReturn(expectedResponse);
+
+        // When
+        GroupPasswordResponse response = commandGroupService.verifyPassword(group.getId(), 1L, request);
+
+        // Then
+        assertThat(response).isNotNull();
+        assertThat(response.status()).isEqualTo("확인되었습니다.");
+
+        verify(groupReader, times(1)).read(group.getId());
+        verify(groupValidator, times(1)).checkGroupAuthor(group, 1L);
+        verify(groupValidator, times(1)).checkGroupPassword(request, group.getPassword());
+    }
+
+    @Test
+    @DisplayName("잘못된 비밀번호를 입력하면 예외가 발생한다.")
+    void VerifyPassword_Fail_WrongPassword() {
+        // Given
+        GroupPasswordRequest request = new GroupPasswordRequest("wrongPassword");
+        String storedPassword = "correctPassword";
+
+        when(groupReader.read(group.getId())).thenReturn(group);
+        doNothing().when(groupValidator).checkGroupAuthor(group, 1L);
+        when(group.getPassword()).thenReturn(storedPassword);
+
+        doThrow(new RuntimeException("비밀번호가 일치하지 않습니다."))
+                .when(groupValidator).checkGroupPassword(request, storedPassword);
+
+        // When & Then
+        assertThatThrownBy(() -> commandGroupService.verifyPassword(group.getId(), 1L, request))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("비밀번호가 일치하지 않습니다.");
+
+        verify(groupReader, times(1)).read(group.getId());
+        verify(groupValidator, times(1)).checkGroupAuthor(group, 1L);
+        verify(groupValidator, times(1)).checkGroupPassword(request, storedPassword);
     }
 }

--- a/src/test/java/com/dnd/moddo/domain/group/service/QueryGroupServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/group/service/QueryGroupServiceTest.java
@@ -7,6 +7,8 @@ import static org.springframework.test.util.ReflectionTestUtils.*;
 
 import java.util.List;
 
+import com.dnd.moddo.domain.group.dto.request.GroupPasswordRequest;
+import com.dnd.moddo.domain.group.dto.response.GroupPasswordResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -48,7 +50,7 @@ class QueryGroupServiceTest {
 
 	@Test
 	@DisplayName("그룹 상세 정보를 정상적으로 조회할 수 있다.")
-	void testFindOne_Success() {
+	void FindOne_Success() {
 		// Given
 		when(groupReader.read(anyLong())).thenReturn(group);
 		when(groupReader.findByGroup(group.getId())).thenReturn(List.of(groupMember));
@@ -71,7 +73,7 @@ class QueryGroupServiceTest {
 
 	@Test
 	@DisplayName("그룹 작성자가 아닐 경우 예외가 발생한다.")
-	void testFindOne_Failure_WhenNotGroupAuthor() {
+	void FindOne_Failure_WhenNotGroupAuthor() {
 		// Given
 		when(groupReader.read(anyLong())).thenReturn(group);
 		doThrow(new RuntimeException("Not an author")).when(groupValidator).checkGroupAuthor(group, 2L);
@@ -87,7 +89,7 @@ class QueryGroupServiceTest {
 
 	@Test
 	@DisplayName("그룹을 찾을 수 없을 경우 예외가 발생한다.")
-	void testFindOne_Failure_WhenGroupNotFound() {
+	void FindOne_Failure_WhenGroupNotFound() {
 		// Given
 		when(groupReader.read(anyLong())).thenThrow(new RuntimeException("Group not found"));
 

--- a/src/test/java/com/dnd/moddo/domain/group/service/implementation/GroupValidatorTest.java
+++ b/src/test/java/com/dnd/moddo/domain/group/service/implementation/GroupValidatorTest.java
@@ -1,17 +1,35 @@
 package com.dnd.moddo.domain.group.service.implementation;
 
+import com.dnd.moddo.domain.group.dto.request.GroupPasswordRequest;
+import com.dnd.moddo.domain.group.dto.response.GroupPasswordResponse;
 import com.dnd.moddo.domain.group.entity.Group;
 import com.dnd.moddo.domain.group.exception.GroupNotAuthorException;
+import com.dnd.moddo.domain.group.exception.InvalidPasswordException;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class GroupValidatorTest {
 
-    private final GroupValidator groupValidator = new GroupValidator();
+    private GroupValidator groupValidator;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        groupValidator = new GroupValidator(passwordEncoder, null); // GroupRepository는 필요 없으면 null 처리
+    }
 
     @Test
     @DisplayName("그룹 작성자와 요청 사용자가 같으면 예외가 발생하지 않는다.")
@@ -35,5 +53,37 @@ class GroupValidatorTest {
         // When & Then
         assertThatThrownBy(() -> groupValidator.checkGroupAuthor(group, writer))
                 .isInstanceOf(GroupNotAuthorException.class);
+    }
+
+    @Test
+    @DisplayName("올바른 비밀번호를 입력하면 확인 메시지를 반환한다.")
+    void checkGroupPassword_Success() {
+        // Given
+        String rawPassword = "correctPassword";
+        String encodedPassword = "$2a$10$WzHqXjA4oH8lTxH9m6Q7se1k2dG0B1h7U4Fv0t5y8LdHwWx7uy6MS";
+        GroupPasswordRequest request = new GroupPasswordRequest(rawPassword);
+
+        when(passwordEncoder.matches(rawPassword, encodedPassword)).thenReturn(true);
+
+        // When
+        GroupPasswordResponse response = groupValidator.checkGroupPassword(request, encodedPassword);
+
+        // Then
+        assertThat(response.status()).isEqualTo("확인되었습니다.");
+    }
+
+    @Test
+    @DisplayName("잘못된 비밀번호를 입력하면 InvalidPasswordException 예외가 발생한다.")
+    void checkGroupPassword_Fail() {
+        // Given
+        String rawPassword = "wrongPassword";
+        String encodedPassword = "$2a$10$WzHqXjA4oH8lTxH9m6Q7se1k2dG0B1h7U4Fv0t5y8LdHwWx7uy6MS";
+        GroupPasswordRequest request = new GroupPasswordRequest(rawPassword);
+
+        when(passwordEncoder.matches(rawPassword, encodedPassword)).thenReturn(false);
+
+        // When & Then
+        assertThatThrownBy(() -> groupValidator.checkGroupPassword(request, encodedPassword))
+                .isInstanceOf(InvalidPasswordException.class);
     }
 }


### PR DESCRIPTION
### #️⃣연관된 이슈
#65 

### 🔀반영 브랜치
feat/#65-password-validate -> develop

### 🔧변경 사항
- `GroupContoller`와 `CommandGroupService`에서 `verifyPassword`를 구현했습니다.
- `GroupVailldator`에서 비밀번호 검증 `checkGroupPassword`를 구현했습니다.

### 💬리뷰 요구사항(선택)
`verifyPassword` 말고 더 좋은 네이밍이 있을까요?
