### PR TITLE
프로필 자동 할당 profileId에 따라 변경

### DIFF
--- a/src/main/java/com/dnd/moddo/domain/groupMember/dto/request/GroupMemberSaveRequest.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/dto/request/GroupMemberSaveRequest.java
@@ -12,11 +12,12 @@ public record GroupMemberSaveRequest(
 	@Pattern(regexp = "^[가-힣a-zA-Z]{1,5}$", message = "참여자 이름은 한글과 영어만 포함하여 5자 이내여야 합니다.")
 	String name
 ) {
-	public GroupMember toEntity(Group group, String profile, ExpenseRole role) {
+	public GroupMember toEntity(Group group, Integer profileId, String profile, ExpenseRole role) {
 		return GroupMember.builder()
 			.name(name)
 			.group(group)
 			.role(role)
+			.profileId(profileId)
 			.profile(profile)
 			.isPaid(false)
 			.build();

--- a/src/main/java/com/dnd/moddo/domain/groupMember/dto/request/GroupMemberSaveRequest.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/dto/request/GroupMemberSaveRequest.java
@@ -12,13 +12,12 @@ public record GroupMemberSaveRequest(
 	@Pattern(regexp = "^[가-힣a-zA-Z]{1,5}$", message = "참여자 이름은 한글과 영어만 포함하여 5자 이내여야 합니다.")
 	String name
 ) {
-	public GroupMember toEntity(Group group, Integer profileId, String profile, ExpenseRole role) {
+	public GroupMember toEntity(Group group, Integer profileId, ExpenseRole role) {
 		return GroupMember.builder()
 			.name(name)
 			.group(group)
 			.role(role)
 			.profileId(profileId)
-			.profile(profile)
 			.isPaid(false)
 			.build();
 	}

--- a/src/main/java/com/dnd/moddo/domain/groupMember/dto/request/GroupMembersSaveRequest.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/dto/request/GroupMembersSaveRequest.java
@@ -14,7 +14,7 @@ public record GroupMembersSaveRequest(
 ) {
 	public List<GroupMember> toEntity(Group group) {
 		return members.stream()
-			.map(m -> m.toEntity(group, null, null, PARTICIPANT))
+			.map(m -> m.toEntity(group, null, PARTICIPANT))
 			.toList();
 	}
 

--- a/src/main/java/com/dnd/moddo/domain/groupMember/dto/request/GroupMembersSaveRequest.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/dto/request/GroupMembersSaveRequest.java
@@ -14,7 +14,7 @@ public record GroupMembersSaveRequest(
 ) {
 	public List<GroupMember> toEntity(Group group) {
 		return members.stream()
-			.map(m -> m.toEntity(group, null, PARTICIPANT))
+			.map(m -> m.toEntity(group, null, null, PARTICIPANT))
 			.toList();
 	}
 

--- a/src/main/java/com/dnd/moddo/domain/groupMember/dto/response/GroupMemberExpenseResponse.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/dto/response/GroupMemberExpenseResponse.java
@@ -27,7 +27,7 @@ public record GroupMemberExpenseResponse(
 			.role(groupMember.getRole())
 			.name(groupMember.getName())
 			.totalAmount(totalAmount)
-			.profile(groupMember.getProfile())
+			.profile(groupMember.getProfileUrl())
 			.isPaid(groupMember.isPaid())
 			.paidAt(groupMember.getPaidAt())
 			.expenses(expenses).build();

--- a/src/main/java/com/dnd/moddo/domain/groupMember/dto/response/GroupMemberResponse.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/dto/response/GroupMemberResponse.java
@@ -24,7 +24,7 @@ public record GroupMemberResponse(
 			.role(groupMember.getRole())
 			.isPaid(groupMember.isPaid())
 			.paidAt(groupMember.getPaidAt())
-			.profile(groupMember.getProfile())
+			.profile(groupMember.getProfileUrl())
 			.build();
 	}
 

--- a/src/main/java/com/dnd/moddo/domain/groupMember/entity/GroupMember.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/entity/GroupMember.java
@@ -37,6 +37,9 @@ public class GroupMember {
 	@Column(name = "profile")
 	private String profile;
 
+	@Column(name = "profile_id", nullable = false)
+	Integer profileId;
+
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "group_id", nullable = false)
 	private Group group;
@@ -52,9 +55,10 @@ public class GroupMember {
 	private ExpenseRole role;
 
 	@Builder
-	public GroupMember(String name, String profile, Group group, boolean isPaid, ExpenseRole role) {
+	public GroupMember(String name, String profile, Integer profileId, Group group, boolean isPaid, ExpenseRole role) {
 		this.name = name;
 		this.profile = profile;
+		this.profileId = profileId;
 		this.group = group;
 		this.isPaid = isPaid;
 		this.role = role;

--- a/src/main/java/com/dnd/moddo/domain/groupMember/entity/GroupMember.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/entity/GroupMember.java
@@ -34,11 +34,8 @@ public class GroupMember {
 	@Column(name = "name", updatable = false, nullable = false)
 	private String name;
 
-	@Column(name = "profile")
-	private String profile;
-
 	@Column(name = "profile_id", nullable = false)
-	Integer profileId;
+	private Integer profileId;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "group_id", nullable = false)
@@ -55,9 +52,8 @@ public class GroupMember {
 	private ExpenseRole role;
 
 	@Builder
-	public GroupMember(String name, String profile, Integer profileId, Group group, boolean isPaid, ExpenseRole role) {
+	public GroupMember(String name, Integer profileId, Group group, boolean isPaid, ExpenseRole role) {
 		this.name = name;
-		this.profile = profile;
 		this.profileId = profileId;
 		this.group = group;
 		this.isPaid = isPaid;
@@ -73,7 +69,10 @@ public class GroupMember {
 		this.paidAt = Boolean.TRUE.equals(isPaid) ? LocalDateTime.now() : null;
 	}
 
-	public void updateProfile(String profile) {
-		this.profile = profile;
+	public String getProfileUrl() {
+		if (profileId == 0) {
+			return "https://moddo-s3.s3.amazonaws.com/profile/MODDO.png";
+		}
+		return "https://moddo-s3.s3.amazonaws.com/profile/" + profileId + ".png";
 	}
 }

--- a/src/main/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberCreator.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberCreator.java
@@ -9,7 +9,6 @@ import com.dnd.moddo.domain.groupMember.entity.type.ExpenseRole;
 import com.dnd.moddo.domain.groupMember.repository.GroupMemberRepository;
 import com.dnd.moddo.domain.user.entity.User;
 import com.dnd.moddo.domain.user.repository.UserRepository;
-import com.dnd.moddo.global.config.S3Bucket;
 
 import lombok.RequiredArgsConstructor;
 
@@ -19,7 +18,6 @@ import lombok.RequiredArgsConstructor;
 public class GroupMemberCreator {
 	private final GroupMemberRepository groupMemberRepository;
 	private final UserRepository userRepository;
-	private final S3Bucket s3Bucket;
 
 	public GroupMember createManagerForGroup(Group group, Long userId) {
 		User user = userRepository.getById(userId);
@@ -29,13 +27,12 @@ public class GroupMemberCreator {
 		GroupMember groupMember = GroupMember.builder()
 			.name(name)
 			.group(group)
+			.profileId(null)
 			.profileId(0)
 			.role(ExpenseRole.MANAGER)
 			.build();
 
 		groupMember.updatePaymentStatus(true);
-		String profile = s3Bucket.getS3Url() + "profile/MODDO.png";
-		groupMember.updateProfile(profile);
 
 		return groupMemberRepository.save(groupMember);
 	}

--- a/src/main/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberCreator.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberCreator.java
@@ -9,6 +9,7 @@ import com.dnd.moddo.domain.groupMember.entity.type.ExpenseRole;
 import com.dnd.moddo.domain.groupMember.repository.GroupMemberRepository;
 import com.dnd.moddo.domain.user.entity.User;
 import com.dnd.moddo.domain.user.repository.UserRepository;
+import com.dnd.moddo.global.config.S3Bucket;
 
 import lombok.RequiredArgsConstructor;
 
@@ -18,6 +19,7 @@ import lombok.RequiredArgsConstructor;
 public class GroupMemberCreator {
 	private final GroupMemberRepository groupMemberRepository;
 	private final UserRepository userRepository;
+	private final S3Bucket s3Bucket;
 
 	public GroupMember createManagerForGroup(Group group, Long userId) {
 		User user = userRepository.getById(userId);
@@ -27,10 +29,13 @@ public class GroupMemberCreator {
 		GroupMember groupMember = GroupMember.builder()
 			.name(name)
 			.group(group)
+			.profileId(0)
 			.role(ExpenseRole.MANAGER)
 			.build();
 
 		groupMember.updatePaymentStatus(true);
+		String profile = s3Bucket.getS3Url() + "profile/moddo.png";
+		groupMember.updateProfile(profile);
 
 		return groupMemberRepository.save(groupMember);
 	}

--- a/src/main/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberCreator.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberCreator.java
@@ -34,7 +34,7 @@ public class GroupMemberCreator {
 			.build();
 
 		groupMember.updatePaymentStatus(true);
-		String profile = s3Bucket.getS3Url() + "profile/moddo.png";
+		String profile = s3Bucket.getS3Url() + "profile/MODDO.png";
 		groupMember.updateProfile(profile);
 
 		return groupMemberRepository.save(groupMember);

--- a/src/main/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberUpdater.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberUpdater.java
@@ -69,7 +69,7 @@ public class GroupMemberUpdater {
 		}
 
 		int maxProfileId = usedProfiles.stream().max(Integer::compareTo).orElse(0);
-		return (maxProfileId % 8) + 1;
+		return (usedProfiles.size() % 8) + 1;
 	}
 
 	private String getProfileUrl(int profileId) {

--- a/src/main/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberUpdater.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberUpdater.java
@@ -13,7 +13,6 @@ import com.dnd.moddo.domain.groupMember.dto.request.PaymentStatusUpdateRequest;
 import com.dnd.moddo.domain.groupMember.entity.GroupMember;
 import com.dnd.moddo.domain.groupMember.entity.type.ExpenseRole;
 import com.dnd.moddo.domain.groupMember.repository.GroupMemberRepository;
-import com.dnd.moddo.global.config.S3Bucket;
 
 import lombok.RequiredArgsConstructor;
 
@@ -25,7 +24,6 @@ public class GroupMemberUpdater {
 	private final GroupMemberReader groupMemberReader;
 	private final GroupMemberValidator groupMemberValidator;
 	private final GroupReader groupReader;
-	private final S3Bucket s3Bucket;
 
 	public GroupMember addToGroup(Long groupId, GroupMemberSaveRequest request) {
 		Group group = groupReader.read(groupId);
@@ -36,21 +34,15 @@ public class GroupMemberUpdater {
 
 		groupMemberValidator.validateMemberNamesNotDuplicate(existingNames);
 
-		List<GroupMember> membersOnly = groupMembers.stream()
+		List<Integer> usedProfiles = groupMembers.stream()
 			.filter(member -> !member.isManager())
-			.toList();
-
-		List<Integer> usedProfiles = membersOnly.stream()
 			.map(GroupMember::getProfileId)
 			.toList();
 
-		int newProfileId = findAvailableProfileId(usedProfiles);
+		Integer newProfileId = findAvailableProfileId(usedProfiles);
 
-		GroupMember newMember = request.toEntity(group, newProfileId, null, ExpenseRole.PARTICIPANT);
+		GroupMember newMember = request.toEntity(group, newProfileId, ExpenseRole.PARTICIPANT);
 		newMember = groupMemberRepository.save(newMember);
-
-		String profileUrl = getProfileUrl(newProfileId);
-		newMember.updateProfile(profileUrl);
 
 		return newMember;
 	}
@@ -61,17 +53,13 @@ public class GroupMemberUpdater {
 		return groupMember;
 	}
 
-	private int findAvailableProfileId(List<Integer> usedProfiles) {
+	private Integer findAvailableProfileId(List<Integer> usedProfiles) {
 		for (int i = 1; i <= 8; i++) {
 			if (!usedProfiles.contains(i)) {
 				return i;
 			}
 		}
-		
-		return (usedProfiles.size() % 8) + 1;
-	}
 
-	private String getProfileUrl(int profileId) {
-		return s3Bucket.getS3Url() + "profile/" + profileId + ".png";
+		return (usedProfiles.size() % 8) + 1;
 	}
 }

--- a/src/main/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberUpdater.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberUpdater.java
@@ -67,8 +67,7 @@ public class GroupMemberUpdater {
 				return i;
 			}
 		}
-
-		int maxProfileId = usedProfiles.stream().max(Integer::compareTo).orElse(0);
+		
 		return (usedProfiles.size() % 8) + 1;
 	}
 

--- a/src/main/java/com/dnd/moddo/domain/memberExpense/dto/response/MemberExpenseResponse.java
+++ b/src/main/java/com/dnd/moddo/domain/memberExpense/dto/response/MemberExpenseResponse.java
@@ -18,7 +18,7 @@ public record MemberExpenseResponse(
 			.id(memberExpense.getGroupMember().getId())
 			.name(memberExpense.getGroupMember().getName())
 			.role(memberExpense.getGroupMember().getRole())
-			.profile(memberExpense.getGroupMember().getProfile())
+			.profile(memberExpense.getGroupMember().getProfileUrl())
 			.amount(memberExpense.getAmount())
 			.build();
 	}

--- a/src/test/java/com/dnd/moddo/domain/group/service/QueryGroupServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/group/service/QueryGroupServiceTest.java
@@ -42,7 +42,7 @@ class QueryGroupServiceTest {
 	@BeforeEach
 	void setUp() {
 		group = new Group("groupName", 1L, "password", null, null, null, null);
-		groupMember = new GroupMember("김완숙", "profile", 1, group, false, ExpenseRole.MANAGER);
+		groupMember = new GroupMember("김완숙", 1, group, false, ExpenseRole.MANAGER);
 
 		setField(group, "id", 1L);
 	}

--- a/src/test/java/com/dnd/moddo/domain/group/service/QueryGroupServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/group/service/QueryGroupServiceTest.java
@@ -41,9 +41,8 @@ class QueryGroupServiceTest {
 
 	@BeforeEach
 	void setUp() {
-		// Given
 		group = new Group("groupName", 1L, "password", null, null, null, null);
-		groupMember = new GroupMember("김완숙", "profile", group, false, ExpenseRole.MANAGER);
+		groupMember = new GroupMember("김완숙", "profile", 1, group, false, ExpenseRole.MANAGER);
 
 		setField(group, "id", 1L);
 	}
@@ -117,8 +116,21 @@ class QueryGroupServiceTest {
 		assertThat(response.groupName()).isEqualTo(group.getName());
 		assertThat(response.bank()).isEqualTo(group.getBank());
 		assertThat(response.accountNumber()).isEqualTo(group.getAccountNumber());
-		assertThat(response.groupName()).isEqualTo(group.getName());
 
 		verify(groupReader, times(1)).findByHeader(group.getId());
+	}
+
+	@Test
+	@DisplayName("그룹 헤더를 찾을 수 없을 경우 예외가 발생한다.")
+	void FindByGroupHeader_Failure_WhenHeaderNotFound() {
+		// Given
+		when(groupReader.findByHeader(anyLong())).thenThrow(new RuntimeException("Header not found"));
+
+		// When & Then
+		assertThatThrownBy(() -> queryGroupService.findByGroupHeader(1L))
+			.isInstanceOf(RuntimeException.class)
+			.hasMessageContaining("Header not found");
+
+		verify(groupReader, times(1)).findByHeader(1L);
 	}
 }

--- a/src/test/java/com/dnd/moddo/domain/groupMember/entity/GroupMemberTest.java
+++ b/src/test/java/com/dnd/moddo/domain/groupMember/entity/GroupMemberTest.java
@@ -30,7 +30,6 @@ class GroupMemberTest {
 			.group(mockGroup)
 			.role(ExpenseRole.MANAGER)
 			.isPaid(true)
-			.profile("profile.jpg")
 			.build();
 
 		// when
@@ -49,7 +48,6 @@ class GroupMemberTest {
 			.group(mockGroup)
 			.role(ExpenseRole.PARTICIPANT)
 			.isPaid(true)
-			.profile("profile.jpg")
 			.build();
 
 		// when
@@ -68,7 +66,6 @@ class GroupMemberTest {
 			.group(mockGroup)
 			.role(ExpenseRole.PARTICIPANT)
 			.isPaid(false)
-			.profile("profile.jpg")
 			.build();
 
 		// when
@@ -77,26 +74,5 @@ class GroupMemberTest {
 		// then
 		assertThat(groupMember.isPaid()).isTrue();
 		assertThat(groupMember.getPaidAt()).isNotNull();
-	}
-
-	@DisplayName("참여자의 프로필을 업데이트할 수 있다.")
-	@Test
-	void testUpdateProfile() {
-		// given
-		GroupMember groupMember = GroupMember.builder()
-			.name("김모또")
-			.group(mockGroup)
-			.role(ExpenseRole.PARTICIPANT)
-			.isPaid(true)
-			.profile("profile.jpg")
-			.build();
-
-		String newProfile = "newProfile.jpg";
-
-		// when
-		groupMember.updateProfile(newProfile);
-
-		// then
-		assertThat(groupMember.getProfile()).isEqualTo(newProfile);
 	}
 }

--- a/src/test/java/com/dnd/moddo/domain/groupMember/service/CommandGroupMemberServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/groupMember/service/CommandGroupMemberServiceTest.java
@@ -72,6 +72,7 @@ public class CommandGroupMemberServiceTest {
 		GroupMember expectedMember = GroupMember.builder()
 			.name("김반숙")
 			.group(mockGroup)
+			.profileId(1)
 			.role(ExpenseRole.PARTICIPANT)
 			.build();
 
@@ -94,6 +95,7 @@ public class CommandGroupMemberServiceTest {
 			.name("김반숙")
 			.group(mockGroup)
 			.isPaid(true)
+			.profileId(1)
 			.role(ExpenseRole.PARTICIPANT)
 			.build();
 		PaymentStatusUpdateRequest request = new PaymentStatusUpdateRequest(true);

--- a/src/test/java/com/dnd/moddo/domain/groupMember/service/CommandGroupMemberServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/groupMember/service/CommandGroupMemberServiceTest.java
@@ -46,8 +46,8 @@ public class CommandGroupMemberServiceTest {
 		Long userId = 1L;
 		GroupMember expectedMembers = GroupMember.builder()
 			.name("김모또")
-			.profile("profile")
 			.group(mockGroup)
+			.profileId(0)
 			.role(ExpenseRole.MANAGER)
 			.build();
 		Group mockGroup = mock(Group.class);

--- a/src/test/java/com/dnd/moddo/domain/groupMember/service/QueryGroupMemberServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/groupMember/service/QueryGroupMemberServiceTest.java
@@ -40,10 +40,12 @@ public class QueryGroupMemberServiceTest {
 			GroupMember.builder()
 				.name("김모또")
 				.group(mockGroup)
+				.profileId(0)
 				.role(ExpenseRole.MANAGER)
 				.build(),
 			GroupMember.builder()
 				.name("김반숙")
+				.profileId(1)
 				.group(mockGroup)
 				.role(ExpenseRole.PARTICIPANT)
 				.build()

--- a/src/test/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberCreatorTest.java
+++ b/src/test/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberCreatorTest.java
@@ -38,7 +38,7 @@ public class GroupMemberCreatorTest {
 		mockGroup = mock(Group.class);
 	}
 
-	@DisplayName("사용자가 비회원인 경우, 총무의 이름은 '김모또'로 생성되고 프로필 URL이 동적으로 생성된다.")
+	@DisplayName("사용자가 비회원인 경우, 총무의 이름은 '김모또'로 생성되고 프로필 ID가 0으로 설정된다.")
 	@Test
 	void create_Success_WithGuestMember() {
 		// given
@@ -51,7 +51,7 @@ public class GroupMemberCreatorTest {
 		GroupMember expectedMember = GroupMember.builder()
 			.name("김모또")
 			.group(mockGroup)
-			.profileId(null)
+			.profileId(0)
 			.role(ExpenseRole.MANAGER)
 			.build();
 
@@ -64,13 +64,13 @@ public class GroupMemberCreatorTest {
 		assertThat(savedMember).isNotNull();
 		assertThat(savedMember.getName()).isEqualTo("김모또");
 		assertThat(savedMember.getRole()).isEqualTo(ExpenseRole.MANAGER);
-		assertThat(savedMember.getProfileUrl()).isEqualTo("https://moddo-s3.s3.amazonaws.com/profile/MODDO.png");
+		assertThat(savedMember.getProfileId()).isEqualTo(0); // profileId 검증
 
 		verify(userRepository, times(1)).getById(eq(userId));
 		verify(groupMemberRepository, times(1)).save(any(GroupMember.class));
 	}
 
-	@DisplayName("사용자가 회원인 경우, 총무의 이름은 회원의 이름으로 생성되고 프로필 URL이 동적으로 생성된다.")
+	@DisplayName("사용자가 회원인 경우, 총무의 이름은 회원의 이름으로 생성되고 프로필 ID가 0으로 설정된다.")
 	@Test
 	void create_Success_WithMember() {
 		// given
@@ -97,7 +97,7 @@ public class GroupMemberCreatorTest {
 		assertThat(savedMember).isNotNull();
 		assertThat(savedMember.getName()).isEqualTo("연노른자");
 		assertThat(savedMember.getRole()).isEqualTo(ExpenseRole.MANAGER);
-		assertThat(savedMember.getProfileUrl()).isEqualTo("https://moddo-s3.s3.amazonaws.com/profile/MODDO.png");
+		assertThat(savedMember.getProfileId()).isEqualTo(0);
 
 		verify(userRepository, times(1)).getById(eq(userId));
 		verify(groupMemberRepository, times(1)).save(any(GroupMember.class));

--- a/src/test/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberDeleterTest.java
+++ b/src/test/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberDeleterTest.java
@@ -44,7 +44,6 @@ class GroupMemberDeleterTest {
 		Long groupMemberId = 1L;
 		GroupMember expectedMember = GroupMember.builder()
 			.name("김반숙")
-			.profile("profile")
 			.group(mockGroup)
 			.role(ExpenseRole.PARTICIPANT)
 			.isPaid(false)
@@ -82,7 +81,6 @@ class GroupMemberDeleterTest {
 		Long groupMemberId = 1L;
 		GroupMember expectedMember = GroupMember.builder()
 			.name("김모또")
-			.profile("profile")
 			.group(mockGroup)
 			.role(ExpenseRole.MANAGER)
 			.isPaid(false)

--- a/src/test/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberReaderTest.java
+++ b/src/test/java/com/dnd/moddo/domain/groupMember/service/implementation/GroupMemberReaderTest.java
@@ -43,14 +43,12 @@ public class GroupMemberReaderTest {
 		List<GroupMember> expectedMembers = List.of(
 			GroupMember.builder()
 				.name("김모또")
-				.profile("profile")
 				.group(mockGroup)
 				.role(ExpenseRole.MANAGER)
 				.isPaid(false)
 				.build(),
 			GroupMember.builder()
 				.name("김반숙")
-				.profile("profile")
 				.group(mockGroup)
 				.role(ExpenseRole.PARTICIPANT)
 				.isPaid(false)
@@ -77,7 +75,6 @@ public class GroupMemberReaderTest {
 		Long groupMemberId = 1L;
 		GroupMember expectedMember = GroupMember.builder()
 			.name("김반숙")
-			.profile("profile")
 			.group(mockGroup)
 			.role(ExpenseRole.PARTICIPANT)
 			.isPaid(false)

--- a/src/test/java/com/dnd/moddo/domain/memberExpense/service/QueryMemberExpenseServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/memberExpense/service/QueryMemberExpenseServiceTest.java
@@ -48,17 +48,17 @@ class QueryMemberExpenseServiceTest {
 
 		mockGroupMember1 = GroupMember.builder()
 			.name("김모또")
-			.profile("profile1.jpg")
 			.group(mockGroup)
 			.isPaid(true)
+			.profileId(0)
 			.role(ExpenseRole.MANAGER)
 			.build();
 
 		mockGroupMember2 = GroupMember.builder()
 			.name("박완숙")
-			.profile("profile2.jpg")
 			.group(mockGroup)
 			.isPaid(false)
+			.profileId(1)
 			.role(ExpenseRole.PARTICIPANT)
 			.build();
 	}

--- a/src/test/java/com/dnd/moddo/domain/memberExpense/service/implementation/MemberExpenseCreatorTest.java
+++ b/src/test/java/com/dnd/moddo/domain/memberExpense/service/implementation/MemberExpenseCreatorTest.java
@@ -41,7 +41,6 @@ class MemberExpenseCreatorTest {
 			.group(mockGroup)
 			.role(ExpenseRole.MANAGER)
 			.isPaid(true)
-			.profile("profile.jpg")
 			.build();
 
 		mockMemberExpenseRequest = mock(MemberExpenseRequest.class);

--- a/src/test/java/com/dnd/moddo/domain/memberExpense/service/implementation/MemberExpenseReaderTest.java
+++ b/src/test/java/com/dnd/moddo/domain/memberExpense/service/implementation/MemberExpenseReaderTest.java
@@ -40,7 +40,6 @@ class MemberExpenseReaderTest {
 			.group(mockGroup)
 			.role(ExpenseRole.MANAGER)
 			.isPaid(true)
-			.profile("profile.jpg")
 			.build();
 	}
 


### PR DESCRIPTION
### #️⃣연관된 이슈
#83  

### 🔀반영 브랜치
feat/#66-member-profile-assign -> develop

### 🔧변경 사항
- 현재 사용 중인 프로필 Id를 기반으로 비어있는 프로필 Id를 탐색해 새로운 멤버에게 할당합니다.
- 모든 Id가 사용 중일 경우, 순환적으로 할당하게 설정했습니다.
- `.filter(member -> !member.isManager())`로 그룹 멤버 중 관리자가 아닌 멤버를 필터링하고, 멤버들의 프로필 Id 목록을 생성했습니다.
- 반복문으로 1~8까지 순차적으로 검사해서 `usedProfiles`에 포함되지 않은 Id를 반환하게 구현했습니다.
  - 모든 Id가 사용중이면 `(usedProfiles.size() % 8) + 1`를 통해 다음 Id를 결정합니다.

### 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요
