### PR TITLE
참여자 추가 시 프로필 자동 할당 기능

### DIFF
--- a/src/main/java/com/dnd/moddo/domain/group/controller/GroupController.java
+++ b/src/main/java/com/dnd/moddo/domain/group/controller/GroupController.java
@@ -19,7 +19,6 @@ import com.dnd.moddo.domain.group.dto.response.GroupResponse;
 import com.dnd.moddo.domain.group.dto.response.GroupSaveResponse;
 import com.dnd.moddo.domain.group.service.CommandGroupService;
 import com.dnd.moddo.domain.group.service.QueryGroupService;
-import com.dnd.moddo.global.common.annotation.VerifyManagerPermission;
 import com.dnd.moddo.global.jwt.service.JwtService;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -76,12 +75,11 @@ public class GroupController {
 		return ResponseEntity.ok(response);
 	}
 
-	@VerifyManagerPermission
 	@GetMapping("/header")
 	public ResponseEntity<GroupHeaderResponse> getHeader(
 		@RequestParam("groupToken") String groupToken) {
 		Long groupId = jwtService.getGroupId(groupToken);
-
+		
 		GroupHeaderResponse response = queryGroupService.findByGroupHeader(groupId);
 		return ResponseEntity.ok(response);
 	}

--- a/src/main/java/com/dnd/moddo/domain/group/dto/response/GroupResponse.java
+++ b/src/main/java/com/dnd/moddo/domain/group/dto/response/GroupResponse.java
@@ -1,25 +1,27 @@
 package com.dnd.moddo.domain.group.dto.response;
 
-import com.dnd.moddo.domain.group.entity.Group;
-
 import java.time.LocalDateTime;
 
+import com.dnd.moddo.domain.group.entity.Group;
+
 public record GroupResponse(
-        Long id,
-        Long writer,
-        LocalDateTime createdAt,
-        LocalDateTime expiredAt,
-        String bank,
-        String accountNumber
+	Long id,
+	Long writer,
+	LocalDateTime createdAt,
+	LocalDateTime expiredAt,
+	String bank,
+	String accountNumber,
+	LocalDateTime deadline
 ) {
-    public static GroupResponse of(Group group) {
-        return new GroupResponse(
-                group.getId(),
-                group.getWriter(),
-                group.getCreatedAt(),
-                group.getExpiredAt(),
-                group.getBank(),
-                group.getAccountNumber()
-        );
-    }
+	public static GroupResponse of(Group group) {
+		return new GroupResponse(
+			group.getId(),
+			group.getWriter(),
+			group.getCreatedAt(),
+			group.getExpiredAt(),
+			group.getBank(),
+			group.getAccountNumber(),
+			group.getDeadline()
+		);
+	}
 }

--- a/src/main/java/com/dnd/moddo/domain/group/entity/Group.java
+++ b/src/main/java/com/dnd/moddo/domain/group/entity/Group.java
@@ -1,10 +1,20 @@
 package com.dnd.moddo.domain.group.entity;
 
-import com.dnd.moddo.domain.group.dto.request.GroupAccountRequest;
-import jakarta.persistence.*;
-import lombok.*;
-
 import java.time.LocalDateTime;
+
+import com.dnd.moddo.domain.group.dto.request.GroupAccountRequest;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
@@ -13,45 +23,47 @@ import java.time.LocalDateTime;
 @Table(name = "groups")
 public class Group {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
 
-    @Column(name = "user_id")
-    private Long writer;
+	@Column(name = "user_id")
+	private Long writer;
 
-    private String name;
+	private String name;
 
-    private String password;
+	private String password;
 
-    private LocalDateTime createdAt;
+	private LocalDateTime createdAt;
 
-    private LocalDateTime expiredAt;
+	private LocalDateTime expiredAt;
 
-    private String bank;
+	private String bank;
 
-    private String accountNumber;
+	private String accountNumber;
 
-    private LocalDateTime deadline;
+	private LocalDateTime deadline;
 
-    @Builder
-    public Group(String name, Long writer, String password, LocalDateTime createdAt, LocalDateTime expiredAt, String bank, String accountNumber, LocalDateTime deadline) {
-        this.name = name;
-        this.writer = writer;
-        this.password = password;
-        this.createdAt = createdAt;
-        this.expiredAt = expiredAt;
-        this.bank = bank;
-        this.accountNumber = accountNumber;
-        this.deadline = LocalDateTime.now().plusDays(1);
-    }
+	@Builder
+	public Group(String name, Long writer, String password, LocalDateTime createdAt,
+		String bank, String accountNumber, LocalDateTime deadline) {
+		this.name = name;
+		this.writer = writer;
+		this.password = password;
+		this.createdAt = createdAt;
+		this.expiredAt = LocalDateTime.now().plusMonths(1);
+		this.bank = bank;
+		this.accountNumber = accountNumber;
+		this.deadline = deadline;
+	}
 
-    public void updateAccount(GroupAccountRequest request) {
-        this.bank = request.bank();
-        this.accountNumber = request.accountNumber();
-    }
+	public void updateAccount(GroupAccountRequest request) {
+		this.bank = request.bank();
+		this.accountNumber = request.accountNumber();
+		this.deadline = LocalDateTime.now().plusDays(1);
+	}
 
-    public boolean isWriter(Long userId) {
-        return this.writer.equals(userId);
-    }
+	public boolean isWriter(Long userId) {
+		return this.writer.equals(userId);
+	}
 }

