### PR TITLE
저장된 이미지와 코드의 이미지명 통합

### DIFF
--- a/src/main/java/com/dnd/moddo/domain/image/dto/CharacterResponse.java
+++ b/src/main/java/com/dnd/moddo/domain/image/dto/CharacterResponse.java
@@ -24,8 +24,8 @@ public record CharacterResponse(
 		return new CharacterResponse(
 			characters.getName(),
 			rarityString,
-			getImageUrl(s3Bucket, characters.getFileName(), characters.getRarity()),
-			getBigImageUrl(s3Bucket, characters.getBigName(), characters.getRarity())
+			getImageUrl(s3Bucket, characters.getName(), characters.getRarity()),
+			getBigImageUrl(s3Bucket, characters.getName(), characters.getRarity())
 		);
 	}
 

--- a/src/main/java/com/dnd/moddo/domain/image/entity/type/Characters.java
+++ b/src/main/java/com/dnd/moddo/domain/image/entity/type/Characters.java
@@ -9,16 +9,14 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum Characters {
-	LUCKY(1, "러키 모또", "lucky", "lucky"),
-	ANGEL(2, "천사 모또", "angel", "angel"),
-	STRAWBERRY(2, "딸기 또또", "strawberry", "strqwberry"),
-	MAGIC(3, "마법사 또또", "magic", "magic"),
-	SLEEP(3, "잠꾸러기 또또", "sleep", "sleep");
+	LUCKY(1, "러키 모또"),
+	ANGEL(2, "천사 모또"),
+	STRAWBERRY(2, "딸기 또또"),
+	MAGIC(3, "마법사 또또"),
+	SLEEP(3, "잠꾸러기 또또");
 
 	private final int rarity;
 	private final String name;
-	private final String fileName;
-	private final String bigName;
 
 	public static List<Characters> getByRarity(int rarity) {
 		return Arrays.stream(values())

--- a/src/test/java/com/dnd/moddo/domain/image/entity/type/CharacterTest.java
+++ b/src/test/java/com/dnd/moddo/domain/image/entity/type/CharacterTest.java
@@ -7,7 +7,7 @@ import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-class CharactersTest {
+class CharacterTest {
 
 	@Test
 	@DisplayName("rarity에 해당하는 캐릭터의 검증한다.")


### PR DESCRIPTION
### #️⃣연관된 이슈
#66

### 🔀반영 브랜치
feat/#66-member-profile-assign -> develop

### 🔧변경 사항
- 임의로 수정한 코드를 되돌리고, S3의 이미지 명을 알맞게 수정했습니다 (ex. angel -> 천사 모또.png)

### 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요
