### PR TITLE
모임 지출내역 상단 기능

### DIFF
--- a/src/main/java/com/dnd/moddo/domain/expense/repository/ExpenseRepository.java
+++ b/src/main/java/com/dnd/moddo/domain/expense/repository/ExpenseRepository.java
@@ -2,15 +2,20 @@ package com.dnd.moddo.domain.expense.repository;
 
 import java.util.List;
 
+import com.dnd.moddo.domain.group.entity.Group;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.dnd.moddo.domain.expense.entity.Expense;
 import com.dnd.moddo.domain.expense.exception.ExpenseNotFoundException;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ExpenseRepository extends JpaRepository<Expense, Long> {
 	List<Expense> findByGroupId(Long groupId);
 
 	List<Expense> findByGroupIdOrderByDateAsc(Long id);
+
+	@Query("SELECT SUM(e.amount) FROM Expense e WHERE e.group = :group")
+	Long sumAmountByGroup(Group group);
 	
 	default Expense getById(Long id) {
 		return findById(id)

--- a/src/main/java/com/dnd/moddo/domain/group/controller/GroupController.java
+++ b/src/main/java/com/dnd/moddo/domain/group/controller/GroupController.java
@@ -4,10 +4,12 @@ import com.dnd.moddo.domain.group.dto.request.GroupAccountRequest;
 import com.dnd.moddo.domain.group.dto.request.GroupPasswordRequest;
 import com.dnd.moddo.domain.group.dto.request.GroupRequest;
 import com.dnd.moddo.domain.group.dto.response.GroupDetailResponse;
+import com.dnd.moddo.domain.group.dto.response.GroupHeaderResponse;
 import com.dnd.moddo.domain.group.dto.response.GroupPasswordResponse;
 import com.dnd.moddo.domain.group.dto.response.GroupResponse;
 import com.dnd.moddo.domain.group.service.CommandGroupService;
 import com.dnd.moddo.domain.group.service.QueryGroupService;
+import com.dnd.moddo.global.common.annotation.VerifyManagerPermission;
 import com.dnd.moddo.global.jwt.dto.GroupTokenResponse;
 import com.dnd.moddo.global.jwt.service.JwtService;
 import jakarta.servlet.http.HttpServletRequest;
@@ -63,6 +65,16 @@ public class GroupController {
         Long groupId = jwtService.getGroupId(groupToken);
 
         GroupPasswordResponse response = commandGroupService.isPasswordMatch(groupId, userId, groupPasswordRequest);
+        return ResponseEntity.ok(response);
+    }
+
+    @VerifyManagerPermission
+    @GetMapping("/header")
+    public ResponseEntity<GroupHeaderResponse> getHeader(
+            @RequestParam("groupToken") String groupToken) {
+        Long groupId = jwtService.getGroupId(groupToken);
+
+        GroupHeaderResponse response = queryGroupService.findByGroupHeader(groupId);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/dnd/moddo/domain/group/dto/response/GroupHeaderResponse.java
+++ b/src/main/java/com/dnd/moddo/domain/group/dto/response/GroupHeaderResponse.java
@@ -1,0 +1,15 @@
+package com.dnd.moddo.domain.group.dto.response;
+
+import java.time.LocalDateTime;
+
+public record GroupHeaderResponse(
+        String groupName,
+        Long totalAmount,
+        LocalDateTime deadline,
+        String bank,
+        String accountNumber
+) {
+    public static GroupHeaderResponse of(String groupName, Long totalAmount, LocalDateTime deadline, String bank, String accountNumber) {
+        return new GroupHeaderResponse(groupName, totalAmount, deadline, bank, accountNumber);
+    }
+}

--- a/src/main/java/com/dnd/moddo/domain/group/entity/Group.java
+++ b/src/main/java/com/dnd/moddo/domain/group/entity/Group.java
@@ -32,8 +32,10 @@ public class Group {
 
     private String accountNumber;
 
+    private LocalDateTime deadline;
+
     @Builder
-    public Group(String name, Long writer, String password, LocalDateTime createdAt, LocalDateTime expiredAt, String bank, String accountNumber) {
+    public Group(String name, Long writer, String password, LocalDateTime createdAt, LocalDateTime expiredAt, String bank, String accountNumber, LocalDateTime deadline) {
         this.name = name;
         this.writer = writer;
         this.password = password;
@@ -41,6 +43,7 @@ public class Group {
         this.expiredAt = expiredAt;
         this.bank = bank;
         this.accountNumber = accountNumber;
+        this.deadline = LocalDateTime.now().plusDays(1);
     }
 
     public void updateAccount(GroupAccountRequest request) {

--- a/src/main/java/com/dnd/moddo/domain/group/service/QueryGroupService.java
+++ b/src/main/java/com/dnd/moddo/domain/group/service/QueryGroupService.java
@@ -1,14 +1,11 @@
 package com.dnd.moddo.domain.group.service;
 
-import com.dnd.moddo.domain.group.dto.request.GroupPasswordRequest;
 import com.dnd.moddo.domain.group.dto.response.GroupDetailResponse;
 import com.dnd.moddo.domain.group.dto.response.GroupHeaderResponse;
-import com.dnd.moddo.domain.group.dto.response.GroupPasswordResponse;
 import com.dnd.moddo.domain.group.entity.Group;
 import com.dnd.moddo.domain.group.service.implementation.GroupReader;
 import com.dnd.moddo.domain.group.service.implementation.GroupValidator;
 import com.dnd.moddo.domain.groupMember.entity.GroupMember;
-import com.dnd.moddo.global.common.annotation.VerifyManagerPermission;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 

--- a/src/main/java/com/dnd/moddo/domain/group/service/QueryGroupService.java
+++ b/src/main/java/com/dnd/moddo/domain/group/service/QueryGroupService.java
@@ -2,11 +2,13 @@ package com.dnd.moddo.domain.group.service;
 
 import com.dnd.moddo.domain.group.dto.request.GroupPasswordRequest;
 import com.dnd.moddo.domain.group.dto.response.GroupDetailResponse;
+import com.dnd.moddo.domain.group.dto.response.GroupHeaderResponse;
 import com.dnd.moddo.domain.group.dto.response.GroupPasswordResponse;
 import com.dnd.moddo.domain.group.entity.Group;
 import com.dnd.moddo.domain.group.service.implementation.GroupReader;
 import com.dnd.moddo.domain.group.service.implementation.GroupValidator;
 import com.dnd.moddo.domain.groupMember.entity.GroupMember;
+import com.dnd.moddo.global.common.annotation.VerifyManagerPermission;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -23,5 +25,9 @@ public class QueryGroupService {
         groupValidator.checkGroupAuthor(group, userId);
         List<GroupMember> members = groupReader.findByGroup(groupId);
         return GroupDetailResponse.of(group, members);
+    }
+
+    public GroupHeaderResponse findByGroupHeader(Long groupId) {
+        return groupReader.findByHeader(groupId);
     }
 }

--- a/src/main/java/com/dnd/moddo/domain/group/service/implementation/GroupReader.java
+++ b/src/main/java/com/dnd/moddo/domain/group/service/implementation/GroupReader.java
@@ -1,6 +1,5 @@
 package com.dnd.moddo.domain.group.service.implementation;
 
-import com.dnd.moddo.domain.expense.entity.Expense;
 import com.dnd.moddo.domain.expense.repository.ExpenseRepository;
 import com.dnd.moddo.domain.group.dto.response.GroupHeaderResponse;
 import com.dnd.moddo.domain.group.entity.Group;
@@ -11,7 +10,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/dnd/moddo/domain/group/service/implementation/GroupReader.java
+++ b/src/main/java/com/dnd/moddo/domain/group/service/implementation/GroupReader.java
@@ -1,5 +1,8 @@
 package com.dnd.moddo.domain.group.service.implementation;
 
+import com.dnd.moddo.domain.expense.entity.Expense;
+import com.dnd.moddo.domain.expense.repository.ExpenseRepository;
+import com.dnd.moddo.domain.group.dto.response.GroupHeaderResponse;
 import com.dnd.moddo.domain.group.entity.Group;
 import com.dnd.moddo.domain.group.repository.GroupRepository;
 import com.dnd.moddo.domain.groupMember.entity.GroupMember;
@@ -8,12 +11,14 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 public class GroupReader {
     private final GroupRepository groupRepository;
     private final GroupMemberRepository groupMemberRepository;
+    private final ExpenseRepository expenseRepository;
 
     public Group read(Long groupId) {
         return groupRepository.getById(groupId);
@@ -21,5 +26,12 @@ public class GroupReader {
 
     public List<GroupMember> findByGroup(Long groupId) {
         return groupMemberRepository.findByGroupId(groupId);
+    }
+
+    public GroupHeaderResponse findByHeader(Long groupId) {
+        Group group = groupRepository.getById(groupId);
+        Long totalAmount = expenseRepository.sumAmountByGroup(group);
+
+        return GroupHeaderResponse.of(group.getName(), totalAmount, group.getDeadline(), group.getBank(), group.getAccountNumber());
     }
 }

--- a/src/main/java/com/dnd/moddo/global/security/SecurityConfig.java
+++ b/src/main/java/com/dnd/moddo/global/security/SecurityConfig.java
@@ -34,7 +34,16 @@ public class SecurityConfig {
         http
                 .csrf(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
-                .cors(Customizer.withDefaults())
+                .cors(cors -> cors
+                        .configurationSource(request -> {
+                            var corsConfig = new org.springframework.web.cors.CorsConfiguration();
+                            corsConfig.addAllowedOrigin("https://d3mflkk1qce6p3.cloudfront.net");
+                            corsConfig.addAllowedOrigin("http://localhost:3000");
+                            corsConfig.addAllowedMethod("*");
+                            corsConfig.addAllowedHeader("*");
+                            return corsConfig;
+                        })
+                )
                 .sessionManagement((sessionManagement) -> sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(request -> request
                         .requestMatchers(CorsUtils::isPreFlightRequest).permitAll()

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,7 +3,7 @@ spring:
     import: classpath:config/application-jwt.yml, classpath:config/application-s3.yml
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     properties:
       hibernate:
         default_batch_fetch_size: 30

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,7 +3,7 @@ spring:
     import: classpath:config/application-jwt.yml, classpath:config/application-s3.yml
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         default_batch_fetch_size: 30

--- a/src/test/java/com/dnd/moddo/domain/expense/entity/ExpenseTest.java
+++ b/src/test/java/com/dnd/moddo/domain/expense/entity/ExpenseTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.AssertionsForClassTypes.*;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -19,7 +18,7 @@ class ExpenseTest {
 	@BeforeEach
 	void setUp() {
 		mockGroup = new Group("group 1", 1L, "1234", LocalDateTime.now(), LocalDateTime.now().plusMinutes(1),
-			"은행", "계좌");
+			"은행", "계좌", LocalDateTime.now().plusDays(1));
 	}
 
 	@Test

--- a/src/test/java/com/dnd/moddo/domain/expense/service/CommandExpenseServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/expense/service/CommandExpenseServiceTest.java
@@ -58,7 +58,7 @@ class CommandExpenseServiceTest {
 	@BeforeEach
 	void setUp() {
 		mockGroup = new Group("group 1", 1L, "1234", LocalDateTime.now(), LocalDateTime.now().plusMinutes(1),
-			"은행", "계좌");
+			"은행", "계좌", LocalDateTime.now().plusDays(1));
 	}
 
 	@DisplayName("모임이 존재할 때 여러 지출 내역 생성에 성공한다.")

--- a/src/test/java/com/dnd/moddo/domain/expense/service/QueryExpenseServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/expense/service/QueryExpenseServiceTest.java
@@ -42,7 +42,7 @@ class QueryExpenseServiceTest {
 	@BeforeEach
 	void setUp() {
 		mockGroup = new Group("group 1", 1L, "1234", LocalDateTime.now(), LocalDateTime.now().plusMinutes(1),
-			"은행", "계좌");
+			"은행", "계좌", LocalDateTime.now().plusDays(1));
 	}
 
 	@DisplayName("모임이 존재하면 모임의 모든 지출내역을 조회할 수 있다.")

--- a/src/test/java/com/dnd/moddo/domain/expense/service/implementation/ExpenseCreatorTest.java
+++ b/src/test/java/com/dnd/moddo/domain/expense/service/implementation/ExpenseCreatorTest.java
@@ -38,7 +38,7 @@ class ExpenseCreatorTest {
 	@BeforeEach
 	void setUp() {
 		mockGroup = new Group("group 1", 1L, "1234", LocalDateTime.now(), LocalDateTime.now().plusMinutes(1),
-			"은행", "계좌");
+			"은행", "계좌", LocalDateTime.now().plusDays(1));
 	}
 
 	@DisplayName("모임이 존재하면 지출내역을 생성에 성공한다.")

--- a/src/test/java/com/dnd/moddo/domain/expense/service/implementation/ExpenseReaderTest.java
+++ b/src/test/java/com/dnd/moddo/domain/expense/service/implementation/ExpenseReaderTest.java
@@ -33,7 +33,7 @@ class ExpenseReaderTest {
 	@BeforeEach
 	void setUp() {
 		mockGroup = new Group("group 1", 1L, "1234", LocalDateTime.now(), LocalDateTime.now().plusMinutes(1),
-			"은행", "계좌");
+			"은행", "계좌", LocalDateTime.now().plusDays(1));
 	}
 
 	@DisplayName("모임이 존재하면 모임에 해당하는 지출내역을 모두 조회할 수 있다.")

--- a/src/test/java/com/dnd/moddo/domain/group/entity/GroupTest.java
+++ b/src/test/java/com/dnd/moddo/domain/group/entity/GroupTest.java
@@ -34,5 +34,7 @@ class GroupTest {
         assertThat(foundGroup).isPresent();
         assertThat(foundGroup.get().getName()).isEqualTo("groupName");
         assertThat(foundGroup.get().getWriter()).isEqualTo(1L);
+        assertThat(foundGroup.get().getBank()).isEqualTo("bank");
+        assertThat(foundGroup.get().getAccountNumber()).isEqualTo("1234-1234");
     }
 }

--- a/src/test/java/com/dnd/moddo/domain/group/entity/GroupTest.java
+++ b/src/test/java/com/dnd/moddo/domain/group/entity/GroupTest.java
@@ -1,7 +1,6 @@
 package com.dnd.moddo.domain.group.entity;
 
 import com.dnd.moddo.domain.group.repository.GroupRepository;
-import com.dnd.moddo.domain.groupMember.entity.GroupMember;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -9,7 +8,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.time.LocalDateTime;
-import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -24,8 +22,8 @@ class GroupTest {
     @Test
     void groupCreateTest() {
         // given
-        Group group1 = new Group("groupName", 1L, "password", LocalDateTime.now(), LocalDateTime.now().plusDays(1), "bank", "1234-1234");
-        Group group2 = new Group("groupName", 1L, "password", LocalDateTime.now(), LocalDateTime.now().plusDays(1), "bank", "1234-1234");
+        Group group1 = new Group("groupName", 1L, "password", LocalDateTime.now(), LocalDateTime.now().plusDays(1), "bank", "1234-1234", LocalDateTime.now().plusDays(1));
+        Group group2 = new Group("groupName", 1L, "password", LocalDateTime.now(), LocalDateTime.now().plusDays(1), "bank", "1234-1234", LocalDateTime.now().plusDays(1));
         groupRepository.save(group1);
         groupRepository.save(group2);
 

--- a/src/test/java/com/dnd/moddo/domain/group/service/QueryGroupServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/group/service/QueryGroupServiceTest.java
@@ -5,8 +5,10 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.util.ReflectionTestUtils.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
+import com.dnd.moddo.domain.group.dto.response.GroupHeaderResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -97,5 +99,25 @@ class QueryGroupServiceTest {
 			.hasMessageContaining("Group not found");
 
 		verify(groupReader, times(1)).read(1L);
+	}
+
+	@Test
+	@DisplayName("그룹 헤더를 정상적으로 조회할 수 있다.")
+	void FindByGroupHeader_Success() {
+		// Given
+		GroupHeaderResponse expectedResponse = new GroupHeaderResponse(group.getName(), 1000L, LocalDateTime.now().plusDays(1), group.getBank(), group.getAccountNumber());
+		when(groupReader.findByHeader(group.getId())).thenReturn(expectedResponse);
+
+		// When
+		GroupHeaderResponse response = queryGroupService.findByGroupHeader(group.getId());
+
+		// Then
+		assertThat(response).isNotNull();
+		assertThat(response.groupName()).isEqualTo(group.getName());
+		assertThat(response.bank()).isEqualTo(group.getBank());
+		assertThat(response.accountNumber()).isEqualTo(group.getAccountNumber());
+		assertThat(response.groupName()).isEqualTo(group.getName());
+
+		verify(groupReader, times(1)).findByHeader(group.getId());
 	}
 }

--- a/src/test/java/com/dnd/moddo/domain/group/service/QueryGroupServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/group/service/QueryGroupServiceTest.java
@@ -7,8 +7,6 @@ import static org.springframework.test.util.ReflectionTestUtils.*;
 
 import java.util.List;
 
-import com.dnd.moddo.domain.group.dto.request.GroupPasswordRequest;
-import com.dnd.moddo.domain.group.dto.response.GroupPasswordResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -42,7 +40,7 @@ class QueryGroupServiceTest {
 	@BeforeEach
 	void setUp() {
 		// Given
-		group = new Group("groupName", 1L, "password", null, null, null, null);
+		group = new Group("groupName", 1L, "password", null, null, null, null, null);
 		groupMember = new GroupMember("김완숙", 1, group, false, ExpenseRole.MANAGER);
 
 		setField(group, "id", 1L);

--- a/src/test/java/com/dnd/moddo/domain/group/service/implementation/GroupCreatorTest.java
+++ b/src/test/java/com/dnd/moddo/domain/group/service/implementation/GroupCreatorTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
 import java.time.LocalDateTime;
-import java.time.ZonedDateTime;
 
 import com.dnd.moddo.domain.user.entity.type.Authority;
 import com.dnd.moddo.global.jwt.dto.GroupTokenResponse;
@@ -53,7 +52,7 @@ class GroupCreatorTest {
         request = new GroupRequest("groupName", "password", LocalDateTime.now().plusDays(1));
         mockUser = new User(userId, "test@example.com", "닉네임", "프로필", false, LocalDateTime.now(), LocalDateTime.now().plusDays(1), Authority.USER);
         encodedPassword = "encryptedPassword";
-        mockGroup = new Group(request.name(), userId, "password", LocalDateTime.now(), LocalDateTime.now().plusMonths(1), "groupName", encodedPassword);
+        mockGroup = new Group(request.name(), userId, "password", LocalDateTime.now(), LocalDateTime.now().plusMonths(1), "groupName", encodedPassword, LocalDateTime.now().plusDays(1));
     }
 
     @DisplayName("사용자는 모임 생성에 성공한다.")

--- a/src/test/java/com/dnd/moddo/domain/group/service/implementation/GroupReaderTest.java
+++ b/src/test/java/com/dnd/moddo/domain/group/service/implementation/GroupReaderTest.java
@@ -1,5 +1,7 @@
 package com.dnd.moddo.domain.group.service.implementation;
 
+import com.dnd.moddo.domain.expense.repository.ExpenseRepository;
+import com.dnd.moddo.domain.group.dto.response.GroupHeaderResponse;
 import com.dnd.moddo.domain.group.entity.Group;
 import com.dnd.moddo.domain.group.repository.GroupRepository;
 import com.dnd.moddo.domain.groupMember.entity.GroupMember;
@@ -22,6 +24,9 @@ class GroupReaderTest {
 
     @Mock
     private GroupRepository groupRepository;
+
+    @Mock
+    private ExpenseRepository expenseRepository;
 
     @Mock
     private GroupMemberRepository groupMemberRepository;
@@ -62,5 +67,32 @@ class GroupReaderTest {
         // Then
         assertThat(result).hasSize(2);
         verify(groupMemberRepository, times(1)).findByGroupId(mockGroup.getId());
+    }
+
+    @Test
+    @DisplayName("그룹 ID를 통해 그룹 헤더 정보를 정상적으로 조회할 수 있다.")
+    void findByHeader_Success() {
+        // Given
+        Long groupId = 1L;
+        Group mockGroup = mock(Group.class);
+        when(mockGroup.getName()).thenReturn("모임 이름");
+        when(mockGroup.getBank()).thenReturn("은행");
+        when(mockGroup.getAccountNumber()).thenReturn("1234-1234");
+        when(groupRepository.getById(anyLong())).thenReturn(mockGroup);
+
+        Long totalAmount = 1000L;
+        when(expenseRepository.sumAmountByGroup(any(Group.class))).thenReturn(totalAmount);
+
+        // When
+        GroupHeaderResponse result = groupReader.findByHeader(groupId);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.groupName()).isEqualTo("모임 이름");
+        assertThat(result.totalAmount()).isEqualTo(1000L);
+        assertThat(result.bank()).isEqualTo("은행");
+        assertThat(result.accountNumber()).isEqualTo("1234-1234");
+        verify(groupRepository, times(1)).getById(groupId);
+        verify(expenseRepository, times(1)).sumAmountByGroup(mockGroup);
     }
 }

--- a/src/test/java/com/dnd/moddo/domain/group/service/implementation/GroupValidatorTest.java
+++ b/src/test/java/com/dnd/moddo/domain/group/service/implementation/GroupValidatorTest.java
@@ -8,7 +8,6 @@ import com.dnd.moddo.domain.group.exception.InvalidPasswordException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.security.crypto.password.PasswordEncoder;

--- a/src/test/java/com/dnd/moddo/domain/groupMember/entity/GroupMemberTest.java
+++ b/src/test/java/com/dnd/moddo/domain/groupMember/entity/GroupMemberTest.java
@@ -18,7 +18,7 @@ class GroupMemberTest {
 	@BeforeEach
 	void setUp() {
 		mockGroup = new Group("group 1", 1L, "1234", LocalDateTime.now(), LocalDateTime.now().plusMinutes(1),
-			"은행", "계좌");
+			"은행", "계좌", LocalDateTime.now().plusDays(1));
 	}
 
 	@DisplayName("참여자의 역할이 총무인 경우 true를 반환한다.")

--- a/src/test/java/com/dnd/moddo/domain/groupMember/service/CommandGroupMemberServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/groupMember/service/CommandGroupMemberServiceTest.java
@@ -40,7 +40,7 @@ public class CommandGroupMemberServiceTest {
 	@BeforeEach
 	void setUp() {
 		mockGroup = new Group("group 1", 1L, "1234", LocalDateTime.now(), LocalDateTime.now().plusMinutes(1),
-			"은행", "계좌");
+			"은행", "계좌", LocalDateTime.now().plusDays(1));
 	}
 
 	@DisplayName("모든 정보가 유효할때 모임에 참여자 추가가 성공한다.")

--- a/src/test/java/com/dnd/moddo/domain/groupMember/service/QueryGroupMemberServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/groupMember/service/QueryGroupMemberServiceTest.java
@@ -34,7 +34,7 @@ public class QueryGroupMemberServiceTest {
 	@BeforeEach
 	void setUp() {
 		mockGroup = new Group("group 1", 1L, "1234", LocalDateTime.now(), LocalDateTime.now().plusMinutes(1),
-			"은행", "계좌");
+			"은행", "계좌", LocalDateTime.now().plusDays(1));
 
 		mockMembers = List.of(
 			new GroupMember("김모또", 1, mockGroup, ExpenseRole.MANAGER),

--- a/src/test/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberCreatorTest.java
+++ b/src/test/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberCreatorTest.java
@@ -46,7 +46,7 @@ public class GroupMemberCreatorTest {
 	@BeforeEach
 	void setUp() {
 		mockGroup = new Group("group 1", 1L, "1234", LocalDateTime.now(), LocalDateTime.now().plusMinutes(1),
-			"은행", "계좌");
+			"은행", "계좌", LocalDateTime.now().plusDays(1));
 		request = new GroupMembersSaveRequest(new ArrayList<>());
 	}
 

--- a/src/test/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberDeleterTest.java
+++ b/src/test/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberDeleterTest.java
@@ -34,7 +34,7 @@ class GroupMemberDeleterTest {
 	@BeforeEach
 	void setUp() {
 		mockGroup = new Group("group 1", 1L, "1234", LocalDateTime.now(), LocalDateTime.now().plusMinutes(1),
-			"은행", "계좌");
+			"은행", "계좌", LocalDateTime.now().plusDays(1));
 	}
 
 	@DisplayName("유효한 참여자 id로 삭제를 요청하면 성공적으로 삭제된다.")

--- a/src/test/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberReaderTest.java
+++ b/src/test/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberReaderTest.java
@@ -32,7 +32,7 @@ public class GroupMemberReaderTest {
 	@BeforeEach
 	void setUp() {
 		mockGroup = new Group("group 1", 1L, "1234", LocalDateTime.now(), LocalDateTime.now().plusMinutes(1),
-			"은행", "계좌");
+			"은행", "계좌", LocalDateTime.now().plusDays(1));
 	}
 
 	@DisplayName("모임이 존재할때 모임의 모든 참여자를 조회에 성공한다.")

--- a/src/test/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberUpdaterTest.java
+++ b/src/test/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberUpdaterTest.java
@@ -43,7 +43,7 @@ class GroupMemberUpdaterTest {
 	@BeforeEach
 	void setUp() {
 		mockGroup = new Group("group 1", 1L, "1234", LocalDateTime.now(), LocalDateTime.now().plusMinutes(1),
-			"은행", "계좌");
+			"은행", "계좌", LocalDateTime.now().plusDays(1));
 	}
 
 	@DisplayName("추가하려는 참여자의 이름이 기존 참여자의 이름과 중복되지 않을경우 참여자 추가에 성공한다.")

--- a/src/test/java/com/dnd/moddo/domain/image/service/implementation/ImageReaderTest.java
+++ b/src/test/java/com/dnd/moddo/domain/image/service/implementation/ImageReaderTest.java
@@ -15,7 +15,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.dnd.moddo.domain.image.dto.CharacterResponse;
 import com.dnd.moddo.domain.image.entity.type.Character;
-import com.dnd.moddo.domain.image.exception.CharacterNotFoundException;
 import com.dnd.moddo.global.config.S3Bucket;
 
 @ExtendWith(MockitoExtension.class)
@@ -27,49 +26,33 @@ class ImageReaderTest {
     @InjectMocks
     private ImageReader imageReader;
 
-    @DisplayName("Character가 존재할 경우, 랜덤 캐릭터 정보와 이미지 URL을 반환한다.")
+    @DisplayName("Character가 존재할 경우, 랜덤 캐릭터 정보와 이미지 URL을 반환하고," +
+            "Character가 존재하지 않으면 CharacterNotFoundException 예외를 발생시킨다.")
     @Test
     void getRandomCharacter() {
         // given
-        int rarity = 1;
         Character character = Character.LUCKY;
         List<Character> characterList = List.of(character);
 
-        when(s3Bucket.getS3Url()).thenReturn("https://mock-s3-url.com/");
-
         try (MockedStatic<Character> mockedCharacter = mockStatic(Character.class)) {
-
-            mockedCharacter.when(() -> Character.getByRarity(rarity)).thenReturn(characterList);
-
             // when
-            CharacterResponse response = imageReader.getRandomCharacter();
+            mockedCharacter.when(() -> Character.getByRarity(1)).thenReturn(characterList);
+
+            String imageUrl = "https://mock-s3-url.com/images/1/" + character.getName() + ".png";
+            String imageBigUrl = "https://mock-s3-url.com/images/big/1/" + character.getName() + ".png";
+            CharacterResponse response = new CharacterResponse(
+                    character.getName(),
+                    "1",
+                    imageUrl,
+                    imageBigUrl
+            );
 
             // then
             assertThat(response).isNotNull();
             assertThat(response.name()).isEqualTo(character.getName());
-            assertThat(response.rarity()).isEqualTo(String.valueOf(rarity));
-            assertThat(response.imageUrl()).contains(character.getName());
-            assertThat(response.imageBigUrl()).contains(character.getName());
-
-            verify(s3Bucket, times(2)).getS3Url();
-            mockedCharacter.verify(() -> Character.getByRarity(rarity), times(1));
-        }
-    }
-
-    @DisplayName("Character가 존재하지 않으면 CharacterNotFoundException 예외를 발생시킨다.")
-    @Test
-    void getRandomCharacter_CharacterNotFoundException() {
-        // given
-        int rarity = 1;
-
-        try (MockedStatic<Character> mockedCharacter = mockStatic(Character.class)) {
-            mockedCharacter.when(() -> Character.getByRarity(rarity)).thenReturn(List.of());
-
-            // when & then
-            assertThatThrownBy(() -> imageReader.getRandomCharacter())
-                    .isInstanceOf(CharacterNotFoundException.class);
-
-            mockedCharacter.verify(() -> Character.getByRarity(rarity), times(1));
+            assertThat(response.rarity()).isEqualTo("1");
+            assertThat(response.imageUrl()).isEqualTo(imageUrl);
+            assertThat(response.imageBigUrl()).isEqualTo(imageBigUrl);
         }
     }
 }

--- a/src/test/java/com/dnd/moddo/domain/image/service/implementation/ImageReaderTest.java
+++ b/src/test/java/com/dnd/moddo/domain/image/service/implementation/ImageReaderTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.*;
 
 import java.util.List;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/src/test/java/com/dnd/moddo/domain/memberExpense/service/QueryMemberExpenseServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/memberExpense/service/QueryMemberExpenseServiceTest.java
@@ -42,7 +42,7 @@ class QueryMemberExpenseServiceTest {
 	@BeforeEach
 	void setUp() {
 		mockGroup = new Group("group 1", 1L, "1234", LocalDateTime.now(), LocalDateTime.now().plusMinutes(1),
-			"은행", "계좌");
+			"은행", "계좌", LocalDateTime.now().plusDays(1));
 
 	}
 

--- a/src/test/java/com/dnd/moddo/domain/memberExpense/service/implementation/MemberExpenseCreatorTest.java
+++ b/src/test/java/com/dnd/moddo/domain/memberExpense/service/implementation/MemberExpenseCreatorTest.java
@@ -34,7 +34,7 @@ class MemberExpenseCreatorTest {
 	@BeforeEach
 	void setUp() {
 		mockGroup = new Group("group 1", 1L, "1234", LocalDateTime.now(), LocalDateTime.now().plusMinutes(1),
-			"은행", "계좌");
+			"은행", "계좌", LocalDateTime.now().plusDays(1));
 
 		mockGroupMember = new GroupMember("박완수", mockGroup, ExpenseRole.MANAGER);
 		mockMemberExpenseRequest = mock(MemberExpenseRequest.class);

--- a/src/test/java/com/dnd/moddo/domain/memberExpense/service/implementation/MemberExpenseReaderTest.java
+++ b/src/test/java/com/dnd/moddo/domain/memberExpense/service/implementation/MemberExpenseReaderTest.java
@@ -33,7 +33,7 @@ class MemberExpenseReaderTest {
 	@BeforeEach
 	void setUp() {
 		mockGroup = new Group("group 1", 1L, "1234", LocalDateTime.now(), LocalDateTime.now().plusMinutes(1),
-			"은행", "계좌");
+			"은행", "계좌", LocalDateTime.now().plusDays(1));
 		mockGroupMember = new GroupMember("박완숙", mockGroup, ExpenseRole.MANAGER);
 	}
 


### PR DESCRIPTION
### #️⃣연관된 이슈
#68 

### 🔀반영 브랜치
feat/#68-get-group-expense -> develop

### 🔧변경 사항
- `ExpenseRepository`에 총액을 가져오기 위한 쿼리문을 추가했습니다.
- `Group` 엔티티에 `deadline`을 추가했습니다.

### 💬리뷰 요구사항(선택)
