### PR TITLE
캐릭터 확률에 따른 랜덤 배정

### DIFF
--- a/src/main/java/com/dnd/moddo/domain/image/controller/ImageController.java
+++ b/src/main/java/com/dnd/moddo/domain/image/controller/ImageController.java
@@ -1,8 +1,10 @@
 package com.dnd.moddo.domain.image.controller;
 
+import com.dnd.moddo.domain.image.dto.CharacterResponse;
 import com.dnd.moddo.domain.image.dto.ImageResponse;
 import com.dnd.moddo.domain.image.dto.TempImageResponse;
 import com.dnd.moddo.domain.image.service.CommandImageService;
+import com.dnd.moddo.domain.image.service.QueryImageService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -16,6 +18,8 @@ import java.util.List;
 public class ImageController {
     private final CommandImageService commandImageService;
 
+    private final QueryImageService queryImageService;
+
     @PostMapping("/temp")
     public ResponseEntity<TempImageResponse> saveTempImage(@RequestParam("file") List<MultipartFile> files) {
         TempImageResponse uniqueKey = commandImageService.uploadTempImage(files);
@@ -26,6 +30,12 @@ public class ImageController {
     public ResponseEntity<ImageResponse> updateImage(@RequestParam("uniqueKey") List<String> uniqueKeys) {
         ImageResponse finalImagePath = commandImageService.uploadFinalImage(uniqueKeys);
         return ResponseEntity.ok(finalImagePath);
+    }
+
+    @GetMapping("/character")
+    public ResponseEntity<CharacterResponse> getRandomCharacter() {
+        CharacterResponse character = queryImageService.getCharacter();
+        return ResponseEntity.ok(character);
     }
 }
 

--- a/src/main/java/com/dnd/moddo/domain/image/dto/CharacterResponse.java
+++ b/src/main/java/com/dnd/moddo/domain/image/dto/CharacterResponse.java
@@ -1,12 +1,29 @@
 package com.dnd.moddo.domain.image.dto;
 
+import com.dnd.moddo.domain.image.entity.type.Character;
+import com.dnd.moddo.global.config.S3Bucket;
+
 public record CharacterResponse(
         String name,
         String rarity,
         String imageUrl,
         String imageBigUrl
 ) {
-    public static CharacterResponse of(String name, String rarity, String imageUrl, String imageBigUrl) {
-        return new CharacterResponse(name, rarity, imageUrl, imageBigUrl);
+    public static CharacterResponse of(Character character, S3Bucket s3Bucket) {
+        String rarityString = String.valueOf(character.getRarity());
+        return new CharacterResponse(
+                character.getName(),
+                rarityString,
+                getImageUrl(s3Bucket, character.getName(), character.getRarity()),
+                getBigImageUrl(s3Bucket, character.getName(), character.getRarity())
+        );
+    }
+
+    private static String getImageUrl(S3Bucket s3Bucket, String name, int rarity) {
+        return s3Bucket.getS3Url() + "/images/" + rarity + "/" + name + ".png";
+    }
+
+    private static String getBigImageUrl(S3Bucket s3Bucket, String name, int rarity) {
+        return s3Bucket.getS3Url() + "/images/big/" + rarity + "/" + name + ".png";
     }
 }

--- a/src/main/java/com/dnd/moddo/domain/image/dto/CharacterResponse.java
+++ b/src/main/java/com/dnd/moddo/domain/image/dto/CharacterResponse.java
@@ -1,0 +1,12 @@
+package com.dnd.moddo.domain.image.dto;
+
+public record CharacterResponse(
+        String name,
+        String rarity,
+        String imageUrl,
+        String imageBigUrl
+) {
+    public static CharacterResponse of(String name, String rarity, String imageUrl, String imageBigUrl) {
+        return new CharacterResponse(name, rarity, imageUrl, imageBigUrl);
+    }
+}

--- a/src/main/java/com/dnd/moddo/domain/image/entity/type/Character.java
+++ b/src/main/java/com/dnd/moddo/domain/image/entity/type/Character.java
@@ -1,0 +1,27 @@
+package com.dnd.moddo.domain.image.entity.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public enum Character {
+    LUCKY(1, "lucky"),
+    ANGEL(2, "angel"),
+    STRAWBERRY(2, "strawberry"),
+    MAGIC(3, "magic"),
+    SLEEP(3, "sleep");
+
+    private final int rarity;
+    private final String name;
+
+    public static List<Character> getByRarity(int rarity) {
+        return Arrays.stream(values())
+                .filter(character -> character.getRarity() == rarity)
+                .toList();
+    }
+}

--- a/src/main/java/com/dnd/moddo/domain/image/exception/CharacterNotFoundException.java
+++ b/src/main/java/com/dnd/moddo/domain/image/exception/CharacterNotFoundException.java
@@ -1,0 +1,8 @@
+package com.dnd.moddo.domain.image.exception;
+
+import com.dnd.moddo.global.exception.ModdoException;
+import org.springframework.http.HttpStatus;
+
+public class CharacterNotFoundException extends ModdoException {
+    public CharacterNotFoundException() { super(HttpStatus.NOT_FOUND, "해당 캐릭터를 찾을 수 없습니다."); }
+}

--- a/src/main/java/com/dnd/moddo/domain/image/service/QueryImageService.java
+++ b/src/main/java/com/dnd/moddo/domain/image/service/QueryImageService.java
@@ -1,0 +1,17 @@
+package com.dnd.moddo.domain.image.service;
+
+import com.dnd.moddo.domain.image.dto.CharacterResponse;
+import com.dnd.moddo.domain.image.service.implementation.ImageReader;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class QueryImageService {
+
+    private final ImageReader imageReader;
+
+    public CharacterResponse getCharacter() {
+        return imageReader.getRandomCharacter();
+    }
+}

--- a/src/main/java/com/dnd/moddo/domain/image/service/implementation/ImageReader.java
+++ b/src/main/java/com/dnd/moddo/domain/image/service/implementation/ImageReader.java
@@ -1,0 +1,46 @@
+package com.dnd.moddo.domain.image.service.implementation;
+
+import com.dnd.moddo.domain.image.dto.CharacterResponse;
+import com.dnd.moddo.domain.image.entity.type.Character;
+import com.dnd.moddo.domain.image.exception.CharacterNotFoundException;
+import com.dnd.moddo.global.config.S3Bucket;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Random;
+
+@Service
+@RequiredArgsConstructor
+public class ImageReader {
+
+    private final S3Bucket s3Bucket;
+
+    public CharacterResponse getRandomCharacter() {
+        int rarity = getRandomRarity();
+        List<Character> characters = Character.getByRarity(rarity);
+
+        if (characters.isEmpty()) {
+            throw new CharacterNotFoundException();
+        }
+
+        Character character = characters.get(new Random().nextInt(characters.size()));
+
+        return CharacterResponse.of(character.getName(), String.valueOf(rarity), getImageUrl(character.getName(), rarity), getBigImageUrl(character.getName(), rarity));
+    }
+
+    private int getRandomRarity() {
+        int roll = new Random().nextInt(100);
+        if (roll < 60) return 1;
+        if (roll < 90) return 2;
+        return 3;
+    }
+
+    private String getImageUrl(String characterName, int rarity) {
+        return s3Bucket.getS3Url() + "character/" + characterName + "-" + rarity + ".png";
+    }
+
+    private String getBigImageUrl(String characterName, int rarity) {
+        return s3Bucket.getS3Url() + "character/" + characterName + "-" + rarity + "-big.png";
+    }
+}

--- a/src/main/java/com/dnd/moddo/domain/image/service/implementation/ImageReader.java
+++ b/src/main/java/com/dnd/moddo/domain/image/service/implementation/ImageReader.java
@@ -25,8 +25,7 @@ public class ImageReader {
         }
 
         Character character = characters.get(new Random().nextInt(characters.size()));
-
-        return CharacterResponse.of(character.getName(), String.valueOf(rarity), getImageUrl(character.getName(), rarity), getBigImageUrl(character.getName(), rarity));
+        return CharacterResponse.of(character, s3Bucket);
     }
 
     private int getRandomRarity() {
@@ -34,13 +33,5 @@ public class ImageReader {
         if (roll < 60) return 1;
         if (roll < 90) return 2;
         return 3;
-    }
-
-    private String getImageUrl(String characterName, int rarity) {
-        return s3Bucket.getS3Url() + "character/" + characterName + "-" + rarity + ".png";
-    }
-
-    private String getBigImageUrl(String characterName, int rarity) {
-        return s3Bucket.getS3Url() + "character/" + characterName + "-" + rarity + "-big.png";
     }
 }

--- a/src/test/java/com/dnd/moddo/domain/image/entity/type/CharacterTest.java
+++ b/src/test/java/com/dnd/moddo/domain/image/entity/type/CharacterTest.java
@@ -1,0 +1,38 @@
+package com.dnd.moddo.domain.image.entity.type;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class CharacterTest {
+
+    @Test
+    @DisplayName("rarity에 해당하는 캐릭터의 검증한다.")
+    void GetByRarity() {
+        // given
+        List<Character> result;
+
+        // when
+        result = Character.getByRarity(2);
+
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result).contains(Character.ANGEL, Character.STRAWBERRY);
+    }
+
+    @Test
+    @DisplayName("옳지않은 rarity일 경우 빈 리스트가 반환된다.")
+    void GetByRarity_isEmpty() {
+        // given
+        List<Character> result;
+
+        // when
+        result = Character.getByRarity(4);
+
+        // then
+        assertThat(result).isEmpty();
+    }
+}

--- a/src/test/java/com/dnd/moddo/domain/image/service/QueryImageServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/image/service/QueryImageServiceTest.java
@@ -1,0 +1,46 @@
+package com.dnd.moddo.domain.image.service;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.*;
+
+import com.dnd.moddo.domain.image.dto.CharacterResponse;
+import com.dnd.moddo.domain.image.service.implementation.ImageReader;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import com.dnd.moddo.domain.image.entity.type.Character;
+
+class QueryImageServiceTest {
+
+    @Mock
+    private ImageReader imageReader;
+
+    @InjectMocks
+    private QueryImageService queryImageService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void getCharacter() {
+        // given
+        Character character = Character.ANGEL;
+        CharacterResponse Response = new CharacterResponse(character.getName(), String.valueOf(character.getRarity()), "imgUrl", "bigImgUrl");
+
+        // when
+        when(imageReader.getRandomCharacter()).thenReturn(Response);
+        CharacterResponse result = queryImageService.getCharacter();
+
+        // then
+        assertThat(result.rarity()).isEqualTo(String.valueOf(character.getRarity()));
+        assertThat(result.name()).isEqualTo(character.getName());
+
+        // verify
+        verify(imageReader, times(1)).getRandomCharacter();
+    }
+}

--- a/src/test/java/com/dnd/moddo/domain/image/service/implementation/ImageReaderTest.java
+++ b/src/test/java/com/dnd/moddo/domain/image/service/implementation/ImageReaderTest.java
@@ -25,9 +25,6 @@ class ImageReaderTest {
     @Mock
     private S3Bucket s3Bucket;
 
-    @Mock
-    private Character character;
-
     @InjectMocks
     private ImageReader imageReader;
 
@@ -36,13 +33,15 @@ class ImageReaderTest {
     void getRandomCharacter() {
         // given
         int rarity = 1;
-        character = Character.LUCKY;
+        Character character = Character.LUCKY;
         List<Character> characterList = List.of(character);
 
         when(s3Bucket.getS3Url()).thenReturn("https://mock-s3-url.com/");
 
         try (MockedStatic<Character> mockedCharacter = mockStatic(Character.class)) {
             mockedCharacter.when(() -> Character.getByRarity(rarity)).thenReturn(characterList);
+
+            System.out.println("Mocked Character List: " + Character.getByRarity(rarity));
 
             // when
             CharacterResponse response = imageReader.getRandomCharacter();
@@ -55,6 +54,7 @@ class ImageReaderTest {
             assertThat(response.imageBigUrl()).contains(character.getName());
 
             verify(s3Bucket, times(2)).getS3Url();
+            mockedCharacter.verify(() -> Character.getByRarity(rarity), times(2));
         }
     }
 
@@ -67,9 +67,13 @@ class ImageReaderTest {
         try (MockedStatic<Character> mockedCharacter = mockStatic(Character.class)) {
             mockedCharacter.when(() -> Character.getByRarity(rarity)).thenReturn(List.of());
 
+            System.out.println("Mocked Empty: " + Character.getByRarity(rarity));
+
             // when & then
             assertThatThrownBy(() -> imageReader.getRandomCharacter())
                     .isInstanceOf(CharacterNotFoundException.class);
+
+            mockedCharacter.verify(() -> Character.getByRarity(rarity), times(1));
         }
     }
 }

--- a/src/test/java/com/dnd/moddo/domain/image/service/implementation/ImageReaderTest.java
+++ b/src/test/java/com/dnd/moddo/domain/image/service/implementation/ImageReaderTest.java
@@ -39,9 +39,8 @@ class ImageReaderTest {
         when(s3Bucket.getS3Url()).thenReturn("https://mock-s3-url.com/");
 
         try (MockedStatic<Character> mockedCharacter = mockStatic(Character.class)) {
-            mockedCharacter.when(() -> Character.getByRarity(rarity)).thenReturn(characterList);
 
-            System.out.println("Mocked Character List: " + Character.getByRarity(rarity));
+            mockedCharacter.when(() -> Character.getByRarity(rarity)).thenReturn(characterList);
 
             // when
             CharacterResponse response = imageReader.getRandomCharacter();
@@ -54,7 +53,7 @@ class ImageReaderTest {
             assertThat(response.imageBigUrl()).contains(character.getName());
 
             verify(s3Bucket, times(2)).getS3Url();
-            mockedCharacter.verify(() -> Character.getByRarity(rarity), times(2));
+            mockedCharacter.verify(() -> Character.getByRarity(rarity), times(1));
         }
     }
 
@@ -66,8 +65,6 @@ class ImageReaderTest {
 
         try (MockedStatic<Character> mockedCharacter = mockStatic(Character.class)) {
             mockedCharacter.when(() -> Character.getByRarity(rarity)).thenReturn(List.of());
-
-            System.out.println("Mocked Empty: " + Character.getByRarity(rarity));
 
             // when & then
             assertThatThrownBy(() -> imageReader.getRandomCharacter())

--- a/src/test/java/com/dnd/moddo/domain/image/service/implementation/ImageReaderTest.java
+++ b/src/test/java/com/dnd/moddo/domain/image/service/implementation/ImageReaderTest.java
@@ -1,0 +1,75 @@
+package com.dnd.moddo.domain.image.service.implementation;
+
+import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.dnd.moddo.domain.image.dto.CharacterResponse;
+import com.dnd.moddo.domain.image.entity.type.Character;
+import com.dnd.moddo.domain.image.exception.CharacterNotFoundException;
+import com.dnd.moddo.global.config.S3Bucket;
+
+@ExtendWith(MockitoExtension.class)
+class ImageReaderTest {
+
+    @Mock
+    private S3Bucket s3Bucket;
+
+    @Mock
+    private Character character;
+
+    @InjectMocks
+    private ImageReader imageReader;
+
+    @DisplayName("Character가 존재할 경우, 랜덤 캐릭터 정보와 이미지 URL을 반환한다.")
+    @Test
+    void getRandomCharacter() {
+        // given
+        int rarity = 1;
+        character = Character.LUCKY;
+        List<Character> characterList = List.of(character);
+
+        when(s3Bucket.getS3Url()).thenReturn("https://mock-s3-url.com/");
+
+        try (MockedStatic<Character> mockedCharacter = mockStatic(Character.class)) {
+            mockedCharacter.when(() -> Character.getByRarity(rarity)).thenReturn(characterList);
+
+            // when
+            CharacterResponse response = imageReader.getRandomCharacter();
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.name()).isEqualTo(character.getName());
+            assertThat(response.rarity()).isEqualTo(String.valueOf(rarity));
+            assertThat(response.imageUrl()).contains(character.getName());
+            assertThat(response.imageBigUrl()).contains(character.getName());
+
+            verify(s3Bucket, times(2)).getS3Url();
+        }
+    }
+
+    @DisplayName("Character가 존재하지 않으면 CharacterNotFoundException 예외를 발생시킨다.")
+    @Test
+    void getRandomCharacter_CharacterNotFoundException() {
+        // given
+        int rarity = 1;
+
+        try (MockedStatic<Character> mockedCharacter = mockStatic(Character.class)) {
+            mockedCharacter.when(() -> Character.getByRarity(rarity)).thenReturn(List.of());
+
+            // when & then
+            assertThatThrownBy(() -> imageReader.getRandomCharacter())
+                    .isInstanceOf(CharacterNotFoundException.class);
+        }
+    }
+}


### PR DESCRIPTION
### #️⃣연관된 이슈
#67 

### 🔀반영 브랜치
feat/#67-character-random -> develop

### 🔧변경 사항
- 캐릭터 확률을 다음과 같이 설정했습니다.
    - 1성 (⭐️): 60%
    - 2성(⭐️⭐️): 20%
    - 3성(⭐️⭐️⭐️): 10%
- S3에 `character/characterName-등급.png`로 저장 후, `enum`에서 캐릭터를 분류했습니다.
- S3에서 이미지를 랜덤으로 불러오기때문에 `find`보다 `get`을 사용했습니다.
- `getByRarity(int rarity)` 메소드를 통해 특정 희귀도에 해당하는 캐릭터 목록을 반환하게했습니다.
- `getRandomCharacter()` 메소드에서 랜덤으로 희귀도를 선택하고, 해당 희귀도에 맞는 캐릭터 목록에서 하나를 무작위로 선택하여 이미지 URL과 함께 반환합니다.

### 💬리뷰 요구사항(선택)
