### PR TITLE
모임 생성 후 총무 자동 생성 기능 추가

### DIFF
--- a/src/main/java/com/dnd/moddo/domain/group/controller/GroupController.java
+++ b/src/main/java/com/dnd/moddo/domain/group/controller/GroupController.java
@@ -1,5 +1,14 @@
 package com.dnd.moddo.domain.group.controller;
 
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
 import com.dnd.moddo.domain.group.dto.request.GroupAccountRequest;
 import com.dnd.moddo.domain.group.dto.request.GroupPasswordRequest;
 import com.dnd.moddo.domain.group.dto.request.GroupRequest;
@@ -7,74 +16,73 @@ import com.dnd.moddo.domain.group.dto.response.GroupDetailResponse;
 import com.dnd.moddo.domain.group.dto.response.GroupHeaderResponse;
 import com.dnd.moddo.domain.group.dto.response.GroupPasswordResponse;
 import com.dnd.moddo.domain.group.dto.response.GroupResponse;
+import com.dnd.moddo.domain.group.dto.response.GroupSaveResponse;
 import com.dnd.moddo.domain.group.service.CommandGroupService;
 import com.dnd.moddo.domain.group.service.QueryGroupService;
 import com.dnd.moddo.global.common.annotation.VerifyManagerPermission;
-import com.dnd.moddo.global.jwt.dto.GroupTokenResponse;
 import com.dnd.moddo.global.jwt.service.JwtService;
+
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/group")
 public class GroupController {
-    private final CommandGroupService commandGroupService;
-    private final JwtService jwtService;
-    private final QueryGroupService queryGroupService;
+	private final CommandGroupService commandGroupService;
+	private final JwtService jwtService;
+	private final QueryGroupService queryGroupService;
 
-    @PostMapping
-    public ResponseEntity<GroupTokenResponse> saveGroup(HttpServletRequest request, @RequestBody GroupRequest groupRequest) {
-        Long userId = jwtService.getUserId(request);
+	@PostMapping
+	public ResponseEntity<GroupSaveResponse> saveGroup(HttpServletRequest request,
+		@RequestBody GroupRequest groupRequest) {
+		Long userId = jwtService.getUserId(request);
+		GroupSaveResponse response = commandGroupService.createGroup(groupRequest, userId);
+		return ResponseEntity.ok(response);
+	}
 
-        GroupTokenResponse response = commandGroupService.createGroup(groupRequest, userId);
-        return ResponseEntity.ok(response);
-    }
+	@PutMapping("/account")
+	public ResponseEntity<GroupResponse> updateAccount(
+		HttpServletRequest request,
+		@RequestParam("groupToken") String groupToken,
+		@RequestBody GroupAccountRequest groupAccountRequest) {
+		Long userId = jwtService.getUserId(request);
+		Long groupId = jwtService.getGroupId(groupToken);
 
-    @PutMapping("/account")
-    public ResponseEntity<GroupResponse> updateAccount(
-            HttpServletRequest request,
-            @RequestParam("groupToken") String groupToken,
-            @RequestBody GroupAccountRequest groupAccountRequest) {
-        Long userId = jwtService.getUserId(request);
-        Long groupId = jwtService.getGroupId(groupToken);
+		GroupResponse response = commandGroupService.updateAccount(groupAccountRequest, userId, groupId);
+		return ResponseEntity.ok(response);
+	}
 
-        GroupResponse response = commandGroupService.updateAccount(groupAccountRequest, userId, groupId);
-        return ResponseEntity.ok(response);
-    }
+	@GetMapping
+	public ResponseEntity<GroupDetailResponse> getGroup(
+		HttpServletRequest request,
+		@RequestParam("groupToken") String groupToken) {
+		Long userId = jwtService.getUserId(request);
+		Long groupId = jwtService.getGroupId(groupToken);
 
-    @GetMapping
-    public ResponseEntity<GroupDetailResponse> getGroup(
-            HttpServletRequest request,
-            @RequestParam("groupToken") String groupToken) {
-        Long userId = jwtService.getUserId(request);
-        Long groupId = jwtService.getGroupId(groupToken);
+		GroupDetailResponse response = queryGroupService.findOne(groupId, userId);
+		return ResponseEntity.ok(response);
+	}
 
-        GroupDetailResponse response = queryGroupService.findOne(groupId, userId);
-        return ResponseEntity.ok(response);
-    }
+	@PostMapping("/password")
+	public ResponseEntity<GroupPasswordResponse> isPasswordMatch(
+		HttpServletRequest request,
+		@RequestParam("groupToken") String groupToken,
+		@RequestBody GroupPasswordRequest groupPasswordRequest) {
+		Long userId = jwtService.getUserId(request);
+		Long groupId = jwtService.getGroupId(groupToken);
 
-    @PostMapping("/password")
-    public ResponseEntity<GroupPasswordResponse> isPasswordMatch(
-            HttpServletRequest request,
-            @RequestParam("groupToken") String groupToken,
-            @RequestBody GroupPasswordRequest groupPasswordRequest) {
-        Long userId = jwtService.getUserId(request);
-        Long groupId = jwtService.getGroupId(groupToken);
+		GroupPasswordResponse response = commandGroupService.isPasswordMatch(groupId, userId, groupPasswordRequest);
+		return ResponseEntity.ok(response);
+	}
 
-        GroupPasswordResponse response = commandGroupService.isPasswordMatch(groupId, userId, groupPasswordRequest);
-        return ResponseEntity.ok(response);
-    }
+	@VerifyManagerPermission
+	@GetMapping("/header")
+	public ResponseEntity<GroupHeaderResponse> getHeader(
+		@RequestParam("groupToken") String groupToken) {
+		Long groupId = jwtService.getGroupId(groupToken);
 
-    @VerifyManagerPermission
-    @GetMapping("/header")
-    public ResponseEntity<GroupHeaderResponse> getHeader(
-            @RequestParam("groupToken") String groupToken) {
-        Long groupId = jwtService.getGroupId(groupToken);
-
-        GroupHeaderResponse response = queryGroupService.findByGroupHeader(groupId);
-        return ResponseEntity.ok(response);
-    }
+		GroupHeaderResponse response = queryGroupService.findByGroupHeader(groupId);
+		return ResponseEntity.ok(response);
+	}
 }

--- a/src/main/java/com/dnd/moddo/domain/group/dto/response/GroupSaveResponse.java
+++ b/src/main/java/com/dnd/moddo/domain/group/dto/response/GroupSaveResponse.java
@@ -1,0 +1,9 @@
+package com.dnd.moddo.domain.group.dto.response;
+
+import com.dnd.moddo.domain.groupMember.dto.response.GroupMemberResponse;
+
+public record GroupSaveResponse(
+	String groupToken,
+	GroupMemberResponse manager
+) {
+}