--- a/src/main/java/com/dnd/moddo/domain/group/service/implementation/GroupCreator.java
+++ b/src/main/java/com/dnd/moddo/domain/group/service/implementation/GroupCreator.java
@@ -30,7 +30,6 @@ public class GroupCreator {
 			.name(request.name())
 			.password(encryptedPassword)
 			.createdAt(LocalDateTime.now())
-			.expiredAt(LocalDateTime.now().plusMonths(1))
 			.build();
 
 		return groupRepository.save(group);

--- a/src/main/java/com/dnd/moddo/domain/groupMember/dto/request/GroupMemberSaveRequest.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/dto/request/GroupMemberSaveRequest.java
@@ -11,10 +11,14 @@ public record GroupMemberSaveRequest(
 	@NotBlank(message = "이름은 필수 입력값 입니다.")
 	@Pattern(regexp = "^[가-힣a-zA-Z]{1,5}$", message = "참여자 이름은 한글과 영어만 포함하여 5자 이내여야 합니다.")
 	String name
-
 ) {
-	public GroupMember toEntity(Group group, ExpenseRole role) {
-		Integer proflieId = null;
-		return new GroupMember(name(), group, role);
+	public GroupMember toEntity(Group group, String profile, ExpenseRole role) {
+		return GroupMember.builder()
+			.name(name)
+			.group(group)
+			.role(role)
+			.profile(profile)
+			.isPaid(false)
+			.build();
 	}
 }

--- a/src/main/java/com/dnd/moddo/domain/groupMember/dto/request/GroupMemberSaveRequest.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/dto/request/GroupMemberSaveRequest.java
@@ -1,6 +1,5 @@
 package com.dnd.moddo.domain.groupMember.dto.request;
 
-import com.dnd.moddo.domain.group.entity.Group;
 import com.dnd.moddo.domain.groupMember.entity.GroupMember;
 import com.dnd.moddo.domain.groupMember.entity.type.ExpenseRole;
 
@@ -13,8 +12,7 @@ public record GroupMemberSaveRequest(
 	String name
 
 ) {
-	public GroupMember toEntity(Group group, ExpenseRole role) {
-		Integer proflieId = null;
-		return new GroupMember(name(), proflieId, group, role);
+	public GroupMember toEntity(ExpenseRole role) {
+		return new GroupMember(name(), role);
 	}
 }

--- a/src/main/java/com/dnd/moddo/domain/groupMember/dto/request/GroupMemberSaveRequest.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/dto/request/GroupMemberSaveRequest.java
@@ -1,5 +1,6 @@
 package com.dnd.moddo.domain.groupMember.dto.request;
 
+import com.dnd.moddo.domain.group.entity.Group;
 import com.dnd.moddo.domain.groupMember.entity.GroupMember;
 import com.dnd.moddo.domain.groupMember.entity.type.ExpenseRole;
 
@@ -12,7 +13,8 @@ public record GroupMemberSaveRequest(
 	String name
 
 ) {
-	public GroupMember toEntity(ExpenseRole role) {
-		return new GroupMember(name(), role);
+	public GroupMember toEntity(Group group, ExpenseRole role) {
+		Integer proflieId = null;
+		return new GroupMember(name(), group, role);
 	}
 }

--- a/src/main/java/com/dnd/moddo/domain/groupMember/dto/request/GroupMembersSaveRequest.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/dto/request/GroupMembersSaveRequest.java
@@ -14,7 +14,7 @@ public record GroupMembersSaveRequest(
 ) {
 	public List<GroupMember> toEntity(Group group) {
 		return members.stream()
-			.map(m -> m.toEntity(group, PARTICIPANT))
+			.map(m -> m.toEntity(group, null, PARTICIPANT))
 			.toList();
 	}
 

--- a/src/main/java/com/dnd/moddo/domain/groupMember/dto/response/GroupMemberExpenseResponse.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/dto/response/GroupMemberExpenseResponse.java
@@ -27,7 +27,7 @@ public record GroupMemberExpenseResponse(
 			.role(groupMember.getRole())
 			.name(groupMember.getName())
 			.totalAmount(totalAmount)
-			.profile(groupMember.getProfileUrl())
+			.profile(groupMember.getProfileUrl(groupMember.getId()))
 			.isPaid(groupMember.isPaid())
 			.paidAt(groupMember.getPaidAt())
 			.expenses(expenses).build();

--- a/src/main/java/com/dnd/moddo/domain/groupMember/dto/response/GroupMemberExpenseResponse.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/dto/response/GroupMemberExpenseResponse.java
@@ -27,7 +27,7 @@ public record GroupMemberExpenseResponse(
 			.role(groupMember.getRole())
 			.name(groupMember.getName())
 			.totalAmount(totalAmount)
-			.profile(groupMember.getProfileUrl(groupMember.getId()))
+			.profile(groupMember.getProfile())
 			.isPaid(groupMember.isPaid())
 			.paidAt(groupMember.getPaidAt())
 			.expenses(expenses).build();

--- a/src/main/java/com/dnd/moddo/domain/groupMember/dto/response/GroupMemberResponse.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/dto/response/GroupMemberResponse.java
@@ -24,7 +24,7 @@ public record GroupMemberResponse(
 			.role(groupMember.getRole())
 			.isPaid(groupMember.isPaid())
 			.paidAt(groupMember.getPaidAt())
-			.profile(groupMember.getProfileUrl())
+			.profile(groupMember.getProfileUrl(groupMember.getId()))
 			.build();
 	}
 

--- a/src/main/java/com/dnd/moddo/domain/groupMember/dto/response/GroupMemberResponse.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/dto/response/GroupMemberResponse.java
@@ -24,7 +24,7 @@ public record GroupMemberResponse(
 			.role(groupMember.getRole())
 			.isPaid(groupMember.isPaid())
 			.paidAt(groupMember.getPaidAt())
-			.profile(groupMember.getProfileUrl(groupMember.getId()))
+			.profile(groupMember.getProfile())
 			.build();
 	}
 

--- a/src/main/java/com/dnd/moddo/domain/groupMember/entity/GroupMember.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/entity/GroupMember.java
@@ -35,10 +35,10 @@ public class GroupMember {
 	private String name;
 
 	@Column(name = "profile")
-	private Integer profile;
+	private String profile;
 
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "group_id")
+	@JoinColumn(name = "group_id", nullable = false)
 	private Group group;
 
 	@Column(name = "is_paid", nullable = false)
@@ -48,22 +48,11 @@ public class GroupMember {
 	private LocalDateTime paidAt;
 
 	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
 	private ExpenseRole role;
 
-	public GroupMember(String name, Group group, ExpenseRole role) {
-		this(name, null, group, false, role);
-	}
-
-	public GroupMember(String name, Group group, boolean isPaid, ExpenseRole role) {
-		this(name, null, group, isPaid, role);
-	}
-
-	public GroupMember(String name, Integer profileId, Group group, ExpenseRole role) {
-		this(name, profileId, group, false, role);
-	}
-
 	@Builder
-	public GroupMember(String name, Integer profile, Group group, boolean isPaid, ExpenseRole role) {
+	public GroupMember(String name, String profile, Group group, boolean isPaid, ExpenseRole role) {
 		this.name = name;
 		this.profile = profile;
 		this.group = group;
@@ -77,18 +66,10 @@ public class GroupMember {
 
 	public void updatePaymentStatus(Boolean isPaid) {
 		this.isPaid = isPaid;
-		if (Boolean.TRUE.equals(isPaid)) {
-			this.paidAt = LocalDateTime.now();
-		} else {
-			this.paidAt = null;
-		}
+		this.paidAt = Boolean.TRUE.equals(isPaid) ? LocalDateTime.now() : null;
 	}
 
-	public String getProfileUrl(Long profileId) {
-		if (profileId > 8) {
-			Long finalId = profileId - 8;
-			return "https://moddo-s3.s3.ap-northeast-2.amazonaws.com/profile/" + finalId + ".png";
-		}
-		return "https://moddo-s3.s3.ap-northeast-2.amazonaws.com/profile/" + profileId + ".png";
+	public void updateProfile(String profile) {
+		this.profile = profile;
 	}
 }

--- a/src/main/java/com/dnd/moddo/domain/groupMember/entity/GroupMember.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/entity/GroupMember.java
@@ -34,8 +34,8 @@ public class GroupMember {
 	@Column(name = "name", updatable = false, nullable = false)
 	private String name;
 
-	@Column(name = "profile_id")
-	private Integer profileId;
+	@Column(name = "profile")
+	private Integer profile;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "group_id")
@@ -63,9 +63,9 @@ public class GroupMember {
 	}
 
 	@Builder
-	public GroupMember(String name, Integer profileId, Group group, boolean isPaid, ExpenseRole role) {
+	public GroupMember(String name, Integer profile, Group group, boolean isPaid, ExpenseRole role) {
 		this.name = name;
-		this.profileId = profileId;
+		this.profile = profile;
 		this.group = group;
 		this.isPaid = isPaid;
 		this.role = role;
@@ -84,11 +84,11 @@ public class GroupMember {
 		}
 	}
 
-	public String getProfileUrl() {
-		if (profileId == null) {
-			return "https://example.com/profiles/default.jpg";
+	public String getProfileUrl(Long profileId) {
+		if (profileId > 8) {
+			Long finalId = profileId - 8;
+			return "https://moddo-s3.s3.ap-northeast-2.amazonaws.com/profile/" + finalId + ".png";
 		}
-		return "https://example.com/profiles/" + profileId + ".jpg";
+		return "https://moddo-s3.s3.ap-northeast-2.amazonaws.com/profile/" + profileId + ".png";
 	}
 }
-

--- a/src/main/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberCreator.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberCreator.java
@@ -26,7 +26,6 @@ public class GroupMemberCreator {
 
 		GroupMember groupMember = GroupMember.builder()
 			.name(name)
-			.profileId(null)     //user 프로필 가져오기
 			.group(group)
 			.role(ExpenseRole.MANAGER)
 			.build();

--- a/src/main/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberUpdater.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberUpdater.java
@@ -56,7 +56,7 @@ public class GroupMemberUpdater {
 			return s3Bucket.getS3Url() + "profile/moddo.png";
 		}
 
-		Long finalId = (memberId - 1) % 9 + 1; // 🔥 ID를 1~9 범위로 변환
+		Long finalId = (memberId - 1) % 9 + 1;
 		return s3Bucket.getS3Url() + "profile/" + finalId + ".png";
 	}
 }

--- a/src/main/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberUpdater.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberUpdater.java
@@ -13,6 +13,7 @@ import com.dnd.moddo.domain.groupMember.dto.request.PaymentStatusUpdateRequest;
 import com.dnd.moddo.domain.groupMember.entity.GroupMember;
 import com.dnd.moddo.domain.groupMember.entity.type.ExpenseRole;
 import com.dnd.moddo.domain.groupMember.repository.GroupMemberRepository;
+import com.dnd.moddo.global.config.S3Bucket;
 
 import lombok.RequiredArgsConstructor;
 
@@ -24,6 +25,7 @@ public class GroupMemberUpdater {
 	private final GroupMemberReader groupMemberReader;
 	private final GroupMemberValidator groupMemberValidator;
 	private final GroupReader groupReader;
+	private final S3Bucket s3Bucket;
 
 	public GroupMember addToGroup(Long groupId, GroupMemberSaveRequest request) {
 		Group group = groupReader.read(groupId);
@@ -34,12 +36,27 @@ public class GroupMemberUpdater {
 
 		groupMemberValidator.validateMemberNamesNotDuplicate(existingNames);
 
-		return groupMemberRepository.save(request.toEntity(group, ExpenseRole.PARTICIPANT));
+		GroupMember newMember = request.toEntity(group, null, ExpenseRole.PARTICIPANT);
+		newMember = groupMemberRepository.save(newMember);
+
+		String profileUrl = getProfileUrl(newMember.getId());
+		newMember.updateProfile(profileUrl);
+
+		return newMember;
 	}
 
 	public GroupMember updatePaymentStatus(Long groupMemberId, PaymentStatusUpdateRequest request) {
 		GroupMember groupMember = groupMemberRepository.getById(groupMemberId);
 		groupMember.updatePaymentStatus(request.isPaid());
 		return groupMember;
+	}
+
+	private String getProfileUrl(Long memberId) {
+		if (memberId == null || memberId < 1) {
+			return s3Bucket.getS3Url() + "profile/moddo.png";
+		}
+
+		Long finalId = (memberId - 1) % 9 + 1; // 🔥 ID를 1~9 범위로 변환
+		return s3Bucket.getS3Url() + "profile/" + finalId + ".png";
 	}
 }

--- a/src/main/java/com/dnd/moddo/domain/image/controller/ImageController.java
+++ b/src/main/java/com/dnd/moddo/domain/image/controller/ImageController.java
@@ -1,41 +1,50 @@
 package com.dnd.moddo.domain.image.controller;
 
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
 import com.dnd.moddo.domain.image.dto.CharacterResponse;
 import com.dnd.moddo.domain.image.dto.ImageResponse;
 import com.dnd.moddo.domain.image.dto.TempImageResponse;
 import com.dnd.moddo.domain.image.service.CommandImageService;
 import com.dnd.moddo.domain.image.service.QueryImageService;
-import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
+import com.dnd.moddo.global.jwt.service.JwtService;
 
-import java.util.List;
+import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping("/api/v1/images")
 @RequiredArgsConstructor
 public class ImageController {
-    private final CommandImageService commandImageService;
+	private final CommandImageService commandImageService;
 
-    private final QueryImageService queryImageService;
+	private final QueryImageService queryImageService;
+	private final JwtService jwtService;
 
-    @PostMapping("/temp")
-    public ResponseEntity<TempImageResponse> saveTempImage(@RequestParam("file") List<MultipartFile> files) {
-        TempImageResponse uniqueKey = commandImageService.uploadTempImage(files);
-        return ResponseEntity.ok(uniqueKey);
-    }
+	@PostMapping("/temp")
+	public ResponseEntity<TempImageResponse> saveTempImage(@RequestParam("file") List<MultipartFile> files) {
+		TempImageResponse uniqueKey = commandImageService.uploadTempImage(files);
+		return ResponseEntity.ok(uniqueKey);
+	}
 
-    @PostMapping("/update")
-    public ResponseEntity<ImageResponse> updateImage(@RequestParam("uniqueKey") List<String> uniqueKeys) {
-        ImageResponse finalImagePath = commandImageService.uploadFinalImage(uniqueKeys);
-        return ResponseEntity.ok(finalImagePath);
-    }
+	@PostMapping("/update")
+	public ResponseEntity<ImageResponse> updateImage(@RequestParam("uniqueKey") List<String> uniqueKeys) {
+		ImageResponse finalImagePath = commandImageService.uploadFinalImage(uniqueKeys);
+		return ResponseEntity.ok(finalImagePath);
+	}
 
-    @GetMapping("/character")
-    public ResponseEntity<CharacterResponse> getRandomCharacter() {
-        CharacterResponse character = queryImageService.getCharacter();
-        return ResponseEntity.ok(character);
-    }
+	@GetMapping("/character")
+	public ResponseEntity<CharacterResponse> getRandomCharacter(@RequestParam("groupToken") String groupToken) {
+		Long groupId = jwtService.getGroupId(groupToken);
+		CharacterResponse character = queryImageService.getCharacter(groupId);
+		return ResponseEntity.ok(character);
+	}
 }
 

--- a/src/main/java/com/dnd/moddo/domain/image/dto/CharacterResponse.java
+++ b/src/main/java/com/dnd/moddo/domain/image/dto/CharacterResponse.java
@@ -4,26 +4,26 @@ import com.dnd.moddo.domain.image.entity.type.Character;
 import com.dnd.moddo.global.config.S3Bucket;
 
 public record CharacterResponse(
-        String name,
-        String rarity,
-        String imageUrl,
-        String imageBigUrl
+	String name,
+	String rarity,
+	String imageUrl,
+	String imageBigUrl
 ) {
-    public static CharacterResponse of(Character character, S3Bucket s3Bucket) {
-        String rarityString = String.valueOf(character.getRarity());
-        return new CharacterResponse(
-                character.getName(),
-                rarityString,
-                getImageUrl(s3Bucket, character.getName(), character.getRarity()),
-                getBigImageUrl(s3Bucket, character.getName(), character.getRarity())
-        );
-    }
+	public static CharacterResponse of(Character character, S3Bucket s3Bucket) {
+		String rarityString = String.valueOf(character.getRarity());
+		return new CharacterResponse(
+			character.getName(),
+			rarityString,
+			getImageUrl(s3Bucket, character.getName(), character.getRarity()),
+			getBigImageUrl(s3Bucket, character.getName(), character.getRarity())
+		);
+	}
 
-    private static String getImageUrl(S3Bucket s3Bucket, String name, int rarity) {
-        return s3Bucket.getS3Url() + "/images/" + rarity + "/" + name + ".png";
-    }
+	private static String getImageUrl(S3Bucket s3Bucket, String name, int rarity) {
+		return s3Bucket.getS3Url() + "character/" + name + "-" + rarity + ".png";
+	}
 
-    private static String getBigImageUrl(S3Bucket s3Bucket, String name, int rarity) {
-        return s3Bucket.getS3Url() + "/images/big/" + rarity + "/" + name + ".png";
-    }
+	private static String getBigImageUrl(S3Bucket s3Bucket, String name, int rarity) {
+		return s3Bucket.getS3Url() + "character/" + name + "-" + rarity + "-big.png";
+	}
 }

--- a/src/main/java/com/dnd/moddo/domain/image/service/QueryImageService.java
+++ b/src/main/java/com/dnd/moddo/domain/image/service/QueryImageService.java
@@ -1,17 +1,19 @@
 package com.dnd.moddo.domain.image.service;
 
+import org.springframework.stereotype.Service;
+
 import com.dnd.moddo.domain.image.dto.CharacterResponse;
 import com.dnd.moddo.domain.image.service.implementation.ImageReader;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class QueryImageService {
 
-    private final ImageReader imageReader;
+	private final ImageReader imageReader;
 
-    public CharacterResponse getCharacter() {
-        return imageReader.getRandomCharacter();
-    }
+	public CharacterResponse getCharacter(Long groupId) {
+		return imageReader.getRandomCharacter(groupId);
+	}
 }

--- a/src/main/java/com/dnd/moddo/domain/image/service/implementation/ImageReader.java
+++ b/src/main/java/com/dnd/moddo/domain/image/service/implementation/ImageReader.java
@@ -1,37 +1,45 @@
 package com.dnd.moddo.domain.image.service.implementation;
 
+import java.util.List;
+import java.util.Random;
+
+import org.springframework.stereotype.Service;
+
+import com.dnd.moddo.domain.group.repository.GroupRepository;
 import com.dnd.moddo.domain.image.dto.CharacterResponse;
 import com.dnd.moddo.domain.image.entity.type.Character;
 import com.dnd.moddo.domain.image.exception.CharacterNotFoundException;
 import com.dnd.moddo.global.config.S3Bucket;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
 
-import java.util.List;
-import java.util.Random;
+import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 public class ImageReader {
 
-    private final S3Bucket s3Bucket;
+	private final S3Bucket s3Bucket;
+	private final GroupRepository groupRepository;
 
-    public CharacterResponse getRandomCharacter() {
-        int rarity = getRandomRarity();
-        List<Character> characters = Character.getByRarity(rarity);
+	public CharacterResponse getRandomCharacter(Long groupId) {
+		groupRepository.findById(groupId);
 
-        if (characters.isEmpty()) {
-            throw new CharacterNotFoundException();
-        }
+		int rarity = getRandomRarity();
+		List<Character> characters = Character.getByRarity(rarity);
 
-        Character character = characters.get(new Random().nextInt(characters.size()));
-        return CharacterResponse.of(character, s3Bucket);
-    }
+		if (characters.isEmpty()) {
+			throw new CharacterNotFoundException();
+		}
 
-    private int getRandomRarity() {
-        int roll = new Random().nextInt(100);
-        if (roll < 60) return 1;
-        if (roll < 90) return 2;
-        return 3;
-    }
+		Character character = characters.get(new Random().nextInt(characters.size()));
+		return CharacterResponse.of(character, s3Bucket);
+	}
+
+	private int getRandomRarity() {
+		int roll = new Random().nextInt(100);
+		if (roll < 60)
+			return 1;
+		if (roll < 90)
+			return 2;
+		return 3;
+	}
 }

--- a/src/main/java/com/dnd/moddo/domain/memberExpense/dto/response/MemberExpenseResponse.java
+++ b/src/main/java/com/dnd/moddo/domain/memberExpense/dto/response/MemberExpenseResponse.java
@@ -18,7 +18,7 @@ public record MemberExpenseResponse(
 			.id(memberExpense.getGroupMember().getId())
 			.name(memberExpense.getGroupMember().getName())
 			.role(memberExpense.getGroupMember().getRole())
-			.profile(memberExpense.getGroupMember().getProfileUrl(memberExpense.getId()))
+			.profile(memberExpense.getGroupMember().getProfile())
 			.amount(memberExpense.getAmount())
 			.build();
 	}

--- a/src/main/java/com/dnd/moddo/domain/memberExpense/dto/response/MemberExpenseResponse.java
+++ b/src/main/java/com/dnd/moddo/domain/memberExpense/dto/response/MemberExpenseResponse.java
@@ -18,7 +18,7 @@ public record MemberExpenseResponse(
 			.id(memberExpense.getGroupMember().getId())
 			.name(memberExpense.getGroupMember().getName())
 			.role(memberExpense.getGroupMember().getRole())
-			.profile(memberExpense.getGroupMember().getProfileUrl())
+			.profile(memberExpense.getGroupMember().getProfileUrl(memberExpense.getId()))
 			.amount(memberExpense.getAmount())
 			.build();
 	}

--- a/src/test/java/com/dnd/moddo/domain/expense/entity/ExpenseTest.java
+++ b/src/test/java/com/dnd/moddo/domain/expense/entity/ExpenseTest.java
@@ -17,7 +17,7 @@ class ExpenseTest {
 
 	@BeforeEach
 	void setUp() {
-		mockGroup = new Group("group 1", 1L, "1234", LocalDateTime.now(), LocalDateTime.now().plusMinutes(1),
+		mockGroup = new Group("group 1", 1L, "1234", LocalDateTime.now().plusMinutes(1),
 			"은행", "계좌", LocalDateTime.now().plusDays(1));
 	}
 

--- a/src/test/java/com/dnd/moddo/domain/expense/service/CommandExpenseServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/expense/service/CommandExpenseServiceTest.java
@@ -8,9 +8,6 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.dnd.moddo.domain.expense.dto.request.ExpenseImageRequest;
-import com.dnd.moddo.domain.group.service.implementation.GroupReader;
-import com.dnd.moddo.domain.group.service.implementation.GroupValidator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -19,6 +16,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.dnd.moddo.domain.expense.dto.request.ExpenseImageRequest;
 import com.dnd.moddo.domain.expense.dto.request.ExpenseRequest;
 import com.dnd.moddo.domain.expense.dto.request.ExpensesRequest;
 import com.dnd.moddo.domain.expense.dto.response.ExpenseResponse;
@@ -30,6 +28,8 @@ import com.dnd.moddo.domain.expense.service.implementation.ExpenseDeleter;
 import com.dnd.moddo.domain.expense.service.implementation.ExpenseReader;
 import com.dnd.moddo.domain.expense.service.implementation.ExpenseUpdater;
 import com.dnd.moddo.domain.group.entity.Group;
+import com.dnd.moddo.domain.group.service.implementation.GroupReader;
+import com.dnd.moddo.domain.group.service.implementation.GroupValidator;
 import com.dnd.moddo.domain.memberExpense.dto.response.MemberExpenseResponse;
 import com.dnd.moddo.domain.memberExpense.service.CommandMemberExpenseService;
 
@@ -57,7 +57,7 @@ class CommandExpenseServiceTest {
 
 	@BeforeEach
 	void setUp() {
-		mockGroup = new Group("group 1", 1L, "1234", LocalDateTime.now(), LocalDateTime.now().plusMinutes(1),
+		mockGroup = new Group("group 1", 1L, "1234", LocalDateTime.now().plusMinutes(1),
 			"은행", "계좌", LocalDateTime.now().plusDays(1));
 	}
 
@@ -183,6 +183,5 @@ class CommandExpenseServiceTest {
 		verify(groupValidator, times(1)).checkGroupAuthor(mockGroup, userId);
 		verify(expenseUpdater, times(1)).updateImgUrl(expenseId, request);
 	}
-
 
 }

--- a/src/test/java/com/dnd/moddo/domain/expense/service/QueryExpenseServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/expense/service/QueryExpenseServiceTest.java
@@ -41,7 +41,7 @@ class QueryExpenseServiceTest {
 
 	@BeforeEach
 	void setUp() {
-		mockGroup = new Group("group 1", 1L, "1234", LocalDateTime.now(), LocalDateTime.now().plusMinutes(1),
+		mockGroup = new Group("group 1", 1L, "1234", LocalDateTime.now().plusMinutes(1),
 			"은행", "계좌", LocalDateTime.now().plusDays(1));
 	}
 

--- a/src/test/java/com/dnd/moddo/domain/expense/service/implementation/ExpenseCreatorTest.java
+++ b/src/test/java/com/dnd/moddo/domain/expense/service/implementation/ExpenseCreatorTest.java
@@ -37,7 +37,7 @@ class ExpenseCreatorTest {
 
 	@BeforeEach
 	void setUp() {
-		mockGroup = new Group("group 1", 1L, "1234", LocalDateTime.now(), LocalDateTime.now().plusMinutes(1),
+		mockGroup = new Group("group 1", 1L, "1234", LocalDateTime.now().plusMinutes(1),
 			"은행", "계좌", LocalDateTime.now().plusDays(1));
 	}
 

--- a/src/test/java/com/dnd/moddo/domain/expense/service/implementation/ExpenseReaderTest.java
+++ b/src/test/java/com/dnd/moddo/domain/expense/service/implementation/ExpenseReaderTest.java
@@ -32,7 +32,7 @@ class ExpenseReaderTest {
 
 	@BeforeEach
 	void setUp() {
-		mockGroup = new Group("group 1", 1L, "1234", LocalDateTime.now(), LocalDateTime.now().plusMinutes(1),
+		mockGroup = new Group("group 1", 1L, "1234", LocalDateTime.now().plusMinutes(1),
 			"은행", "계좌", LocalDateTime.now().plusDays(1));
 	}
 

--- a/src/test/java/com/dnd/moddo/domain/group/entity/GroupTest.java
+++ b/src/test/java/com/dnd/moddo/domain/group/entity/GroupTest.java
@@ -3,41 +3,74 @@ package com.dnd.moddo.domain.group.entity;
 import static org.assertj.core.api.Assertions.*;
 
 import java.time.LocalDateTime;
-import java.util.Optional;
 
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import com.dnd.moddo.domain.group.repository.GroupRepository;
+import com.dnd.moddo.domain.group.dto.request.GroupAccountRequest;
 
-@ExtendWith(SpringExtension.class)
-@SpringBootTest
 class GroupTest {
 
-	@Autowired
-	private GroupRepository groupRepository;
+	private Group mockGroup;
 
+	@BeforeEach
+	void setUp() {
+		mockGroup = new Group("group 1", 1L, "1234", LocalDateTime.now().plusMinutes(1),
+			"은행", "계좌", LocalDateTime.now().plusDays(1));
+	}
+
+	@DisplayName("그룹의 작성자(userId)가 해당 그룹의 작성자인지 확인한다.")
 	@Test
-	void groupCreateTest() {
+	void testIsWriter_whenUserIsWriter() {
 		// given
-		Group group1 = new Group("groupName", 1L, "password", LocalDateTime.now().plusDays(1), "bank", "1234-1234",
-			LocalDateTime.now().plusDays(1));
-		Group group2 = new Group("groupName", 1L, "password", LocalDateTime.now().plusDays(1), "bank", "1234-1234",
-			LocalDateTime.now().plusDays(1));
-		groupRepository.save(group1);
-		groupRepository.save(group2);
+		Long userId = 1L;
 
 		// when
-		Optional<Group> foundGroup = groupRepository.findById(1L);
+		boolean isWriter = mockGroup.isWriter(userId);
 
 		// then
-		assertThat(foundGroup).isPresent();
-		assertThat(foundGroup.get().getName()).isEqualTo("groupName");
-		assertThat(foundGroup.get().getWriter()).isEqualTo(1L);
-		assertThat(foundGroup.get().getBank()).isEqualTo("bank");
-		assertThat(foundGroup.get().getAccountNumber()).isEqualTo("1234-1234");
+		assertThat(isWriter).isTrue();
+	}
+
+	@DisplayName("그룹의 작성자가 아닌 경우 false를 반환한다.")
+	@Test
+	void testIsWriter_whenUserIsNotWriter() {
+		// given
+		Long userId = 2L;
+
+		// when
+		boolean isWriter = mockGroup.isWriter(userId);
+
+		// then
+		assertThat(isWriter).isFalse();
+	}
+
+	@DisplayName("그룹의 계좌 정보를 업데이트할 수 있다.")
+	@Test
+	void testUpdateAccount() {
+		// given
+		GroupAccountRequest request = new GroupAccountRequest("새로운 은행", "새로운 계좌");
+
+		// when
+		mockGroup.updateAccount(request);
+
+		// then
+		assertThat(mockGroup.getBank()).isEqualTo("새로운 은행");
+		assertThat(mockGroup.getAccountNumber()).isEqualTo("새로운 계좌");
+		assertThat(mockGroup.getDeadline()).isAfter(LocalDateTime.now());
+	}
+
+	@DisplayName("그룹의 작성자를 확인할 수 있다.")
+	@Test
+	void testGroupWriter() {
+		// given
+		Long writerId = 1L;
+
+		// when
+		Long actualWriterId = mockGroup.getWriter();
+
+		// then
+		assertThat(actualWriterId).isEqualTo(writerId);
 	}
 }

--- a/src/test/java/com/dnd/moddo/domain/group/entity/GroupTest.java
+++ b/src/test/java/com/dnd/moddo/domain/group/entity/GroupTest.java
@@ -1,40 +1,43 @@
 package com.dnd.moddo.domain.group.entity;
 
-import com.dnd.moddo.domain.group.repository.GroupRepository;
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import java.time.LocalDateTime;
-import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import com.dnd.moddo.domain.group.repository.GroupRepository;
 
 @ExtendWith(SpringExtension.class)
 @SpringBootTest
 class GroupTest {
 
-    @Autowired
-    private GroupRepository groupRepository;
+	@Autowired
+	private GroupRepository groupRepository;
 
-    @Test
-    void groupCreateTest() {
-        // given
-        Group group1 = new Group("groupName", 1L, "password", LocalDateTime.now(), LocalDateTime.now().plusDays(1), "bank", "1234-1234", LocalDateTime.now().plusDays(1));
-        Group group2 = new Group("groupName", 1L, "password", LocalDateTime.now(), LocalDateTime.now().plusDays(1), "bank", "1234-1234", LocalDateTime.now().plusDays(1));
-        groupRepository.save(group1);
-        groupRepository.save(group2);
+	@Test
+	void groupCreateTest() {
+		// given
+		Group group1 = new Group("groupName", 1L, "password", LocalDateTime.now().plusDays(1), "bank", "1234-1234",
+			LocalDateTime.now().plusDays(1));
+		Group group2 = new Group("groupName", 1L, "password", LocalDateTime.now().plusDays(1), "bank", "1234-1234",
+			LocalDateTime.now().plusDays(1));
+		groupRepository.save(group1);
+		groupRepository.save(group2);
 
-        // when
-        Optional<Group> foundGroup = groupRepository.findById(1L);
+		// when
+		Optional<Group> foundGroup = groupRepository.findById(1L);
 
-        // then
-        assertThat(foundGroup).isPresent();
-        assertThat(foundGroup.get().getName()).isEqualTo("groupName");
-        assertThat(foundGroup.get().getWriter()).isEqualTo(1L);
-        assertThat(foundGroup.get().getBank()).isEqualTo("bank");
-        assertThat(foundGroup.get().getAccountNumber()).isEqualTo("1234-1234");
-    }
+		// then
+		assertThat(foundGroup).isPresent();
+		assertThat(foundGroup.get().getName()).isEqualTo("groupName");
+		assertThat(foundGroup.get().getWriter()).isEqualTo(1L);
+		assertThat(foundGroup.get().getBank()).isEqualTo("bank");
+		assertThat(foundGroup.get().getAccountNumber()).isEqualTo("1234-1234");
+	}
 }

--- a/src/test/java/com/dnd/moddo/domain/group/service/CommandGroupServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/group/service/CommandGroupServiceTest.java
@@ -60,8 +60,8 @@ class CommandGroupServiceTest {
 	@BeforeEach
 	void setUp() {
 		groupRequest = new GroupRequest("GroupName", "password123", LocalDateTime.now());
-		groupResponse = new GroupResponse(1L, 1L, LocalDateTime.now(), LocalDateTime.now().minusDays(1), "bank",
-			"1234-1234");
+		groupResponse = new GroupResponse(1L, 1L, LocalDateTime.now(), LocalDateTime.now().plusDays(1), "bank",
+			"1234-1234", LocalDateTime.now().plusDays(1));
 		groupAccountRequest = new GroupAccountRequest("newBank", "5678-5678");
 		expectedResponse = new GroupSaveResponse("group-token", mock(GroupMemberResponse.class));
 

--- a/src/test/java/com/dnd/moddo/domain/group/service/QueryGroupServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/group/service/QueryGroupServiceTest.java
@@ -8,7 +8,6 @@ import static org.springframework.test.util.ReflectionTestUtils.*;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import com.dnd.moddo.domain.group.dto.response.GroupHeaderResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -18,6 +17,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.dnd.moddo.domain.group.dto.response.GroupDetailResponse;
+import com.dnd.moddo.domain.group.dto.response.GroupHeaderResponse;
 import com.dnd.moddo.domain.group.entity.Group;
 import com.dnd.moddo.domain.group.service.implementation.GroupReader;
 import com.dnd.moddo.domain.group.service.implementation.GroupValidator;
@@ -42,7 +42,7 @@ class QueryGroupServiceTest {
 	@BeforeEach
 	void setUp() {
 		// Given
-		group = new Group("groupName", 1L, "password", null, null, null, null, null);
+		group = new Group("groupName", 1L, "password", null, null, null, null);
 		groupMember = new GroupMember("김완숙", 1, group, false, ExpenseRole.MANAGER);
 
 		setField(group, "id", 1L);
@@ -105,7 +105,8 @@ class QueryGroupServiceTest {
 	@DisplayName("그룹 헤더를 정상적으로 조회할 수 있다.")
 	void FindByGroupHeader_Success() {
 		// Given
-		GroupHeaderResponse expectedResponse = new GroupHeaderResponse(group.getName(), 1000L, LocalDateTime.now().plusDays(1), group.getBank(), group.getAccountNumber());
+		GroupHeaderResponse expectedResponse = new GroupHeaderResponse(group.getName(), 1000L,
+			LocalDateTime.now().plusDays(1), group.getBank(), group.getAccountNumber());
 		when(groupReader.findByHeader(group.getId())).thenReturn(expectedResponse);
 
 		// When

--- a/src/test/java/com/dnd/moddo/domain/group/service/QueryGroupServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/group/service/QueryGroupServiceTest.java
@@ -43,7 +43,7 @@ class QueryGroupServiceTest {
 	void setUp() {
 		// Given
 		group = new Group("groupName", 1L, "password", null, null, null, null);
-		groupMember = new GroupMember("김완숙", 1, group, false, ExpenseRole.MANAGER);
+		groupMember = new GroupMember("김완숙", "profile", group, false, ExpenseRole.MANAGER);
 
 		setField(group, "id", 1L);
 	}

--- a/src/test/java/com/dnd/moddo/domain/group/service/implementation/GroupCreatorTest.java
+++ b/src/test/java/com/dnd/moddo/domain/group/service/implementation/GroupCreatorTest.java
@@ -52,8 +52,8 @@ class GroupCreatorTest {
 		mockUser = new User(userId, "test@example.com", "닉네임", "프로필", false, LocalDateTime.now(),
 			LocalDateTime.now().plusDays(1), Authority.USER);
 		encodedPassword = "encryptedPassword";
-		mockGroup = new Group(request.name(), userId, "password", LocalDateTime.now(),
-			LocalDateTime.now().plusMonths(1), "groupName", encodedPassword, LocalDateTime.now().plusDays(1));
+		mockGroup = new Group(request.name(), userId, "password", LocalDateTime.now().plusMonths(1), "groupName",
+			encodedPassword, LocalDateTime.now().plusDays(1));
 	}
 
 	@DisplayName("사용자는 모임 생성에 성공한다.")

--- a/src/test/java/com/dnd/moddo/domain/groupMember/entity/GroupMemberTest.java
+++ b/src/test/java/com/dnd/moddo/domain/groupMember/entity/GroupMemberTest.java
@@ -1,6 +1,6 @@
 package com.dnd.moddo.domain.groupMember.entity;
 
-import static org.assertj.core.api.AssertionsForClassTypes.*;
+import static org.assertj.core.api.Assertions.*;
 
 import java.time.LocalDateTime;
 
@@ -25,7 +25,13 @@ class GroupMemberTest {
 	@Test
 	void testIsManager_whenRoleIsManager() {
 		// given
-		GroupMember groupMember = new GroupMember("김모또", mockGroup, ExpenseRole.MANAGER);
+		GroupMember groupMember = GroupMember.builder()
+			.name("김모또")
+			.group(mockGroup)
+			.role(ExpenseRole.MANAGER)
+			.isPaid(true)
+			.profile("profile.jpg")
+			.build();
 
 		// when
 		boolean isManager = groupMember.isManager();
@@ -38,7 +44,13 @@ class GroupMemberTest {
 	@Test
 	void testIsManager_whenRoleIsNotManager() {
 		// given
-		GroupMember groupMember = new GroupMember("김모또", mockGroup, ExpenseRole.PARTICIPANT);
+		GroupMember groupMember = GroupMember.builder()
+			.name("김모또")
+			.group(mockGroup)
+			.role(ExpenseRole.PARTICIPANT)
+			.isPaid(true)
+			.profile("profile.jpg")
+			.build();
 
 		// when
 		boolean isManager = groupMember.isManager();
@@ -46,5 +58,4 @@ class GroupMemberTest {
 		// then
 		assertThat(isManager).isFalse();
 	}
-
 }

--- a/src/test/java/com/dnd/moddo/domain/groupMember/entity/GroupMemberTest.java
+++ b/src/test/java/com/dnd/moddo/domain/groupMember/entity/GroupMemberTest.java
@@ -17,7 +17,7 @@ class GroupMemberTest {
 
 	@BeforeEach
 	void setUp() {
-		mockGroup = new Group("group 1", 1L, "1234", LocalDateTime.now(), LocalDateTime.now().plusMinutes(1),
+		mockGroup = new Group("group 1", 1L, "1234", LocalDateTime.now().plusMinutes(1),
 			"은행", "계좌", LocalDateTime.now().plusDays(1));
 	}
 

--- a/src/test/java/com/dnd/moddo/domain/groupMember/entity/GroupMemberTest.java
+++ b/src/test/java/com/dnd/moddo/domain/groupMember/entity/GroupMemberTest.java
@@ -58,4 +58,45 @@ class GroupMemberTest {
 		// then
 		assertThat(isManager).isFalse();
 	}
+
+	@DisplayName("참여자가 입금 상태를 변경할 수 있다.")
+	@Test
+	void testUpdatePaymentStatus() {
+		// given
+		GroupMember groupMember = GroupMember.builder()
+			.name("김모또")
+			.group(mockGroup)
+			.role(ExpenseRole.PARTICIPANT)
+			.isPaid(false)
+			.profile("profile.jpg")
+			.build();
+
+		// when
+		groupMember.updatePaymentStatus(true);
+
+		// then
+		assertThat(groupMember.isPaid()).isTrue();
+		assertThat(groupMember.getPaidAt()).isNotNull();
+	}
+
+	@DisplayName("참여자의 프로필을 업데이트할 수 있다.")
+	@Test
+	void testUpdateProfile() {
+		// given
+		GroupMember groupMember = GroupMember.builder()
+			.name("김모또")
+			.group(mockGroup)
+			.role(ExpenseRole.PARTICIPANT)
+			.isPaid(true)
+			.profile("profile.jpg")
+			.build();
+
+		String newProfile = "newProfile.jpg";
+
+		// when
+		groupMember.updateProfile(newProfile);
+
+		// then
+		assertThat(groupMember.getProfile()).isEqualTo(newProfile);
+	}
 }

--- a/src/test/java/com/dnd/moddo/domain/groupMember/service/CommandGroupMemberServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/groupMember/service/CommandGroupMemberServiceTest.java
@@ -35,7 +35,7 @@ public class CommandGroupMemberServiceTest {
 
 	@BeforeEach
 	void setUp() {
-		mockGroup = new Group("group 1", 1L, "1234", LocalDateTime.now(), LocalDateTime.now().plusMinutes(1),
+		mockGroup = new Group("group 1", 1L, "1234", LocalDateTime.now().plusMinutes(1),
 			"은행", "계좌", LocalDateTime.now().plusDays(1));
 	}
 

--- a/src/test/java/com/dnd/moddo/domain/groupMember/service/CommandGroupMemberServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/groupMember/service/CommandGroupMemberServiceTest.java
@@ -44,7 +44,12 @@ public class CommandGroupMemberServiceTest {
 	void createSuccess() {
 		//given
 		Long userId = 1L;
-		GroupMember expectedMembers = new GroupMember("김모또", 1, mockGroup, ExpenseRole.MANAGER);
+		GroupMember expectedMembers = GroupMember.builder()
+			.name("김모또")
+			.profile("profile")
+			.group(mockGroup)
+			.role(ExpenseRole.MANAGER)
+			.build();
 		Group mockGroup = mock(Group.class);
 		when(groupMemberCreator.createManagerForGroup(any(Group.class), eq(userId))).thenReturn(expectedMembers);
 
@@ -64,7 +69,11 @@ public class CommandGroupMemberServiceTest {
 		//given
 		Long groupId = mockGroup.getId();
 		GroupMemberSaveRequest request = mock(GroupMemberSaveRequest.class);
-		GroupMember expectedMember = new GroupMember("김반숙", mockGroup, ExpenseRole.PARTICIPANT);
+		GroupMember expectedMember = GroupMember.builder()
+			.name("김반숙")
+			.group(mockGroup)
+			.role(ExpenseRole.PARTICIPANT)
+			.build();
 
 		when(groupMemberUpdater.addToGroup(eq(groupId), any(GroupMemberSaveRequest.class))).thenReturn(expectedMember);
 
@@ -81,7 +90,12 @@ public class CommandGroupMemberServiceTest {
 	@Test
 	void updatePaymentStatus_Success() {
 		//given
-		GroupMember expectedGroupMember = new GroupMember("김반숙", mockGroup, true, ExpenseRole.PARTICIPANT);
+		GroupMember expectedGroupMember = GroupMember.builder()
+			.name("김반숙")
+			.group(mockGroup)
+			.isPaid(true)
+			.role(ExpenseRole.PARTICIPANT)
+			.build();
 		PaymentStatusUpdateRequest request = new PaymentStatusUpdateRequest(true);
 		when(groupMemberUpdater.updatePaymentStatus(any(), eq(request))).thenReturn(expectedGroupMember);
 
@@ -95,6 +109,5 @@ public class CommandGroupMemberServiceTest {
 		assertThat(response.isPaid()).isTrue();
 
 		verify(groupMemberUpdater, times(1)).updatePaymentStatus(any(), eq(request));
-
 	}
 }

--- a/src/test/java/com/dnd/moddo/domain/groupMember/service/QueryGroupMemberServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/groupMember/service/QueryGroupMemberServiceTest.java
@@ -33,11 +33,11 @@ public class QueryGroupMemberServiceTest {
 
 	@BeforeEach
 	void setUp() {
-		mockGroup = new Group("group 1", 1L, "1234", LocalDateTime.now(), LocalDateTime.now().plusMinutes(1),
+		mockGroup = new Group("group 1", 1L, "1234", LocalDateTime.now().plusMinutes(1),
 			"은행", "계좌", LocalDateTime.now().plusDays(1));
 
 		mockMembers = List.of(
-			new GroupMember("김모또", 1, mockGroup, ExpenseRole.MANAGER),
+			new GroupMember("김모또", mockGroup, ExpenseRole.MANAGER),
 			new GroupMember("김반숙", 2, mockGroup, ExpenseRole.PARTICIPANT)
 		);
 	}

--- a/src/test/java/com/dnd/moddo/domain/groupMember/service/QueryGroupMemberServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/groupMember/service/QueryGroupMemberServiceTest.java
@@ -37,8 +37,16 @@ public class QueryGroupMemberServiceTest {
 			"은행", "계좌", LocalDateTime.now().plusDays(1));
 
 		mockMembers = List.of(
-			new GroupMember("김모또", mockGroup, ExpenseRole.MANAGER),
-			new GroupMember("김반숙", 2, mockGroup, ExpenseRole.PARTICIPANT)
+			GroupMember.builder()
+				.name("김모또")
+				.group(mockGroup)
+				.role(ExpenseRole.MANAGER)
+				.build(),
+			GroupMember.builder()
+				.name("김반숙")
+				.group(mockGroup)
+				.role(ExpenseRole.PARTICIPANT)
+				.build()
 		);
 	}
 
@@ -49,6 +57,7 @@ public class QueryGroupMemberServiceTest {
 		Long groupId = mockGroup.getId();
 
 		when(groupMemberReader.findAllByGroupId(eq(groupId))).thenReturn(mockMembers);
+
 		//when
 		GroupMembersResponse response = queryGroupMemberService.findAll(groupId);
 

--- a/src/test/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberCreatorTest.java
+++ b/src/test/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberCreatorTest.java
@@ -51,7 +51,12 @@ public class GroupMemberCreatorTest {
 		when(userRepository.getById(eq(userId))).thenReturn(mockUser);
 		when(mockUser.getIsMember()).thenReturn(false);
 
-		GroupMember expectedMember = new GroupMember("김모또", 1, mockGroup, ExpenseRole.MANAGER);
+		GroupMember expectedMember = GroupMember.builder()
+			.name("김모또")
+			.profile("profle")
+			.group(mockGroup)
+			.role(ExpenseRole.MANAGER)
+			.build();
 
 		when(groupMemberRepository.save(any())).thenReturn(expectedMember);
 
@@ -77,7 +82,13 @@ public class GroupMemberCreatorTest {
 		when(mockUser.getIsMember()).thenReturn(true);
 		when(mockUser.getName()).thenReturn("연노른자");
 
-		GroupMember expectedMember = new GroupMember("연노른자", 1, mockGroup, ExpenseRole.MANAGER);
+		GroupMember expectedMember = GroupMember.builder()
+			.name("연노른자")
+			.profile("profile")
+			.group(mockGroup)
+			.role(ExpenseRole.MANAGER)
+			.build();
+
 		when(groupMemberRepository.save(any(GroupMember.class))).thenReturn(expectedMember);
 
 		//when

--- a/src/test/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberDeleterTest.java
+++ b/src/test/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberDeleterTest.java
@@ -33,7 +33,7 @@ class GroupMemberDeleterTest {
 
 	@BeforeEach
 	void setUp() {
-		mockGroup = new Group("group 1", 1L, "1234", LocalDateTime.now(), LocalDateTime.now().plusMinutes(1),
+		mockGroup = new Group("group 1", 1L, "1234", LocalDateTime.now().plusMinutes(1),
 			"은행", "계좌", LocalDateTime.now().plusDays(1));
 	}
 

--- a/src/test/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberDeleterTest.java
+++ b/src/test/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberDeleterTest.java
@@ -42,7 +42,13 @@ class GroupMemberDeleterTest {
 	void delete_Success_ValidGroupMemberId() {
 		//given
 		Long groupMemberId = 1L;
-		GroupMember expectedMember = new GroupMember("김반숙", mockGroup, ExpenseRole.PARTICIPANT);
+		GroupMember expectedMember = GroupMember.builder()
+			.name("김반숙")
+			.profile("profile")
+			.group(mockGroup)
+			.role(ExpenseRole.PARTICIPANT)
+			.isPaid(false)
+			.build();
 
 		when(groupMemberReader.findByGroupMemberId(eq(groupMemberId))).thenReturn(expectedMember);
 		doNothing().when(groupMemberRepository).delete(any(GroupMember.class));
@@ -67,7 +73,6 @@ class GroupMemberDeleterTest {
 		assertThatThrownBy(() -> {
 			groupMemberDeleter.delete(groupMemberId);
 		}).hasMessage("해당 참여자를 찾을 수 없습니다. (GroupMember ID: " + groupMemberId + ")");
-
 	}
 
 	@DisplayName("유효한 참여자 id로 삭제를 요청하면 성공적으로 삭제된다.")
@@ -75,7 +80,13 @@ class GroupMemberDeleterTest {
 	void delete_ThrowException_WhenRoleIsManager() {
 		//given
 		Long groupMemberId = 1L;
-		GroupMember expectedMember = new GroupMember("김모또", mockGroup, ExpenseRole.MANAGER);
+		GroupMember expectedMember = GroupMember.builder()
+			.name("김모또")
+			.profile("profile")
+			.group(mockGroup)
+			.role(ExpenseRole.MANAGER)
+			.isPaid(false)
+			.build();
 
 		when(groupMemberReader.findByGroupMemberId(eq(groupMemberId))).thenReturn(expectedMember);
 

--- a/src/test/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberReaderTest.java
+++ b/src/test/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberReaderTest.java
@@ -41,8 +41,20 @@ public class GroupMemberReaderTest {
 		//given
 		Long groupId = mockGroup.getId();
 		List<GroupMember> expectedMembers = List.of(
-			new GroupMember("김모또", 1, mockGroup, ExpenseRole.MANAGER),
-			new GroupMember("김반숙", 2, mockGroup, ExpenseRole.PARTICIPANT)
+			GroupMember.builder()
+				.name("김모또")
+				.profile("profile")
+				.group(mockGroup)
+				.role(ExpenseRole.MANAGER)
+				.isPaid(false)
+				.build(),
+			GroupMember.builder()
+				.name("김반숙")
+				.profile("profile")
+				.group(mockGroup)
+				.role(ExpenseRole.PARTICIPANT)
+				.isPaid(false)
+				.build()
 		);
 
 		when(groupMemberRepository.findByGroupId(eq(groupId))).thenReturn(expectedMembers);
@@ -63,7 +75,13 @@ public class GroupMemberReaderTest {
 	void findByGroupMemberIdSuccess() {
 		//given
 		Long groupMemberId = 1L;
-		GroupMember expectedMember = new GroupMember("김반숙", mockGroup, ExpenseRole.PARTICIPANT);
+		GroupMember expectedMember = GroupMember.builder()
+			.name("김반숙")
+			.profile("profile")
+			.group(mockGroup)
+			.role(ExpenseRole.PARTICIPANT)
+			.isPaid(false)
+			.build();
 
 		when(groupMemberRepository.getById(eq(groupMemberId))).thenReturn(expectedMember);
 
@@ -89,7 +107,6 @@ public class GroupMemberReaderTest {
 		assertThatThrownBy(() -> {
 			groupMemberReader.findByGroupMemberId(groupMemberId);
 		}).hasMessage("해당 참여자를 찾을 수 없습니다. (GroupMember ID: " + groupMemberId + ")");
-
 	}
 
 }

--- a/src/test/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberReaderTest.java
+++ b/src/test/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberReaderTest.java
@@ -31,7 +31,7 @@ public class GroupMemberReaderTest {
 
 	@BeforeEach
 	void setUp() {
-		mockGroup = new Group("group 1", 1L, "1234", LocalDateTime.now(), LocalDateTime.now().plusMinutes(1),
+		mockGroup = new Group("group 1", 1L, "1234", LocalDateTime.now().plusMinutes(1),
 			"은행", "계좌", LocalDateTime.now().plusDays(1));
 	}
 

--- a/src/test/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberUpdaterTest.java
+++ b/src/test/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberUpdaterTest.java
@@ -1,7 +1,6 @@
 package com.dnd.moddo.domain.groupMember.service.implementation;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import java.util.ArrayList;
@@ -16,7 +15,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.dnd.moddo.domain.group.entity.Group;
-import com.dnd.moddo.domain.group.repository.GroupRepository;
 import com.dnd.moddo.domain.group.service.implementation.GroupReader;
 import com.dnd.moddo.domain.groupMember.dto.request.GroupMemberSaveRequest;
 import com.dnd.moddo.domain.groupMember.dto.request.PaymentStatusUpdateRequest;
@@ -37,8 +35,6 @@ class GroupMemberUpdaterTest {
 	@Mock
 	private GroupReader groupReader;
 	@Mock
-	private GroupRepository groupRepository;
-	@Mock
 	private S3Bucket s3Bucket;
 	@InjectMocks
 	private GroupMemberUpdater groupMemberUpdater;
@@ -53,10 +49,12 @@ class GroupMemberUpdaterTest {
 	@DisplayName("추가하려는 참여자의 이름이 기존 참여자의 이름과 중복되지 않을경우 참여자 추가에 성공한다.")
 	@Test
 	void addToGroupSuccess() {
-		//given
+		// given
 		Long groupId = 1L;
 		GroupMemberSaveRequest request = mock(GroupMemberSaveRequest.class);
+		String newMemberName = "김반숙";
 
+		when(request.name()).thenReturn(newMemberName);
 		when(groupReader.read(eq(groupId))).thenReturn(mockGroup);
 
 		List<GroupMember> mockGroupMembers = new ArrayList<>();
@@ -65,39 +63,43 @@ class GroupMemberUpdaterTest {
 		doNothing().when(groupMemberValidator).validateMemberNamesNotDuplicate(any());
 
 		GroupMember expectedGroupMember = GroupMember.builder()
-			.name("김반숙")
+			.name(newMemberName)
 			.group(mockGroup)
 			.role(ExpenseRole.PARTICIPANT)
 			.build();
 		when(groupMemberRepository.save(any())).thenReturn(expectedGroupMember);
 
-		//when
+		// when
 		GroupMember result = groupMemberUpdater.addToGroup(groupId, request);
 
-		//then
+		// then
 		assertThat(result).isNotNull();
 		assertThat(result.getGroup()).isEqualTo(mockGroup);
-		assertThat(result.getName()).isEqualTo("김반숙");
+		assertThat(result.getName()).isEqualTo(newMemberName);
 
 		verify(groupMemberRepository, times(1)).save(any());
 	}
 
-	@DisplayName("추가하려는 참여자의 이름이 기존 참여자의 이름과 중복되는 경우 예외가 발생한다..")
+	@DisplayName("추가하려는 참여자의 이름이 기존 참여자의 이름과 중복되는 경우 예외가 발생한다.")
 	@Test
 	void addToGroupDuplicatedName() {
-		//given
+		// given
 		Long groupId = 1L;
 		GroupMemberSaveRequest request = mock(GroupMemberSaveRequest.class);
+		String duplicatedName = "김반숙";
 
+		when(request.name()).thenReturn(duplicatedName);
 		when(groupReader.read(eq(groupId))).thenReturn(mockGroup);
 
 		List<GroupMember> mockGroupMembers = new ArrayList<>();
+		GroupMember existingMember = GroupMember.builder().name(duplicatedName).build();
+		mockGroupMembers.add(existingMember);
 		when(groupMemberReader.findAllByGroupId(eq(groupId))).thenReturn(mockGroupMembers);
 
 		doThrow(new GroupMemberDuplicateNameException()).when(groupMemberValidator)
 			.validateMemberNamesNotDuplicate(any());
 
-		//when & then
+		// when & then
 		assertThatThrownBy(() -> {
 			groupMemberUpdater.addToGroup(groupId, request);
 		}).hasMessage("중복된 참여자의 이름은 저장할 수 없습니다.");
@@ -106,8 +108,7 @@ class GroupMemberUpdaterTest {
 	@DisplayName("참여자가 유효할 때 참여자의 입금 상태를 변경할 수 있다.")
 	@Test
 	void updatePaymentStatus_Success() {
-		//given
-
+		// given
 		GroupMember groupMember = GroupMember.builder()
 			.name("김반숙")
 			.group(mockGroup)
@@ -117,10 +118,10 @@ class GroupMemberUpdaterTest {
 
 		when(groupMemberRepository.getById(any())).thenReturn(groupMember);
 
-		//then
+		// when
 		GroupMember result = groupMemberUpdater.updatePaymentStatus(1L, request);
 
-		//then
+		// then
 		assertThat(result).isNotNull();
 		assertThat(result.isPaid()).isTrue();
 	}

--- a/src/test/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberUpdaterTest.java
+++ b/src/test/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberUpdaterTest.java
@@ -24,6 +24,7 @@ import com.dnd.moddo.domain.groupMember.entity.GroupMember;
 import com.dnd.moddo.domain.groupMember.entity.type.ExpenseRole;
 import com.dnd.moddo.domain.groupMember.exception.GroupMemberDuplicateNameException;
 import com.dnd.moddo.domain.groupMember.repository.GroupMemberRepository;
+import com.dnd.moddo.global.config.S3Bucket;
 
 @ExtendWith(MockitoExtension.class)
 class GroupMemberUpdaterTest {
@@ -37,6 +38,8 @@ class GroupMemberUpdaterTest {
 	private GroupReader groupReader;
 	@Mock
 	private GroupRepository groupRepository;
+	@Mock
+	private S3Bucket s3Bucket;
 	@InjectMocks
 	private GroupMemberUpdater groupMemberUpdater;
 
@@ -61,7 +64,11 @@ class GroupMemberUpdaterTest {
 
 		doNothing().when(groupMemberValidator).validateMemberNamesNotDuplicate(any());
 
-		GroupMember expectedGroupMember = new GroupMember("김반숙", mockGroup, ExpenseRole.PARTICIPANT);
+		GroupMember expectedGroupMember = GroupMember.builder()
+			.name("김반숙")
+			.group(mockGroup)
+			.role(ExpenseRole.PARTICIPANT)
+			.build();
 		when(groupMemberRepository.save(any())).thenReturn(expectedGroupMember);
 
 		//when
@@ -101,7 +108,11 @@ class GroupMemberUpdaterTest {
 	void updatePaymentStatus_Success() {
 		//given
 
-		GroupMember groupMember = new GroupMember("김반숙", mockGroup, ExpenseRole.PARTICIPANT);
+		GroupMember groupMember = GroupMember.builder()
+			.name("김반숙")
+			.group(mockGroup)
+			.role(ExpenseRole.PARTICIPANT)
+			.build();
 		PaymentStatusUpdateRequest request = new PaymentStatusUpdateRequest(true);
 
 		when(groupMemberRepository.getById(any())).thenReturn(groupMember);

--- a/src/test/java/com/dnd/moddo/domain/image/service/QueryImageServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/image/service/QueryImageServiceTest.java
@@ -1,46 +1,47 @@
 package com.dnd.moddo.domain.image.service;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.*;
 import static org.mockito.Mockito.*;
 
-import com.dnd.moddo.domain.image.dto.CharacterResponse;
-import com.dnd.moddo.domain.image.service.implementation.ImageReader;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import com.dnd.moddo.domain.image.dto.CharacterResponse;
 import com.dnd.moddo.domain.image.entity.type.Character;
+import com.dnd.moddo.domain.image.service.implementation.ImageReader;
 
 class QueryImageServiceTest {
 
-    @Mock
-    private ImageReader imageReader;
+	@Mock
+	private ImageReader imageReader;
 
-    @InjectMocks
-    private QueryImageService queryImageService;
+	@InjectMocks
+	private QueryImageService queryImageService;
 
-    @BeforeEach
-    void setUp() {
-        MockitoAnnotations.openMocks(this);
-    }
+	@BeforeEach
+	void setUp() {
+		MockitoAnnotations.openMocks(this);
+	}
 
-    @Test
-    void getCharacter() {
-        // given
-        Character character = Character.ANGEL;
-        CharacterResponse Response = new CharacterResponse(character.getName(), String.valueOf(character.getRarity()), "imgUrl", "bigImgUrl");
+	@Test
+	void getCharacter() {
+		// given
+		Character character = Character.ANGEL;
+		CharacterResponse Response = new CharacterResponse(character.getName(), String.valueOf(character.getRarity()),
+			"imgUrl", "bigImgUrl");
 
-        // when
-        when(imageReader.getRandomCharacter()).thenReturn(Response);
-        CharacterResponse result = queryImageService.getCharacter();
+		// when
+		when(imageReader.getRandomCharacter(1L)).thenReturn(Response);
+		CharacterResponse result = queryImageService.getCharacter(1L);
 
-        // then
-        assertThat(result.rarity()).isEqualTo(String.valueOf(character.getRarity()));
-        assertThat(result.name()).isEqualTo(character.getName());
+		// then
+		assertThat(result.rarity()).isEqualTo(String.valueOf(character.getRarity()));
+		assertThat(result.name()).isEqualTo(character.getName());
 
-        // verify
-        verify(imageReader, times(1)).getRandomCharacter();
-    }
+		// verify
+		verify(imageReader, times(1)).getRandomCharacter(1L);
+	}
 }

--- a/src/test/java/com/dnd/moddo/domain/memberExpense/service/QueryMemberExpenseServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/memberExpense/service/QueryMemberExpenseServiceTest.java
@@ -41,7 +41,7 @@ class QueryMemberExpenseServiceTest {
 
 	@BeforeEach
 	void setUp() {
-		mockGroup = new Group("group 1", 1L, "1234", LocalDateTime.now(), LocalDateTime.now().plusMinutes(1),
+		mockGroup = new Group("group 1", 1L, "1234", LocalDateTime.now().plusMinutes(1),
 			"은행", "계좌", LocalDateTime.now().plusDays(1));
 
 	}

--- a/src/test/java/com/dnd/moddo/domain/memberExpense/service/QueryMemberExpenseServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/memberExpense/service/QueryMemberExpenseServiceTest.java
@@ -38,12 +38,29 @@ class QueryMemberExpenseServiceTest {
 	private QueryMemberExpenseService queryMemberExpenseService;
 
 	private Group mockGroup;
+	private GroupMember mockGroupMember1;
+	private GroupMember mockGroupMember2;
 
 	@BeforeEach
 	void setUp() {
 		mockGroup = new Group("group 1", 1L, "1234", LocalDateTime.now().plusMinutes(1),
 			"은행", "계좌", LocalDateTime.now().plusDays(1));
 
+		mockGroupMember1 = GroupMember.builder()
+			.name("김모또")
+			.profile("profile1.jpg")
+			.group(mockGroup)
+			.isPaid(true)
+			.role(ExpenseRole.MANAGER)
+			.build();
+
+		mockGroupMember2 = GroupMember.builder()
+			.name("박완숙")
+			.profile("profile2.jpg")
+			.group(mockGroup)
+			.isPaid(false)
+			.role(ExpenseRole.PARTICIPANT)
+			.build();
 	}
 
 	@DisplayName("지출내역이 유효할때 지출내역의 참여자별 지출내역 조회에 성공한다.")
@@ -51,8 +68,6 @@ class QueryMemberExpenseServiceTest {
 	void findAllByExpenseId() {
 		//given
 		Long expenseId = 1L;
-		GroupMember mockGroupMember1 = new GroupMember("김모또", mockGroup, ExpenseRole.MANAGER);
-		GroupMember mockGroupMember2 = new GroupMember("박완숙", mockGroup, ExpenseRole.PARTICIPANT);
 
 		List<MemberExpense> expectedMemberExpense = List.of(
 			new MemberExpense(expenseId, mockGroupMember1, 15000L),
@@ -100,10 +115,8 @@ class QueryMemberExpenseServiceTest {
 		when(expense2.getId()).thenReturn(2L);
 
 		when(groupMemberReader.findAllByGroupId(eq(groupId))).thenReturn(groupMembers);
-
 		when(memberExpenseReader.findAllByGroupMemberIds(List.of(1L, 2L)))
 			.thenReturn(List.of(memberExpense1, memberExpense2));
-
 		when(expenseReader.findAllByGroupId(any())).thenReturn(List.of(expense1, expense2));
 
 		// when

--- a/src/test/java/com/dnd/moddo/domain/memberExpense/service/implementation/MemberExpenseCreatorTest.java
+++ b/src/test/java/com/dnd/moddo/domain/memberExpense/service/implementation/MemberExpenseCreatorTest.java
@@ -1,6 +1,6 @@
 package com.dnd.moddo.domain.memberExpense.service.implementation;
 
-import static org.assertj.core.api.AssertionsForClassTypes.*;
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import java.time.LocalDateTime;
@@ -36,7 +36,14 @@ class MemberExpenseCreatorTest {
 		mockGroup = new Group("group 1", 1L, "1234", LocalDateTime.now().plusMinutes(1),
 			"은행", "계좌", LocalDateTime.now().plusDays(1));
 
-		mockGroupMember = new GroupMember("박완수", mockGroup, ExpenseRole.MANAGER);
+		mockGroupMember = GroupMember.builder()
+			.name("박완수")
+			.group(mockGroup)
+			.role(ExpenseRole.MANAGER)
+			.isPaid(true)
+			.profile("profile.jpg")
+			.build();
+
 		mockMemberExpenseRequest = mock(MemberExpenseRequest.class);
 	}
 
@@ -45,8 +52,8 @@ class MemberExpenseCreatorTest {
 	void createMemberExpenseSuccess() {
 		//given
 		Long expenseId = 1L;
-		MemberExpense mockMemberExpense = new MemberExpense(expenseId, mockGroupMember,
-			mockMemberExpenseRequest.amount());
+		MemberExpense mockMemberExpense = new MemberExpense(expenseId, mockGroupMember, 10000L);
+
 		when(mockMemberExpenseRequest.toEntity(expenseId, mockGroupMember)).thenReturn(mockMemberExpense);
 		when(memberExpenseRepository.save(any(MemberExpense.class))).thenReturn(mockMemberExpense);
 
@@ -54,8 +61,11 @@ class MemberExpenseCreatorTest {
 		MemberExpense result = memberExpenseCreator.create(expenseId, mockGroupMember, mockMemberExpenseRequest);
 
 		//then
+		assertThat(result).isNotNull();
 		assertThat(result).isEqualTo(mockMemberExpense);
-		verify(memberExpenseRepository, times(1)).save(any(MemberExpense.class));
+		assertThat(result.getAmount()).isEqualTo(10000L);
+		assertThat(result.getGroupMember()).isEqualTo(mockGroupMember);
 
+		verify(memberExpenseRepository, times(1)).save(any(MemberExpense.class));
 	}
 }

--- a/src/test/java/com/dnd/moddo/domain/memberExpense/service/implementation/MemberExpenseCreatorTest.java
+++ b/src/test/java/com/dnd/moddo/domain/memberExpense/service/implementation/MemberExpenseCreatorTest.java
@@ -33,7 +33,7 @@ class MemberExpenseCreatorTest {
 
 	@BeforeEach
 	void setUp() {
-		mockGroup = new Group("group 1", 1L, "1234", LocalDateTime.now(), LocalDateTime.now().plusMinutes(1),
+		mockGroup = new Group("group 1", 1L, "1234", LocalDateTime.now().plusMinutes(1),
 			"은행", "계좌", LocalDateTime.now().plusDays(1));
 
 		mockGroupMember = new GroupMember("박완수", mockGroup, ExpenseRole.MANAGER);

--- a/src/test/java/com/dnd/moddo/domain/memberExpense/service/implementation/MemberExpenseReaderTest.java
+++ b/src/test/java/com/dnd/moddo/domain/memberExpense/service/implementation/MemberExpenseReaderTest.java
@@ -34,22 +34,32 @@ class MemberExpenseReaderTest {
 	void setUp() {
 		mockGroup = new Group("group 1", 1L, "1234", LocalDateTime.now().plusMinutes(1),
 			"은행", "계좌", LocalDateTime.now().plusDays(1));
-		mockGroupMember = new GroupMember("박완숙", mockGroup, ExpenseRole.MANAGER);
+
+		mockGroupMember = GroupMember.builder()
+			.name("박완숙")
+			.group(mockGroup)
+			.role(ExpenseRole.MANAGER)
+			.isPaid(true)
+			.profile("profile.jpg")
+			.build();
 	}
 
 	@DisplayName("지출내역이 존재하면 해당 지출내역의 참여자별 지출내역을 조회에 성공한다.")
 	@Test
-	void findAllByExpenseIdS() {
-		//given
+	void findAllByExpenseId_Success() {
+		// given
 		Long expenseId = 1L;
-		List<MemberExpense> expectedMemberExpense = List.of(new MemberExpense(expenseId, mockGroupMember, 15000L));
+		// Mock 데이터 준비
+		List<MemberExpense> expectedMemberExpense = List.of(
+			new MemberExpense(expenseId, mockGroupMember, 15000L)
+		);
 
 		when(memberExpenseRepository.findByExpenseId(eq(expenseId))).thenReturn(expectedMemberExpense);
 
-		//when
+		// when
 		List<MemberExpense> result = memberExpenseReader.findAllByExpenseId(expenseId);
 
-		//then
+		// then
 		assertThat(result).isNotEmpty();
 		assertThat(result.get(0).getAmount()).isEqualTo(15000L);
 		assertThat(result.get(0).getGroupMember()).isEqualTo(mockGroupMember);
@@ -57,12 +67,16 @@ class MemberExpenseReaderTest {
 		verify(memberExpenseRepository, times(1)).findByExpenseId(eq(expenseId));
 	}
 
-	@DisplayName("참여자별 지출내역을 참여자id, 지출내역 map으로 변환하여 조회할 수 있다.")
+	@DisplayName("참여자별 지출내역을 참여자 id, 지출내역 map으로 변환하여 조회할 수 있다.")
 	@Test
-	public void findAllByGroupMemberIds_Success() {
-		//given
-		GroupMember groupMember1 = mock(GroupMember.class);
-		GroupMember groupMember2 = mock(GroupMember.class);
+	void findAllByGroupMemberIds_Success() {
+		// given
+		GroupMember groupMember1 = GroupMember.builder()
+			.name("김모또")
+			.group(mockGroup)
+			.role(ExpenseRole.PARTICIPANT)
+			.build();
+		GroupMember groupMember2 = GroupMember.builder().name("박완숙").group(mockGroup).role(ExpenseRole.MANAGER).build();
 
 		List<MemberExpense> mockExpenses = List.of(
 			new MemberExpense(1L, groupMember1, 1000L),
@@ -74,10 +88,10 @@ class MemberExpenseReaderTest {
 
 		when(memberExpenseRepository.findAllByGroupMemberIds(groupMemberIds)).thenReturn(mockExpenses);
 
-		//when
+		// when
 		List<MemberExpense> result = memberExpenseReader.findAllByGroupMemberIds(groupMemberIds);
 
-		//then
+		// then
 		assertThat(result).isNotEmpty();
 		assertThat(result).hasSize(mockExpenses.size());
 
@@ -87,9 +101,13 @@ class MemberExpenseReaderTest {
 	@DisplayName("지출내역 id들로 모든 참여자별 지출내역을 조회할 수 있다.")
 	@Test
 	void findAllByExpenseIds_Success() {
-		//given
-		GroupMember groupMember1 = mock(GroupMember.class);
-		GroupMember groupMember2 = mock(GroupMember.class);
+		// given
+		GroupMember groupMember1 = GroupMember.builder()
+			.name("김모또")
+			.group(mockGroup)
+			.role(ExpenseRole.PARTICIPANT)
+			.build();
+		GroupMember groupMember2 = GroupMember.builder().name("박완숙").group(mockGroup).role(ExpenseRole.MANAGER).build();
 
 		List<MemberExpense> mockExpenses = List.of(
 			new MemberExpense(1L, groupMember1, 1000L),
@@ -101,11 +119,13 @@ class MemberExpenseReaderTest {
 
 		when(memberExpenseRepository.findAllByExpenseIds(eq(expenseIds))).thenReturn(mockExpenses);
 
-		//then
+		// when
 		List<MemberExpense> result = memberExpenseReader.findAllByExpenseIds(expenseIds);
 
-		//then
+		// then
 		assertThat(result).isNotEmpty();
 		assertThat(result).hasSize(mockExpenses.size());
+
+		verify(memberExpenseRepository, times(1)).findAllByExpenseIds(eq(expenseIds));
 	}
 }

--- a/src/test/java/com/dnd/moddo/domain/memberExpense/service/implementation/MemberExpenseReaderTest.java
+++ b/src/test/java/com/dnd/moddo/domain/memberExpense/service/implementation/MemberExpenseReaderTest.java
@@ -32,7 +32,7 @@ class MemberExpenseReaderTest {
 
 	@BeforeEach
 	void setUp() {
-		mockGroup = new Group("group 1", 1L, "1234", LocalDateTime.now(), LocalDateTime.now().plusMinutes(1),
+		mockGroup = new Group("group 1", 1L, "1234", LocalDateTime.now().plusMinutes(1),
 			"은행", "계좌", LocalDateTime.now().plusDays(1));
 		mockGroupMember = new GroupMember("박완숙", mockGroup, ExpenseRole.MANAGER);
 	}


### PR DESCRIPTION
### #️⃣연관된 이슈
#66 

### 🔀반영 브랜치
feat/#66-member-profile-assign -> develop

### 🔧변경 사항
- Group의 createAt이 null로 들어오는 오류를 수정했습니다.
- `getProfileUrl()` 메서드의 url을 S3 url에 맞춰 수정했습니다.

### 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요