--- a/src/main/java/com/dnd/moddo/domain/group/service/CommandGroupService.java
+++ b/src/main/java/com/dnd/moddo/domain/group/service/CommandGroupService.java
@@ -33,7 +33,7 @@ public class CommandGroupService {
 
 	public GroupSaveResponse createGroup(GroupRequest request, Long userId) {
 		Group group = groupCreator.createGroup(request, userId);
-		GroupMemberResponse manager = commandGroupMemberService.addManager(group.getId(), userId);
+		GroupMemberResponse manager = commandGroupMemberService.createManager(group.getId(), userId);
 		String groupToken = jwtProvider.generateGroupToken(group.getId());
 		return new GroupSaveResponse(groupToken, manager);
 	}

--- a/src/main/java/com/dnd/moddo/domain/group/service/CommandGroupService.java
+++ b/src/main/java/com/dnd/moddo/domain/group/service/CommandGroupService.java
@@ -1,44 +1,54 @@
 package com.dnd.moddo.domain.group.service;
 
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.dnd.moddo.domain.group.dto.request.GroupAccountRequest;
 import com.dnd.moddo.domain.group.dto.request.GroupPasswordRequest;
 import com.dnd.moddo.domain.group.dto.request.GroupRequest;
 import com.dnd.moddo.domain.group.dto.response.GroupPasswordResponse;
 import com.dnd.moddo.domain.group.dto.response.GroupResponse;
+import com.dnd.moddo.domain.group.dto.response.GroupSaveResponse;
 import com.dnd.moddo.domain.group.entity.Group;
 import com.dnd.moddo.domain.group.service.implementation.GroupCreator;
 import com.dnd.moddo.domain.group.service.implementation.GroupReader;
 import com.dnd.moddo.domain.group.service.implementation.GroupUpdater;
 import com.dnd.moddo.domain.group.service.implementation.GroupValidator;
-import com.dnd.moddo.global.jwt.dto.GroupTokenResponse;
+import com.dnd.moddo.domain.groupMember.dto.response.GroupMemberResponse;
+import com.dnd.moddo.domain.groupMember.service.CommandGroupMemberService;
+import com.dnd.moddo.global.jwt.utill.JwtProvider;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class CommandGroupService {
-    private final GroupCreator groupCreator;
-    private final GroupUpdater groupUpdater;
-    private final GroupValidator groupValidator;
-    private final GroupReader groupReader;
+	private final GroupCreator groupCreator;
+	private final GroupUpdater groupUpdater;
+	private final GroupValidator groupValidator;
+	private final GroupReader groupReader;
+	private final JwtProvider jwtProvider;
+	private final CommandGroupMemberService commandGroupMemberService;
 
-    public GroupTokenResponse createGroup(GroupRequest request, Long userId) {
-        return groupCreator.createGroup(request, userId);
-    }
+	public GroupSaveResponse createGroup(GroupRequest request, Long userId) {
+		Group group = groupCreator.createGroup(request, userId);
+		GroupMemberResponse manager = commandGroupMemberService.addManager(group.getId(), userId);
+		String groupToken = jwtProvider.generateGroupToken(group.getId());
+		return new GroupSaveResponse(groupToken, manager);
+	}
 
-    public GroupResponse updateAccount(GroupAccountRequest request, Long userId, Long groupId) {
-        Group group = groupReader.read(groupId);
-        groupValidator.checkGroupAuthor(group, userId);
-        group = groupUpdater.updateAccount(request, group.getId());
-        return GroupResponse.of(group);
-    }
+	public GroupResponse updateAccount(GroupAccountRequest request, Long userId, Long groupId) {
+		Group group = groupReader.read(groupId);
+		groupValidator.checkGroupAuthor(group, userId);
+		group = groupUpdater.updateAccount(request, group.getId());
+		return GroupResponse.of(group);
+	}
 
-    public GroupPasswordResponse isPasswordMatch(Long groupId, Long userId, GroupPasswordRequest request) {
-        Group group = groupReader.read(groupId);
-        groupValidator.checkGroupAuthor(group, userId);
-        GroupPasswordResponse response = groupValidator.checkGroupPassword(request, group.getPassword());
-        return response;
-    }
+	public GroupPasswordResponse isPasswordMatch(Long groupId, Long userId, GroupPasswordRequest request) {
+		Group group = groupReader.read(groupId);
+		groupValidator.checkGroupAuthor(group, userId);
+		GroupPasswordResponse response = groupValidator.checkGroupPassword(request, group.getPassword());
+		return response;
+	}
 }

--- a/src/main/java/com/dnd/moddo/domain/group/service/CommandGroupService.java
+++ b/src/main/java/com/dnd/moddo/domain/group/service/CommandGroupService.java
@@ -33,7 +33,7 @@ public class CommandGroupService {
 
 	public GroupSaveResponse createGroup(GroupRequest request, Long userId) {
 		Group group = groupCreator.createGroup(request, userId);
-		GroupMemberResponse manager = commandGroupMemberService.createManager(group.getId(), userId);
+		GroupMemberResponse manager = commandGroupMemberService.createManager(group, userId);
 		String groupToken = jwtProvider.generateGroupToken(group.getId());
 		return new GroupSaveResponse(groupToken, manager);
 	}

--- a/src/main/java/com/dnd/moddo/domain/group/service/implementation/GroupCreator.java
+++ b/src/main/java/com/dnd/moddo/domain/group/service/implementation/GroupCreator.java
@@ -1,42 +1,38 @@
 package com.dnd.moddo.domain.group.service.implementation;
 
+import java.time.LocalDateTime;
+
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+
 import com.dnd.moddo.domain.group.dto.request.GroupRequest;
-import com.dnd.moddo.domain.group.dto.response.GroupResponse;
 import com.dnd.moddo.domain.group.entity.Group;
 import com.dnd.moddo.domain.group.repository.GroupRepository;
 import com.dnd.moddo.domain.user.entity.User;
 import com.dnd.moddo.domain.user.repository.UserRepository;
-import com.dnd.moddo.global.jwt.dto.GroupTokenResponse;
-import com.dnd.moddo.global.jwt.utill.JwtProvider;
-import lombok.RequiredArgsConstructor;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.stereotype.Service;
 
-import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 public class GroupCreator {
 
-    private final GroupRepository groupRepository;
-    private final UserRepository userRepository;
-    private final BCryptPasswordEncoder passwordEncoder;
-    private final JwtProvider jwtProvider;
+	private final GroupRepository groupRepository;
+	private final UserRepository userRepository;
+	private final BCryptPasswordEncoder passwordEncoder;
 
-    public GroupTokenResponse createGroup(GroupRequest request, Long userId) {
-        User user = userRepository.getById(userId);
-        String encryptedPassword = passwordEncoder.encode(request.password());
+	public Group createGroup(GroupRequest request, Long userId) {
+		User user = userRepository.getById(userId);
+		String encryptedPassword = passwordEncoder.encode(request.password());
 
-        Group group = Group.builder()
-                .writer(user.getId())
-                .name(request.name())
-                .password(encryptedPassword)
-                .createdAt(LocalDateTime.now())
-                .expiredAt(LocalDateTime.now().plusMonths(1))
-                .build();
+		Group group = Group.builder()
+			.writer(user.getId())
+			.name(request.name())
+			.password(encryptedPassword)
+			.createdAt(LocalDateTime.now())
+			.expiredAt(LocalDateTime.now().plusMonths(1))
+			.build();
 
-        groupRepository.save(group);
-
-        return jwtProvider.generateGroupToken(group.getId());
-    }
+		return groupRepository.save(group);
+	}
 }

--- a/src/main/java/com/dnd/moddo/domain/groupMember/controller/GroupMemberController.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/controller/GroupMemberController.java
@@ -4,7 +4,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -12,7 +11,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.dnd.moddo.domain.groupMember.dto.request.GroupMemberSaveRequest;
-import com.dnd.moddo.domain.groupMember.dto.request.GroupMembersSaveRequest;
 import com.dnd.moddo.domain.groupMember.dto.request.PaymentStatusUpdateRequest;
 import com.dnd.moddo.domain.groupMember.dto.response.GroupMemberResponse;
 import com.dnd.moddo.domain.groupMember.dto.response.GroupMembersResponse;
@@ -21,7 +19,6 @@ import com.dnd.moddo.domain.groupMember.service.QueryGroupMemberService;
 import com.dnd.moddo.global.common.annotation.VerifyManagerPermission;
 import com.dnd.moddo.global.jwt.service.JwtService;
 
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -32,18 +29,6 @@ public class GroupMemberController {
 	private final QueryGroupMemberService queryGroupMemberService;
 	private final CommandGroupMemberService commandGroupMemberService;
 	private final JwtService jwtService;
-
-	@PostMapping
-	public ResponseEntity<GroupMembersResponse> saveGroupMembers(
-		HttpServletRequest httpRequest,
-		@RequestParam("groupToken") String groupToken,
-		@Valid @RequestBody GroupMembersSaveRequest request
-	) {
-		Long userId = jwtService.getUserId(httpRequest);
-		Long groupId = jwtService.getGroupId(groupToken);
-		GroupMembersResponse response = commandGroupMemberService.create(groupId, userId, request);
-		return ResponseEntity.ok(response);
-	}
 
 	@GetMapping
 	public ResponseEntity<GroupMembersResponse> getGroupMembers(

--- a/src/main/java/com/dnd/moddo/domain/groupMember/dto/request/GroupMemberSaveRequest.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/dto/request/GroupMemberSaveRequest.java
@@ -14,7 +14,7 @@ public record GroupMemberSaveRequest(
 
 ) {
 	public GroupMember toEntity(Group group, ExpenseRole role) {
-		int proflieId = 0;
+		Integer proflieId = null;
 		return new GroupMember(name(), proflieId, group, role);
 	}
 }

--- a/src/main/java/com/dnd/moddo/domain/groupMember/dto/request/GroupMemberSaveRequest.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/dto/request/GroupMemberSaveRequest.java
@@ -14,6 +14,7 @@ public record GroupMemberSaveRequest(
 
 ) {
 	public GroupMember toEntity(Group group, ExpenseRole role) {
-		return new GroupMember(name(), group, role);
+		int proflieId = 0;
+		return new GroupMember(name(), proflieId, group, role);
 	}
 }

--- a/src/main/java/com/dnd/moddo/domain/groupMember/dto/response/GroupMemberExpenseResponse.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/dto/response/GroupMemberExpenseResponse.java
@@ -15,6 +15,7 @@ public record GroupMemberExpenseResponse(
 	ExpenseRole role,
 	String name,
 	Long totalAmount,
+	String profile,
 	boolean isPaid,
 	LocalDateTime paidAt,
 	List<MemberExpenseDetailResponse> expenses
@@ -26,6 +27,7 @@ public record GroupMemberExpenseResponse(
 			.role(groupMember.getRole())
 			.name(groupMember.getName())
 			.totalAmount(totalAmount)
+			.profile(groupMember.getProfileUrl())
 			.isPaid(groupMember.isPaid())
 			.paidAt(groupMember.getPaidAt())
 			.expenses(expenses).build();

--- a/src/main/java/com/dnd/moddo/domain/groupMember/dto/response/GroupMemberResponse.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/dto/response/GroupMemberResponse.java
@@ -24,14 +24,8 @@ public record GroupMemberResponse(
 			.role(groupMember.getRole())
 			.isPaid(groupMember.isPaid())
 			.paidAt(groupMember.getPaidAt())
-			.profile(generateProfileUrl(groupMember.getProfileId()))
+			.profile(groupMember.getProfileUrl())
 			.build();
 	}
 
-	private static String generateProfileUrl(Integer profile) {
-		if (profile == null) {
-			return "https://example.com/profiles/default.jpg";
-		}
-		return "https://example.com/profiles/" + profile + ".jpg";
-	}
 }

--- a/src/main/java/com/dnd/moddo/domain/groupMember/entity/GroupMember.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/entity/GroupMember.java
@@ -83,5 +83,12 @@ public class GroupMember {
 			this.paidAt = null;
 		}
 	}
+
+	public String getProfileUrl() {
+		if (profileId == null) {
+			return "https://example.com/profiles/default.jpg";
+		}
+		return "https://example.com/profiles/" + profileId + ".jpg";
+	}
 }
 

--- a/src/main/java/com/dnd/moddo/domain/groupMember/service/CommandGroupMemberService.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/service/CommandGroupMemberService.java
@@ -33,6 +33,11 @@ public class CommandGroupMemberService {
 		return GroupMemberResponse.of(groupMember);
 	}
 
+	public GroupMemberResponse addManager(Long groupId, Long userId) {
+		GroupMember groupMember = groupMemberUpdater.addManagerToGroup(userId, groupId);
+		return GroupMemberResponse.of(groupMember);
+	}
+
 	public GroupMemberResponse updatePaymentStatus(Long groupMemberId, PaymentStatusUpdateRequest request) {
 		GroupMember groupMember = groupMemberUpdater.updatePaymentStatus(groupMemberId, request);
 		return GroupMemberResponse.of(groupMember);

--- a/src/main/java/com/dnd/moddo/domain/groupMember/service/CommandGroupMemberService.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/service/CommandGroupMemberService.java
@@ -2,6 +2,7 @@ package com.dnd.moddo.domain.groupMember.service;
 
 import org.springframework.stereotype.Service;
 
+import com.dnd.moddo.domain.group.entity.Group;
 import com.dnd.moddo.domain.groupMember.dto.request.GroupMemberSaveRequest;
 import com.dnd.moddo.domain.groupMember.dto.request.PaymentStatusUpdateRequest;
 import com.dnd.moddo.domain.groupMember.dto.response.GroupMemberResponse;
@@ -19,8 +20,8 @@ public class CommandGroupMemberService {
 	private final GroupMemberUpdater groupMemberUpdater;
 	private final GroupMemberDeleter groupMemberDeleter;
 
-	public GroupMemberResponse createManager(Long groupId, Long userId) {
-		GroupMember groupMember = groupMemberCreator.createManagerForGroup(userId, groupId);
+	public GroupMemberResponse createManager(Group group, Long userId) {
+		GroupMember groupMember = groupMemberCreator.createManagerForGroup(group, userId);
 		return GroupMemberResponse.of(groupMember);
 	}
 

--- a/src/main/java/com/dnd/moddo/domain/groupMember/service/CommandGroupMemberService.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/service/CommandGroupMemberService.java
@@ -1,14 +1,10 @@
 package com.dnd.moddo.domain.groupMember.service;
 
-import java.util.List;
-
 import org.springframework.stereotype.Service;
 
 import com.dnd.moddo.domain.groupMember.dto.request.GroupMemberSaveRequest;
-import com.dnd.moddo.domain.groupMember.dto.request.GroupMembersSaveRequest;
 import com.dnd.moddo.domain.groupMember.dto.request.PaymentStatusUpdateRequest;
 import com.dnd.moddo.domain.groupMember.dto.response.GroupMemberResponse;
-import com.dnd.moddo.domain.groupMember.dto.response.GroupMembersResponse;
 import com.dnd.moddo.domain.groupMember.entity.GroupMember;
 import com.dnd.moddo.domain.groupMember.service.implementation.GroupMemberCreator;
 import com.dnd.moddo.domain.groupMember.service.implementation.GroupMemberDeleter;
@@ -23,18 +19,13 @@ public class CommandGroupMemberService {
 	private final GroupMemberUpdater groupMemberUpdater;
 	private final GroupMemberDeleter groupMemberDeleter;
 
-	public GroupMembersResponse create(Long groupId, Long userId, GroupMembersSaveRequest request) {
-		List<GroupMember> members = groupMemberCreator.create(groupId, userId, request);
-		return GroupMembersResponse.of(members);
+	public GroupMemberResponse createManager(Long groupId, Long userId) {
+		GroupMember groupMember = groupMemberCreator.createManagerForGroup(userId, groupId);
+		return GroupMemberResponse.of(groupMember);
 	}
 
 	public GroupMemberResponse addGroupMember(Long groupId, GroupMemberSaveRequest request) {
 		GroupMember groupMember = groupMemberUpdater.addToGroup(groupId, request);
-		return GroupMemberResponse.of(groupMember);
-	}
-
-	public GroupMemberResponse addManager(Long groupId, Long userId) {
-		GroupMember groupMember = groupMemberUpdater.addManagerToGroup(userId, groupId);
 		return GroupMemberResponse.of(groupMember);
 	}
 

--- a/src/main/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberCreator.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberCreator.java
@@ -1,14 +1,10 @@
 package com.dnd.moddo.domain.groupMember.service.implementation;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.dnd.moddo.domain.group.entity.Group;
 import com.dnd.moddo.domain.group.service.implementation.GroupReader;
-import com.dnd.moddo.domain.groupMember.dto.request.GroupMembersSaveRequest;
 import com.dnd.moddo.domain.groupMember.entity.GroupMember;
 import com.dnd.moddo.domain.groupMember.entity.type.ExpenseRole;
 import com.dnd.moddo.domain.groupMember.repository.GroupMemberRepository;
@@ -22,35 +18,24 @@ import lombok.RequiredArgsConstructor;
 @Transactional
 public class GroupMemberCreator {
 	private final GroupMemberRepository groupMemberRepository;
-	private final GroupMemberValidator groupMemberValidator;
 	private final GroupReader groupReader;
 	private final UserRepository userRepository;
 
-	public List<GroupMember> create(Long groupId, Long userId, GroupMembersSaveRequest request) {
+	public GroupMember createManagerForGroup(Long userId, Long groupId) {
+		User user = userRepository.getById(userId);
 		Group group = groupReader.read(groupId);
 
-		List<String> requestNames = request.extractNames();
-
-		groupMemberValidator.validateMemberNamesNotDuplicate(requestNames);
-
-		List<GroupMember> newMembers = new ArrayList<>();
-
-		newMembers.add(createManager(userId, group));
-		newMembers.addAll(request.toEntity(group));
-
-		return groupMemberRepository.saveAll(newMembers);
-	}
-
-	private GroupMember createManager(Long userId, Group group) {
-		User user = userRepository.getById(userId);
 		String name = user.getIsMember() ? user.getName() : "김모또";
-		return GroupMember.builder()
+
+		GroupMember groupMember = GroupMember.builder()
 			.name(name)
 			.profileId(null)     //user 프로필 가져오기
 			.group(group)
-			.isPaid(true)
 			.role(ExpenseRole.MANAGER)
 			.build();
 
+		groupMember.updatePaymentStatus(true);
+
+		return groupMemberRepository.save(groupMember);
 	}
 }

--- a/src/main/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberCreator.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberCreator.java
@@ -4,7 +4,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.dnd.moddo.domain.group.entity.Group;
-import com.dnd.moddo.domain.group.service.implementation.GroupReader;
 import com.dnd.moddo.domain.groupMember.entity.GroupMember;
 import com.dnd.moddo.domain.groupMember.entity.type.ExpenseRole;
 import com.dnd.moddo.domain.groupMember.repository.GroupMemberRepository;
@@ -18,12 +17,10 @@ import lombok.RequiredArgsConstructor;
 @Transactional
 public class GroupMemberCreator {
 	private final GroupMemberRepository groupMemberRepository;
-	private final GroupReader groupReader;
 	private final UserRepository userRepository;
 
-	public GroupMember createManagerForGroup(Long userId, Long groupId) {
+	public GroupMember createManagerForGroup(Group group, Long userId) {
 		User user = userRepository.getById(userId);
-		Group group = groupReader.read(groupId);
 
 		String name = user.getIsMember() ? user.getName() : "김모또";
 

--- a/src/main/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberUpdater.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberUpdater.java
@@ -7,12 +7,14 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.dnd.moddo.domain.group.entity.Group;
-import com.dnd.moddo.domain.group.repository.GroupRepository;
+import com.dnd.moddo.domain.group.service.implementation.GroupReader;
 import com.dnd.moddo.domain.groupMember.dto.request.GroupMemberSaveRequest;
 import com.dnd.moddo.domain.groupMember.dto.request.PaymentStatusUpdateRequest;
 import com.dnd.moddo.domain.groupMember.entity.GroupMember;
 import com.dnd.moddo.domain.groupMember.entity.type.ExpenseRole;
 import com.dnd.moddo.domain.groupMember.repository.GroupMemberRepository;
+import com.dnd.moddo.domain.user.entity.User;
+import com.dnd.moddo.domain.user.repository.UserRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -23,10 +25,11 @@ public class GroupMemberUpdater {
 	private final GroupMemberRepository groupMemberRepository;
 	private final GroupMemberReader groupMemberReader;
 	private final GroupMemberValidator groupMemberValidator;
-	private final GroupRepository groupRepository;
+	private final GroupReader groupReader;
+	private final UserRepository userRepository;
 
 	public GroupMember addToGroup(Long groupId, GroupMemberSaveRequest request) {
-		Group group = groupRepository.getById(groupId);
+		Group group = groupReader.read(groupId);
 		List<GroupMember> groupMembers = groupMemberReader.findAllByGroupId(groupId);
 
 		List<String> existingNames = new ArrayList<>(groupMembers.stream().map(GroupMember::getName).toList());
@@ -35,6 +38,24 @@ public class GroupMemberUpdater {
 		groupMemberValidator.validateMemberNamesNotDuplicate(existingNames);
 
 		return groupMemberRepository.save(request.toEntity(group, ExpenseRole.PARTICIPANT));
+	}
+
+	public GroupMember addManagerToGroup(Long userId, Long groupId) {
+		User user = userRepository.getById(userId);
+		Group group = groupReader.read(groupId);
+
+		String name = user.getIsMember() ? user.getName() : "김모또";
+
+		GroupMember groupMember = GroupMember.builder()
+			.name(name)
+			.profileId(null)     //user 프로필 가져오기
+			.group(group)
+			.role(ExpenseRole.MANAGER)
+			.build();
+
+		groupMember.updatePaymentStatus(true);
+
+		return groupMemberRepository.save(groupMember);
 	}
 
 	public GroupMember updatePaymentStatus(Long groupMemberId, PaymentStatusUpdateRequest request) {

--- a/src/main/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberUpdater.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberUpdater.java
@@ -13,8 +13,6 @@ import com.dnd.moddo.domain.groupMember.dto.request.PaymentStatusUpdateRequest;
 import com.dnd.moddo.domain.groupMember.entity.GroupMember;
 import com.dnd.moddo.domain.groupMember.entity.type.ExpenseRole;
 import com.dnd.moddo.domain.groupMember.repository.GroupMemberRepository;
-import com.dnd.moddo.domain.user.entity.User;
-import com.dnd.moddo.domain.user.repository.UserRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -26,7 +24,6 @@ public class GroupMemberUpdater {
 	private final GroupMemberReader groupMemberReader;
 	private final GroupMemberValidator groupMemberValidator;
 	private final GroupReader groupReader;
-	private final UserRepository userRepository;
 
 	public GroupMember addToGroup(Long groupId, GroupMemberSaveRequest request) {
 		Group group = groupReader.read(groupId);
@@ -38,24 +35,6 @@ public class GroupMemberUpdater {
 		groupMemberValidator.validateMemberNamesNotDuplicate(existingNames);
 
 		return groupMemberRepository.save(request.toEntity(group, ExpenseRole.PARTICIPANT));
-	}
-
-	public GroupMember addManagerToGroup(Long userId, Long groupId) {
-		User user = userRepository.getById(userId);
-		Group group = groupReader.read(groupId);
-
-		String name = user.getIsMember() ? user.getName() : "김모또";
-
-		GroupMember groupMember = GroupMember.builder()
-			.name(name)
-			.profileId(null)     //user 프로필 가져오기
-			.group(group)
-			.role(ExpenseRole.MANAGER)
-			.build();
-
-		groupMember.updatePaymentStatus(true);
-
-		return groupMemberRepository.save(groupMember);
 	}
 
 	public GroupMember updatePaymentStatus(Long groupMemberId, PaymentStatusUpdateRequest request) {

--- a/src/main/java/com/dnd/moddo/domain/memberExpense/dto/request/MemberExpenseRequest.java
+++ b/src/main/java/com/dnd/moddo/domain/memberExpense/dto/request/MemberExpenseRequest.java
@@ -10,7 +10,7 @@ import jakarta.validation.constraints.Positive;
 public record MemberExpenseRequest(
 	@NotNull(message = "참여자 id는 필수 항목입니다.")
 	@Positive(message = "참여자 id는 양수여야 합니다.")
-	Long memberId,
+	Long id,
 
 	@Positive(message = "지출내역 값은 양수여야 합니다.")
 	@Max(value = 5_000_000, message = "지출내역 값은 최대 500만원까지 입력할 수 있습니다.")

--- a/src/main/java/com/dnd/moddo/domain/memberExpense/dto/response/MemberExpenseResponse.java
+++ b/src/main/java/com/dnd/moddo/domain/memberExpense/dto/response/MemberExpenseResponse.java
@@ -3,17 +3,23 @@ package com.dnd.moddo.domain.memberExpense.dto.response;
 import com.dnd.moddo.domain.groupMember.entity.type.ExpenseRole;
 import com.dnd.moddo.domain.memberExpense.entity.MemberExpense;
 
+import lombok.Builder;
+
+@Builder
 public record MemberExpenseResponse(
 	Long id,
 	ExpenseRole role,
 	String name,
+	String profile,
 	Long amount
 ) {
 	public static MemberExpenseResponse of(MemberExpense memberExpense) {
-		return new MemberExpenseResponse(
-			memberExpense.getGroupMember().getId(),
-			memberExpense.getGroupMember().getRole(),
-			memberExpense.getGroupMember().getName(),
-			memberExpense.getAmount());
+		return MemberExpenseResponse.builder()
+			.id(memberExpense.getGroupMember().getId())
+			.name(memberExpense.getGroupMember().getName())
+			.role(memberExpense.getGroupMember().getRole())
+			.profile(memberExpense.getGroupMember().getProfileUrl())
+			.amount(memberExpense.getAmount())
+			.build();
 	}
 }

--- a/src/main/java/com/dnd/moddo/domain/memberExpense/service/CommandMemberExpenseService.java
+++ b/src/main/java/com/dnd/moddo/domain/memberExpense/service/CommandMemberExpenseService.java
@@ -31,7 +31,7 @@ public class CommandMemberExpenseService {
 	public List<MemberExpenseResponse> create(Long expenseId, List<MemberExpenseRequest> request) {
 		return request.stream()
 			.map(m -> {
-				GroupMember groupMember = groupMemberReader.findByGroupMemberId(m.memberId());
+				GroupMember groupMember = groupMemberReader.findByGroupMemberId(m.id());
 				return MemberExpenseResponse.of(memberExpenseCreator.create(expenseId, groupMember, m));
 			}).toList();
 
@@ -57,7 +57,7 @@ public class CommandMemberExpenseService {
 		Map<Long, MemberExpense> existingMemberExpenses,
 		MemberExpenseRequest request) {
 
-		Long groupMemberId = request.memberId();
+		Long groupMemberId = request.id();
 		MemberExpenseResponse response;
 
 		if (existingMemberExpenses.containsKey(groupMemberId)) {
@@ -79,7 +79,7 @@ public class CommandMemberExpenseService {
 		List<MemberExpense> memberExpenses) {
 		// 1. 요청된 멤버들의 memberId를 추출
 		Set<Long> requestMemberIds = requests.stream()
-			.map(MemberExpenseRequest::memberId)
+			.map(MemberExpenseRequest::id)
 			.collect(Collectors.toSet());
 
 		//2. 멤버별 지출내역중 요청된 멤버 id에 포함되지 않는 지출내역을 찾는다.

--- a/src/main/java/com/dnd/moddo/domain/memberExpense/service/implementation/MemberExpenseValidator.java
+++ b/src/main/java/com/dnd/moddo/domain/memberExpense/service/implementation/MemberExpenseValidator.java
@@ -20,7 +20,7 @@ public class MemberExpenseValidator {
 	public void validateMembersArePartOfGroup(Long groupId, List<MemberExpenseRequest> requests) {
 		Set<Long> validGroupMemberIds = new HashSet<>(groupMemberReader.findIdsByGroupId(groupId));
 		List<Long> requestedGroupMemberIds = requests.stream()
-			.map(MemberExpenseRequest::memberId)
+			.map(MemberExpenseRequest::id)
 			.toList();
 
 		requestedGroupMemberIds.forEach(id -> {

--- a/src/main/java/com/dnd/moddo/global/jwt/utill/JwtProvider.java
+++ b/src/main/java/com/dnd/moddo/global/jwt/utill/JwtProvider.java
@@ -1,69 +1,69 @@
 package com.dnd.moddo.global.jwt.utill;
 
-import com.dnd.moddo.global.jwt.dto.GroupTokenResponse;
-import com.dnd.moddo.global.jwt.dto.TokenResponse;
-import com.dnd.moddo.global.jwt.properties.JwtProperties;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Component;
+import static com.dnd.moddo.global.jwt.properties.JwtConstants.*;
 
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Date;
 
-import static com.dnd.moddo.global.jwt.properties.JwtConstants.*;
+import org.springframework.stereotype.Component;
+
+import com.dnd.moddo.global.jwt.dto.TokenResponse;
+import com.dnd.moddo.global.jwt.properties.JwtProperties;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @Component
 public class JwtProvider {
 
-    private final JwtProperties jwtProperties;
+	private final JwtProperties jwtProperties;
 
-    public String generateAccessToken(Long id, String email, String role) {
-        return generateToken(id, email, role, ACCESS_KEY.getMessage(), jwtProperties.getAccessExpiration());
-    }
+	public String generateAccessToken(Long id, String email, String role) {
+		return generateToken(id, email, role, ACCESS_KEY.getMessage(), jwtProperties.getAccessExpiration());
+	}
 
-    public TokenResponse generateToken(Long id, String email, String role, Boolean isMember) {
-        String accessToken = generateToken(id, email, role, ACCESS_KEY.getMessage(), jwtProperties.getAccessExpiration());
-        String refreshToken = generateToken(id, email, role, REFRESH_KEY.getMessage(), jwtProperties.getRefreshExpiration());
+	public TokenResponse generateToken(Long id, String email, String role, Boolean isMember) {
+		String accessToken = generateToken(id, email, role, ACCESS_KEY.getMessage(),
+			jwtProperties.getAccessExpiration());
+		String refreshToken = generateToken(id, email, role, REFRESH_KEY.getMessage(),
+			jwtProperties.getRefreshExpiration());
 
-        return new TokenResponse(accessToken, refreshToken, getExpiredTime(), isMember);
-    }
+		return new TokenResponse(accessToken, refreshToken, getExpiredTime(), isMember);
+	}
 
-    public GroupTokenResponse generateGroupToken(Long groupId) {
-        String groupToken = generateGroupToken(groupId, GROUP_KEY.getMessage());
+	public String generateGroupToken(Long groupId) {
+		return generateGroupToken(groupId, GROUP_KEY.getMessage());
+	}
 
-        return new GroupTokenResponse(groupToken);
-    }
+	private String generateToken(Long id, String email, String role, String type, Long exp) {
+		return Jwts.builder()
+			.claim(AUTH_ID.getMessage(), id)
+			.claim(EMAIL.getMessage(), email)
+			.setHeaderParam(TYPE.message, type)
+			.claim(ROLE.getMessage(), role)
+			.signWith(jwtProperties.getSecretKey(), SignatureAlgorithm.HS256)
+			.setExpiration(
+				new Date(System.currentTimeMillis() + exp * 1000)
+			)
+			.compact();
+	}
 
+	private String generateGroupToken(Long groupId, String type) {
+		return Jwts.builder()
+			.claim(GROUP_ID.getMessage(), groupId)
+			.setHeaderParam(TYPE.message, type)
+			.signWith(jwtProperties.getSecretKey(), SignatureAlgorithm.HS256)
+			.setExpiration(
+				Date.from(LocalDate.now().plusMonths(1).atStartOfDay(ZoneId.systemDefault()).toInstant())
+			)
+			.compact();
+	}
 
-    private String generateToken(Long id, String email, String role, String type, Long exp) {
-        return Jwts.builder()
-                .claim(AUTH_ID.getMessage(), id)
-                .claim(EMAIL.getMessage(), email)
-                .setHeaderParam(TYPE.message, type)
-                .claim(ROLE.getMessage(), role)
-                .signWith(jwtProperties.getSecretKey(), SignatureAlgorithm.HS256)
-                .setExpiration(
-                        new Date(System.currentTimeMillis() + exp * 1000)
-                )
-                .compact();
-    }
-
-    private String generateGroupToken(Long groupId, String type) {
-        return Jwts.builder()
-                .claim(GROUP_ID.getMessage(), groupId)
-                .setHeaderParam(TYPE.message, type)
-                .signWith(jwtProperties.getSecretKey(), SignatureAlgorithm.HS256)
-                .setExpiration(
-                        Date.from(LocalDate.now().plusMonths(1).atStartOfDay(ZoneId.systemDefault()).toInstant())
-                )
-                .compact();
-    }
-
-    private ZonedDateTime getExpiredTime() {
-        return ZonedDateTime.now().plusSeconds(jwtProperties.getRefreshExpiration());
-    }
+	private ZonedDateTime getExpiredTime() {
+		return ZonedDateTime.now().plusSeconds(jwtProperties.getRefreshExpiration());
+	}
 }

--- a/src/test/java/com/dnd/moddo/domain/expense/service/QueryExpenseServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/expense/service/QueryExpenseServiceTest.java
@@ -59,11 +59,11 @@ class QueryExpenseServiceTest {
 		Long expenseId1 = 1L, expenseId2 = 2L;
 
 		List<MemberExpenseResponse> responses1 = List.of(
-			new MemberExpenseResponse(1L, ExpenseRole.MANAGER, "김모또", 15000L),
-			new MemberExpenseResponse(2L, ExpenseRole.PARTICIPANT, "박완숙", 5000L));
+			new MemberExpenseResponse(1L, ExpenseRole.MANAGER, "김모또", null, 15000L),
+			new MemberExpenseResponse(2L, ExpenseRole.PARTICIPANT, "박완숙", null, 5000L));
 		List<MemberExpenseResponse> responses2 = List.of(
-			new MemberExpenseResponse(1L, ExpenseRole.MANAGER, "김모또", 15000L),
-			new MemberExpenseResponse(2L, ExpenseRole.PARTICIPANT, "박완숙", 2000L));
+			new MemberExpenseResponse(1L, ExpenseRole.MANAGER, "김모또", null, 15000L),
+			new MemberExpenseResponse(2L, ExpenseRole.PARTICIPANT, "박완숙", null, 2000L));
 
 		when(queryMemberExpenseService.findAllByExpenseId(any()))
 			.thenReturn(responses1)

--- a/src/test/java/com/dnd/moddo/domain/group/service/CommandGroupServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/group/service/CommandGroupServiceTest.java
@@ -78,7 +78,7 @@ class CommandGroupServiceTest {
 		when(groupCreator.createGroup(any(GroupRequest.class), anyLong())).thenReturn(group);
 		when(jwtProvider.generateGroupToken(any())).thenReturn("group-token");
 		when(group.getId()).thenReturn(1L);
-		when(commandGroupMemberService.addManager(any(), any())).thenReturn(groupMemberResponse);
+		when(commandGroupMemberService.createManager(any(), any())).thenReturn(groupMemberResponse);
 
 		// When
 		GroupSaveResponse response = commandGroupService.createGroup(groupRequest, 1L);
@@ -89,7 +89,7 @@ class CommandGroupServiceTest {
 		assertThat(response.manager().role()).isEqualTo(ExpenseRole.MANAGER);
 
 		verify(groupCreator, times(1)).createGroup(any(GroupRequest.class), anyLong());
-		verify(commandGroupMemberService, times(1)).addManager(any(), any());
+		verify(commandGroupMemberService, times(1)).createManager(any(), any());
 	}
 
 	@Test

--- a/src/test/java/com/dnd/moddo/domain/group/service/CommandGroupServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/group/service/CommandGroupServiceTest.java
@@ -1,16 +1,11 @@
 package com.dnd.moddo.domain.group.service;
 
-import com.dnd.moddo.domain.group.dto.request.GroupAccountRequest;
-import com.dnd.moddo.domain.group.dto.request.GroupPasswordRequest;
-import com.dnd.moddo.domain.group.dto.request.GroupRequest;
-import com.dnd.moddo.domain.group.dto.response.GroupPasswordResponse;
-import com.dnd.moddo.domain.group.dto.response.GroupResponse;
-import com.dnd.moddo.domain.group.entity.Group;
-import com.dnd.moddo.domain.group.service.implementation.GroupCreator;
-import com.dnd.moddo.domain.group.service.implementation.GroupReader;
-import com.dnd.moddo.domain.group.service.implementation.GroupUpdater;
-import com.dnd.moddo.domain.group.service.implementation.GroupValidator;
-import com.dnd.moddo.global.jwt.dto.GroupTokenResponse;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDateTime;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -19,126 +14,146 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.time.LocalDateTime;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.*;
+import com.dnd.moddo.domain.group.dto.request.GroupAccountRequest;
+import com.dnd.moddo.domain.group.dto.request.GroupPasswordRequest;
+import com.dnd.moddo.domain.group.dto.request.GroupRequest;
+import com.dnd.moddo.domain.group.dto.response.GroupPasswordResponse;
+import com.dnd.moddo.domain.group.dto.response.GroupResponse;
+import com.dnd.moddo.domain.group.dto.response.GroupSaveResponse;
+import com.dnd.moddo.domain.group.entity.Group;
+import com.dnd.moddo.domain.group.service.implementation.GroupCreator;
+import com.dnd.moddo.domain.group.service.implementation.GroupReader;
+import com.dnd.moddo.domain.group.service.implementation.GroupUpdater;
+import com.dnd.moddo.domain.group.service.implementation.GroupValidator;
+import com.dnd.moddo.domain.groupMember.dto.response.GroupMemberResponse;
+import com.dnd.moddo.domain.groupMember.entity.type.ExpenseRole;
+import com.dnd.moddo.domain.groupMember.service.CommandGroupMemberService;
+import com.dnd.moddo.global.jwt.utill.JwtProvider;
 
 @ExtendWith(MockitoExtension.class)
 class CommandGroupServiceTest {
 
-    @Mock
-    private GroupCreator groupCreator;
+	@Mock
+	private GroupCreator groupCreator;
 
-    @Mock
-    private GroupUpdater groupUpdater; // 추가
+	@Mock
+	private GroupUpdater groupUpdater; // 추가
 
-    @Mock
-    private GroupReader groupReader;
+	@Mock
+	private GroupReader groupReader;
 
-    @Mock
-    private GroupValidator groupValidator;
+	@Mock
+	private GroupValidator groupValidator;
+	@Mock
+	private JwtProvider jwtProvider;
+	@Mock
+	private CommandGroupMemberService commandGroupMemberService;
+	@InjectMocks
+	private CommandGroupService commandGroupService;
 
-    @InjectMocks
-    private CommandGroupService commandGroupService;
+	private GroupRequest groupRequest;
+	private GroupResponse groupResponse;
+	private GroupAccountRequest groupAccountRequest;
+	private Group group;
+	private GroupSaveResponse expectedResponse;
 
-    private GroupRequest groupRequest;
-    private GroupResponse groupResponse;
-    private GroupAccountRequest groupAccountRequest;
-    private Group group;
-    private GroupTokenResponse expectedResponse;
+	@BeforeEach
+	void setUp() {
+		groupRequest = new GroupRequest("GroupName", "password123", LocalDateTime.now());
+		groupResponse = new GroupResponse(1L, 1L, LocalDateTime.now(), LocalDateTime.now().minusDays(1), "bank",
+			"1234-1234");
+		groupAccountRequest = new GroupAccountRequest("newBank", "5678-5678");
+		expectedResponse = new GroupSaveResponse("group-token", mock(GroupMemberResponse.class));
 
-    @BeforeEach
-    void setUp() {
-        groupRequest = new GroupRequest("GroupName", "password123", LocalDateTime.now());
-        groupResponse = new GroupResponse(1L, 1L, LocalDateTime.now(), LocalDateTime.now().minusDays(1), "bank", "1234-1234");
-        groupAccountRequest = new GroupAccountRequest("newBank", "5678-5678");
-        expectedResponse = new GroupTokenResponse("group-token");
+		group = mock(Group.class);
+	}
 
-        group = mock(Group.class);
-    }
+	@Test
+	@DisplayName("그룹과 총무를 생성할 수 있다.")
+	void createGroup() {
+		// Given
+		GroupMemberResponse groupMemberResponse = new GroupMemberResponse(1L, ExpenseRole.MANAGER, "김모또", null, true,
+			LocalDateTime.now());
 
-    @Test
-    @DisplayName("그룹을 생성할 수 있다.")
-    void createGroup() {
-        // Given
-        when(groupCreator.createGroup(any(GroupRequest.class), anyLong())).thenReturn(expectedResponse);
+		when(groupCreator.createGroup(any(GroupRequest.class), anyLong())).thenReturn(group);
+		when(jwtProvider.generateGroupToken(any())).thenReturn("group-token");
+		when(group.getId()).thenReturn(1L);
+		when(commandGroupMemberService.addManager(any(), any())).thenReturn(groupMemberResponse);
 
-        // When
-        GroupTokenResponse response = commandGroupService.createGroup(groupRequest, 1L);
+		// When
+		GroupSaveResponse response = commandGroupService.createGroup(groupRequest, 1L);
 
-        // Then
-        assertThat(response).isNotNull();
-        assertThat(response.groupToken()).isEqualTo("group-token");
+		// Then
+		assertThat(response).isNotNull();
+		assertThat(response.groupToken()).isEqualTo("group-token");
+		assertThat(response.manager().role()).isEqualTo(ExpenseRole.MANAGER);
 
-        verify(groupCreator, times(1)).createGroup(any(GroupRequest.class), anyLong());
-    }
+		verify(groupCreator, times(1)).createGroup(any(GroupRequest.class), anyLong());
+		verify(commandGroupMemberService, times(1)).addManager(any(), any());
+	}
 
-    @Test
-    @DisplayName("그룹의 계좌 정보를 업데이트할 수 있다.")
-    void updateGroupAccount() {
-        // Given
-        when(groupReader.read(anyLong())).thenReturn(group);
-        when(groupUpdater.updateAccount(any(GroupAccountRequest.class), anyLong())).thenReturn(group);
-        doNothing().when(groupValidator).checkGroupAuthor(any(Group.class), anyLong());
+	@Test
+	@DisplayName("그룹의 계좌 정보를 업데이트할 수 있다.")
+	void updateGroupAccount() {
+		// Given
+		when(groupReader.read(anyLong())).thenReturn(group);
+		when(groupUpdater.updateAccount(any(GroupAccountRequest.class), anyLong())).thenReturn(group);
+		doNothing().when(groupValidator).checkGroupAuthor(any(Group.class), anyLong());
 
-        // When
-        GroupResponse result = commandGroupService.updateAccount(groupAccountRequest, group.getWriter(), group.getId());
+		// When
+		GroupResponse result = commandGroupService.updateAccount(groupAccountRequest, group.getWriter(), group.getId());
 
-        // Then
-        assertThat(result).isNotNull();
-        verify(groupReader, times(1)).read(anyLong());
-        verify(groupValidator, times(1)).checkGroupAuthor(any(Group.class), anyLong());
-        verify(groupUpdater, times(1)).updateAccount(any(GroupAccountRequest.class), anyLong());
-    }
+		// Then
+		assertThat(result).isNotNull();
+		verify(groupReader, times(1)).read(anyLong());
+		verify(groupValidator, times(1)).checkGroupAuthor(any(Group.class), anyLong());
+		verify(groupUpdater, times(1)).updateAccount(any(GroupAccountRequest.class), anyLong());
+	}
 
-    @Test
-    @DisplayName("올바른 비밀번호를 입력하면 확인 메시지를 반환한다.")
-    void VerifyPassword_Success() {
-        // Given
-        GroupPasswordRequest request = new GroupPasswordRequest("correctPassword");
-        GroupPasswordResponse expectedResponse = GroupPasswordResponse.from("확인되었습니다.");
+	@Test
+	@DisplayName("올바른 비밀번호를 입력하면 확인 메시지를 반환한다.")
+	void VerifyPassword_Success() {
+		// Given
+		GroupPasswordRequest request = new GroupPasswordRequest("correctPassword");
+		GroupPasswordResponse expectedResponse = GroupPasswordResponse.from("확인되었습니다.");
 
-        when(groupReader.read(group.getId())).thenReturn(group);
-        doNothing().when(groupValidator).checkGroupAuthor(group, 1L);
-        when(groupValidator.checkGroupPassword(request, group.getPassword())).thenReturn(expectedResponse);
+		when(groupReader.read(group.getId())).thenReturn(group);
+		doNothing().when(groupValidator).checkGroupAuthor(group, 1L);
+		when(groupValidator.checkGroupPassword(request, group.getPassword())).thenReturn(expectedResponse);
 
-        // When
-        GroupPasswordResponse response = commandGroupService.isPasswordMatch(group.getId(), 1L, request);
+		// When
+		GroupPasswordResponse response = commandGroupService.isPasswordMatch(group.getId(), 1L, request);
 
-        // Then
-        assertThat(response).isNotNull();
-        assertThat(response.status()).isEqualTo("확인되었습니다.");
+		// Then
+		assertThat(response).isNotNull();
+		assertThat(response.status()).isEqualTo("확인되었습니다.");
 
-        verify(groupReader, times(1)).read(group.getId());
-        verify(groupValidator, times(1)).checkGroupAuthor(group, 1L);
-        verify(groupValidator, times(1)).checkGroupPassword(request, group.getPassword());
-    }
+		verify(groupReader, times(1)).read(group.getId());
+		verify(groupValidator, times(1)).checkGroupAuthor(group, 1L);
+		verify(groupValidator, times(1)).checkGroupPassword(request, group.getPassword());
+	}
 
-    @Test
-    @DisplayName("잘못된 비밀번호를 입력하면 예외가 발생한다.")
-    void VerifyPassword_Fail_WrongPassword() {
-        // Given
-        GroupPasswordRequest request = new GroupPasswordRequest("wrongPassword");
-        String storedPassword = "correctPassword";
+	@Test
+	@DisplayName("잘못된 비밀번호를 입력하면 예외가 발생한다.")
+	void VerifyPassword_Fail_WrongPassword() {
+		// Given
+		GroupPasswordRequest request = new GroupPasswordRequest("wrongPassword");
+		String storedPassword = "correctPassword";
 
-        when(groupReader.read(group.getId())).thenReturn(group);
-        doNothing().when(groupValidator).checkGroupAuthor(group, 1L);
-        when(group.getPassword()).thenReturn(storedPassword);
+		when(groupReader.read(group.getId())).thenReturn(group);
+		doNothing().when(groupValidator).checkGroupAuthor(group, 1L);
+		when(group.getPassword()).thenReturn(storedPassword);
 
-        doThrow(new RuntimeException("비밀번호가 일치하지 않습니다."))
-                .when(groupValidator).checkGroupPassword(request, storedPassword);
+		doThrow(new RuntimeException("비밀번호가 일치하지 않습니다."))
+			.when(groupValidator).checkGroupPassword(request, storedPassword);
 
-        // When & Then
-        assertThatThrownBy(() -> commandGroupService.isPasswordMatch(group.getId(), 1L, request))
-                .isInstanceOf(RuntimeException.class)
-                .hasMessageContaining("비밀번호가 일치하지 않습니다.");
+		// When & Then
+		assertThatThrownBy(() -> commandGroupService.isPasswordMatch(group.getId(), 1L, request))
+			.isInstanceOf(RuntimeException.class)
+			.hasMessageContaining("비밀번호가 일치하지 않습니다.");
 
-        verify(groupReader, times(1)).read(group.getId());
-        verify(groupValidator, times(1)).checkGroupAuthor(group, 1L);
-        verify(groupValidator, times(1)).checkGroupPassword(request, storedPassword);
-    }
+		verify(groupReader, times(1)).read(group.getId());
+		verify(groupValidator, times(1)).checkGroupAuthor(group, 1L);
+		verify(groupValidator, times(1)).checkGroupPassword(request, storedPassword);
+	}
 }

--- a/src/test/java/com/dnd/moddo/domain/group/service/implementation/GroupCreatorTest.java
+++ b/src/test/java/com/dnd/moddo/domain/group/service/implementation/GroupCreatorTest.java
@@ -1,13 +1,10 @@
 package com.dnd.moddo.domain.group.service.implementation;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import java.time.LocalDateTime;
 
-import com.dnd.moddo.domain.user.entity.type.Authority;
-import com.dnd.moddo.global.jwt.dto.GroupTokenResponse;
-import com.dnd.moddo.global.jwt.utill.JwtProvider;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -21,59 +18,61 @@ import com.dnd.moddo.domain.group.dto.request.GroupRequest;
 import com.dnd.moddo.domain.group.entity.Group;
 import com.dnd.moddo.domain.group.repository.GroupRepository;
 import com.dnd.moddo.domain.user.entity.User;
+import com.dnd.moddo.domain.user.entity.type.Authority;
 import com.dnd.moddo.domain.user.repository.UserRepository;
+import com.dnd.moddo.global.jwt.utill.JwtProvider;
 
 @ExtendWith(MockitoExtension.class)
 class GroupCreatorTest {
-    @Mock
-    private GroupRepository groupRepository;
+	@Mock
+	private GroupRepository groupRepository;
 
-    @Mock
-    private UserRepository userRepository;
+	@Mock
+	private UserRepository userRepository;
 
-    @Mock
-    private BCryptPasswordEncoder passwordEncoder;
+	@Mock
+	private BCryptPasswordEncoder passwordEncoder;
 
-    @Mock
-    private JwtProvider jwtProvider;
+	@Mock
+	private JwtProvider jwtProvider;
 
-    @InjectMocks
-    private GroupCreator groupCreator;
+	@InjectMocks
+	private GroupCreator groupCreator;
 
-    private Long userId;
-    private GroupRequest request;
-    private User mockUser;
-    private String encodedPassword;
-    private Group mockGroup;
+	private Long userId;
+	private GroupRequest request;
+	private User mockUser;
+	private String encodedPassword;
+	private Group mockGroup;
 
-    @BeforeEach
-    void setUp() {
-        userId = 1L;
-        request = new GroupRequest("groupName", "password", LocalDateTime.now().plusDays(1));
-        mockUser = new User(userId, "test@example.com", "닉네임", "프로필", false, LocalDateTime.now(), LocalDateTime.now().plusDays(1), Authority.USER);
-        encodedPassword = "encryptedPassword";
-        mockGroup = new Group(request.name(), userId, "password", LocalDateTime.now(), LocalDateTime.now().plusMonths(1), "groupName", encodedPassword, LocalDateTime.now().plusDays(1));
-    }
+	@BeforeEach
+	void setUp() {
+		userId = 1L;
+		request = new GroupRequest("groupName", "password", LocalDateTime.now().plusDays(1));
+		mockUser = new User(userId, "test@example.com", "닉네임", "프로필", false, LocalDateTime.now(),
+			LocalDateTime.now().plusDays(1), Authority.USER);
+		encodedPassword = "encryptedPassword";
+		mockGroup = new Group(request.name(), userId, "password", LocalDateTime.now(),
+			LocalDateTime.now().plusMonths(1), "groupName", encodedPassword, LocalDateTime.now().plusDays(1));
+	}
 
-    @DisplayName("사용자는 모임 생성에 성공한다.")
-    @Test
-    void createGroupSuccess() {
-        // given
-        when(userRepository.getById(userId)).thenReturn(mockUser);
-        when(passwordEncoder.encode(request.password())).thenReturn(encodedPassword);
-        when(groupRepository.save(any(Group.class))).thenReturn(mockGroup);
-        when(jwtProvider.generateGroupToken(mockGroup.getId())).thenReturn(new GroupTokenResponse("group-token"));
+	@DisplayName("사용자는 모임 생성에 성공한다.")
+	@Test
+	void createGroupSuccess() {
+		// given
+		when(userRepository.getById(userId)).thenReturn(mockUser);
+		when(passwordEncoder.encode(request.password())).thenReturn(encodedPassword);
+		when(groupRepository.save(any(Group.class))).thenReturn(mockGroup);
 
-        // when
-        GroupTokenResponse response = groupCreator.createGroup(request, userId);
+		// when
+		Group response = groupCreator.createGroup(request, userId);
 
-        // then
-        assertThat(response).isNotNull();
-        assertThat(response.groupToken()).isEqualTo("group-token");
+		// then
+		assertThat(response).isNotNull();
+		assertThat(response.getName()).isEqualTo(request.name());
 
-        verify(userRepository, times(1)).getById(userId);
-        verify(passwordEncoder, times(1)).encode(request.password());
-        verify(groupRepository, times(1)).save(any(Group.class));
-        verify(jwtProvider, times(1)).generateGroupToken(mockGroup.getId());
-    }
+		verify(userRepository, times(1)).getById(userId);
+		verify(passwordEncoder, times(1)).encode(request.password());
+		verify(groupRepository, times(1)).save(any(Group.class));
+	}
 }

--- a/src/test/java/com/dnd/moddo/domain/groupMember/service/CommandGroupMemberServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/groupMember/service/CommandGroupMemberServiceTest.java
@@ -5,7 +5,6 @@ import static org.mockito.Mockito.*;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -20,7 +19,6 @@ import com.dnd.moddo.domain.groupMember.dto.request.GroupMemberSaveRequest;
 import com.dnd.moddo.domain.groupMember.dto.request.GroupMembersSaveRequest;
 import com.dnd.moddo.domain.groupMember.dto.request.PaymentStatusUpdateRequest;
 import com.dnd.moddo.domain.groupMember.dto.response.GroupMemberResponse;
-import com.dnd.moddo.domain.groupMember.dto.response.GroupMembersResponse;
 import com.dnd.moddo.domain.groupMember.entity.GroupMember;
 import com.dnd.moddo.domain.groupMember.entity.type.ExpenseRole;
 import com.dnd.moddo.domain.groupMember.service.implementation.GroupMemberCreator;
@@ -49,22 +47,18 @@ public class CommandGroupMemberServiceTest {
 		//given
 		Long groupId = mockGroup.getId(), userId = 1L;
 		GroupMembersSaveRequest request = new GroupMembersSaveRequest(new ArrayList<>());
-		List<GroupMember> expectedMembers = List.of(
-			new GroupMember("김모또", 1, mockGroup, ExpenseRole.MANAGER),
-			new GroupMember("김반숙", 2, mockGroup, ExpenseRole.PARTICIPANT)
-		);
+		GroupMember expectedMembers = new GroupMember("김모또", 1, mockGroup, ExpenseRole.MANAGER);
 
-		when(groupMemberCreator.create(eq(groupId), any(), eq(request))).thenReturn(expectedMembers);
+		when(groupMemberCreator.createManagerForGroup(eq(groupId), any())).thenReturn(expectedMembers);
 
 		// when
-		GroupMembersResponse response = commandGroupMemberService.create(groupId, userId, request);
+		GroupMemberResponse response = commandGroupMemberService.createManager(groupId, userId);
 
 		//then
 		assertThat(response).isNotNull();
-		assertThat(response.members().size()).isEqualTo(2);
-		assertThat(response.members().get(0).name()).isEqualTo("김모또");
-		assertThat(response.members().get(0).role()).isEqualTo(ExpenseRole.MANAGER);
-		verify(groupMemberCreator, times(1)).create(eq(groupId), any(), eq(request));
+		assertThat(response.name()).isEqualTo("김모또");
+		assertThat(response.role()).isEqualTo(ExpenseRole.MANAGER);
+		verify(groupMemberCreator, times(1)).createManagerForGroup(eq(groupId), any());
 	}
 
 	@DisplayName("모든 정보가 유효할때 기존 모임의 참여자 추가가 성공한다.")

--- a/src/test/java/com/dnd/moddo/domain/groupMember/service/CommandGroupMemberServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/groupMember/service/CommandGroupMemberServiceTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.BDDAssertions.*;
 import static org.mockito.Mockito.*;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -16,7 +15,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.dnd.moddo.domain.group.entity.Group;
 import com.dnd.moddo.domain.groupMember.dto.request.GroupMemberSaveRequest;
-import com.dnd.moddo.domain.groupMember.dto.request.GroupMembersSaveRequest;
 import com.dnd.moddo.domain.groupMember.dto.request.PaymentStatusUpdateRequest;
 import com.dnd.moddo.domain.groupMember.dto.response.GroupMemberResponse;
 import com.dnd.moddo.domain.groupMember.entity.GroupMember;
@@ -41,15 +39,14 @@ public class CommandGroupMemberServiceTest {
 			"은행", "계좌", LocalDateTime.now().plusDays(1));
 	}
 
-	@DisplayName("모든 정보가 유효할때 모임에 참여자 추가가 성공한다.")
+	@DisplayName("모든 정보가 유효할때 총무 생성에 성공한다.")
 	@Test
 	void createSuccess() {
 		//given
-		Long groupId = mockGroup.getId(), userId = 1L;
-		GroupMembersSaveRequest request = new GroupMembersSaveRequest(new ArrayList<>());
+		Long groupId = 1L, userId = 1L;
 		GroupMember expectedMembers = new GroupMember("김모또", 1, mockGroup, ExpenseRole.MANAGER);
 
-		when(groupMemberCreator.createManagerForGroup(eq(groupId), any())).thenReturn(expectedMembers);
+		when(groupMemberCreator.createManagerForGroup(eq(groupId), eq(userId))).thenReturn(expectedMembers);
 
 		// when
 		GroupMemberResponse response = commandGroupMemberService.createManager(groupId, userId);

--- a/src/test/java/com/dnd/moddo/domain/groupMember/service/CommandGroupMemberServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/groupMember/service/CommandGroupMemberServiceTest.java
@@ -43,19 +43,19 @@ public class CommandGroupMemberServiceTest {
 	@Test
 	void createSuccess() {
 		//given
-		Long groupId = 1L, userId = 1L;
+		Long userId = 1L;
 		GroupMember expectedMembers = new GroupMember("김모또", 1, mockGroup, ExpenseRole.MANAGER);
-
-		when(groupMemberCreator.createManagerForGroup(eq(groupId), eq(userId))).thenReturn(expectedMembers);
+		Group mockGroup = mock(Group.class);
+		when(groupMemberCreator.createManagerForGroup(any(Group.class), eq(userId))).thenReturn(expectedMembers);
 
 		// when
-		GroupMemberResponse response = commandGroupMemberService.createManager(groupId, userId);
+		GroupMemberResponse response = commandGroupMemberService.createManager(mockGroup, userId);
 
 		//then
 		assertThat(response).isNotNull();
 		assertThat(response.name()).isEqualTo("김모또");
 		assertThat(response.role()).isEqualTo(ExpenseRole.MANAGER);
-		verify(groupMemberCreator, times(1)).createManagerForGroup(eq(groupId), any());
+		verify(groupMemberCreator, times(1)).createManagerForGroup(any(Group.class), any());
 	}
 
 	@DisplayName("모든 정보가 유효할때 기존 모임의 참여자 추가가 성공한다.")

--- a/src/test/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberCreatorTest.java
+++ b/src/test/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberCreatorTest.java
@@ -47,8 +47,6 @@ public class GroupMemberCreatorTest {
 		Long groupId = 1L, userId = 1L;
 		Group mockGroup = mock(Group.class);
 
-		when(groupReader.read(eq(groupId))).thenReturn(mockGroup);
-
 		User mockUser = mock(User.class);
 		when(userRepository.getById(eq(userId))).thenReturn(mockUser);
 		when(mockUser.getIsMember()).thenReturn(false);
@@ -58,7 +56,7 @@ public class GroupMemberCreatorTest {
 		when(groupMemberRepository.save(any())).thenReturn(expectedMember);
 
 		//when
-		GroupMember savedMember = groupMemberCreator.createManagerForGroup(groupId, userId);
+		GroupMember savedMember = groupMemberCreator.createManagerForGroup(mockGroup, userId);
 
 		//then
 		assertThat(savedMember).isNotNull();
@@ -71,10 +69,8 @@ public class GroupMemberCreatorTest {
 	@Test
 	void create_Success_WithMember() {
 		//given
-		Long groupId = 1L, userId = 1L;
+		Long userId = 1L;
 		Group mockGroup = mock(Group.class);
-
-		when(groupReader.read(eq(groupId))).thenReturn(mockGroup);
 
 		User mockUser = mock(User.class);
 		when(userRepository.getById(eq(userId))).thenReturn(mockUser);
@@ -85,7 +81,7 @@ public class GroupMemberCreatorTest {
 		when(groupMemberRepository.save(any(GroupMember.class))).thenReturn(expectedMember);
 
 		//when
-		GroupMember savedMember = groupMemberCreator.createManagerForGroup(groupId, userId);
+		GroupMember savedMember = groupMemberCreator.createManagerForGroup(mockGroup, userId);
 
 		//then
 		assertThat(savedMember).isNotNull();

--- a/src/test/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberCreatorTest.java
+++ b/src/test/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberCreatorTest.java
@@ -4,9 +4,6 @@ import static org.assertj.core.api.BDDAssertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -17,7 +14,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.dnd.moddo.domain.group.entity.Group;
 import com.dnd.moddo.domain.group.service.implementation.GroupReader;
-import com.dnd.moddo.domain.groupMember.dto.request.GroupMembersSaveRequest;
 import com.dnd.moddo.domain.groupMember.entity.GroupMember;
 import com.dnd.moddo.domain.groupMember.entity.type.ExpenseRole;
 import com.dnd.moddo.domain.groupMember.repository.GroupMemberRepository;
@@ -39,20 +35,17 @@ public class GroupMemberCreatorTest {
 
 	private Group mockGroup;
 
-	private GroupMembersSaveRequest request;
-
 	@BeforeEach
 	void setUp() {
-		mockGroup = new Group("group 1", 1L, "1234", LocalDateTime.now(), LocalDateTime.now().plusMinutes(1),
-			"은행", "계좌", LocalDateTime.now().plusDays(1));
-		request = new GroupMembersSaveRequest(new ArrayList<>());
+		mockGroup = mock(Group.class);
 	}
 
 	@DisplayName("사용자가 비회원인 경우, 모든 이름이 중복없이 유효할 때 총무의 이름은 '김모또'로 생성된다.")
 	@Test
 	void create_Success_WithGuestMember() {
 		//given
-		Long groupId = mockGroup.getId(), userId = 1L;
+		Long groupId = 1L, userId = 1L;
+		Group mockGroup = mock(Group.class);
 
 		when(groupReader.read(eq(groupId))).thenReturn(mockGroup);
 
@@ -71,18 +64,17 @@ public class GroupMemberCreatorTest {
 		assertThat(savedMember).isNotNull();
 		assertThat(savedMember.getName()).isEqualTo("김모또");
 		assertThat(savedMember.getRole()).isEqualTo(ExpenseRole.MANAGER);
-		verify(groupMemberRepository, times(1)).saveAll(anyList());
+		verify(groupMemberRepository, times(1)).save(any());
 	}
 
 	@DisplayName("사용자가 회원인 경우, 모든 이름이 중복없이 유효할 때 총무의 이름은 회원의 이름으로 생성된다.")
 	@Test
 	void create_Success_WithMember() {
 		//given
-		Long groupId = mockGroup.getId(), userId = 1L;
+		Long groupId = 1L, userId = 1L;
+		Group mockGroup = mock(Group.class);
 
 		when(groupReader.read(eq(groupId))).thenReturn(mockGroup);
-
-		doNothing().when(groupMemberValidator).validateMemberNamesNotDuplicate(any());
 
 		User mockUser = mock(User.class);
 		when(userRepository.getById(eq(userId))).thenReturn(mockUser);
@@ -101,6 +93,6 @@ public class GroupMemberCreatorTest {
 		assertThat(savedMember.getRole()).isEqualTo(ExpenseRole.MANAGER);
 
 		verify(userRepository, times(1)).getById(eq(userId));
-		verify(groupMemberRepository, times(1)).saveAll(anyList());
+		verify(groupMemberRepository, times(1)).save(any());
 	}
 }

--- a/src/test/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberUpdaterTest.java
+++ b/src/test/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberUpdaterTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.Mockito.*;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -18,6 +17,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.dnd.moddo.domain.group.entity.Group;
 import com.dnd.moddo.domain.group.repository.GroupRepository;
+import com.dnd.moddo.domain.group.service.implementation.GroupReader;
 import com.dnd.moddo.domain.groupMember.dto.request.GroupMemberSaveRequest;
 import com.dnd.moddo.domain.groupMember.dto.request.PaymentStatusUpdateRequest;
 import com.dnd.moddo.domain.groupMember.entity.GroupMember;
@@ -34,6 +34,8 @@ class GroupMemberUpdaterTest {
 	@Mock
 	private GroupMemberValidator groupMemberValidator;
 	@Mock
+	private GroupReader groupReader;
+	@Mock
 	private GroupRepository groupRepository;
 	@InjectMocks
 	private GroupMemberUpdater groupMemberUpdater;
@@ -41,18 +43,18 @@ class GroupMemberUpdaterTest {
 	private Group mockGroup;
 
 	@BeforeEach
-	void setUp() {
-		mockGroup = new Group("group 1", 1L, "1234", LocalDateTime.now(), LocalDateTime.now().plusMinutes(1),
-			"은행", "계좌", LocalDateTime.now().plusDays(1));
+	void setup() {
+		mockGroup = mock(Group.class);
 	}
 
 	@DisplayName("추가하려는 참여자의 이름이 기존 참여자의 이름과 중복되지 않을경우 참여자 추가에 성공한다.")
 	@Test
 	void addToGroupSuccess() {
 		//given
-		Long groupId = mockGroup.getId();
+		Long groupId = 1L;
 		GroupMemberSaveRequest request = mock(GroupMemberSaveRequest.class);
-		when(groupRepository.getById(eq(groupId))).thenReturn(mockGroup);
+
+		when(groupReader.read(eq(groupId))).thenReturn(mockGroup);
 
 		List<GroupMember> mockGroupMembers = new ArrayList<>();
 		when(groupMemberReader.findAllByGroupId(eq(groupId))).thenReturn(mockGroupMembers);
@@ -77,9 +79,10 @@ class GroupMemberUpdaterTest {
 	@Test
 	void addToGroupDuplicatedName() {
 		//given
-		Long groupId = mockGroup.getId();
+		Long groupId = 1L;
 		GroupMemberSaveRequest request = mock(GroupMemberSaveRequest.class);
-		when(groupRepository.getById(eq(groupId))).thenReturn(mockGroup);
+
+		when(groupReader.read(eq(groupId))).thenReturn(mockGroup);
 
 		List<GroupMember> mockGroupMembers = new ArrayList<>();
 		when(groupMemberReader.findAllByGroupId(eq(groupId))).thenReturn(mockGroupMembers);
@@ -97,6 +100,7 @@ class GroupMemberUpdaterTest {
 	@Test
 	void updatePaymentStatus_Success() {
 		//given
+
 		GroupMember groupMember = new GroupMember("김반숙", mockGroup, ExpenseRole.PARTICIPANT);
 		PaymentStatusUpdateRequest request = new PaymentStatusUpdateRequest(true);
 


### PR DESCRIPTION
### #️⃣연관된 이슈
#75 

### 🔀반영 브랜치
feat/#75-group-member-addition -> develop

### 🔧변경 사항
- 모임이 생성된 후 바로 총무가 생성될 수 있도록 기능을 추가했습니다.
  - 기존에는 `groupToken`을 `groupCreator.createGroup()`에서 넘겨줬었는데, 모임 생성 후 총무를 생성할 때 생성된 모임의 정보가 필요해서 `groupCreator.createGroup()`에서 `groupToken` 생성하는 부분을 분리했습니다!
  - 최대한 기존 코드에 영향을 주지 않으면서 기능을 추가하고 싶었지만 생성된 `group`을 받기 위해서는 `groupCreator.createGroup()`에서 토큰 생성 부분을 분리하고 `group`만 반환하도록 할지, 아니면 `GroupCreator`내부에 총무 생성 로직을 추가하고, 생성된 총무 정보를 token과 함께 반환할지 두 가지 방법이 떠올랐어요. 🤔
  - 하지만 두 번째 방법은 GroupCreator가 총무 생성까지 담당하게 되어 단일 책임 원칙을 위반하는 것 같아서 첫 번째 방법을 선택했습니다! 💡
- `jwtTokenProvider.generateGroupToken()`은 원래 `GroupTokenResponse`를 반환했는데, 이제는 토큰 문자열을 그대로 반환하도록 수정했습니다. ✨
  - `GroupTokenResponse` 형태를 유지하려 했지만  아래와 같이 불필요하게 response가 wrapping되는 문제가 발생했기 때문에 이렇게 변경했습니다. 😅
    ``` json
    {
        "groupToken": { 👈 이중으로 wrapping
            "groupToken": "grouptoken"
        },
        "manager": {
            "id": 1,
            "role": "MANAGER",
            "name": "김모또",
            "profile": "https://example.com/profiles/default.jpg",
            "isPaid": true,
            "paidAt": "2025-02-19T21:57:50.139608"
        }
    }
    ```
  - 그래서 해당 토큰을 발급하는 부분을 사용하는 곳이 `createGroup`밖에 없는 것 같아서 아래와 같은 형태를 유지할 수 있도록 반환 타입을 수정했습니다. 😊
     ``` json
     {
      "groupToken": "grouptoken",
      "manager": {
          "id": 1,
          "role": "MANAGER",
          "name": "김모또",
          "profile": "https://example.com/profiles/default.jpg",
          "isPaid": true,
          "paidAt": "2025-02-19T21:57:50.139608"
        }
      }
     ```
 - 총무를 생성할 때 기존에는 builder를 활용하여 총무의 `isPaid`는 true값으로 세팅되도록 하였습니다. 이렇게 하면 `paidAt`이 null로 세팅되게 됩니다. 하지만 `paidAt`이 null로 비어있는게 정책과 맞지 않는 것 같아서 `groupMember.updatePaymentStatus(true)`를 해주어, isPaid의 값과 paidAt의 값을 동시에 세팅해주었습니다.
 
### 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요
