### PR TITLE
입금 내역 업데이트 시 낙관적 락 적용

### DIFF
--- a/src/main/java/com/dnd/moddo/domain/groupMember/entity/GroupMember.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/entity/GroupMember.java
@@ -16,6 +16,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -50,6 +51,9 @@ public class GroupMember {
 	@Enumerated(EnumType.STRING)
 	@Column(nullable = false)
 	private ExpenseRole role;
+
+	@Version
+	private Long version = 0L;
 
 	@Builder
 	public GroupMember(String name, Integer profileId, Group group, boolean isPaid, ExpenseRole role) {

--- a/src/main/java/com/dnd/moddo/domain/groupMember/exception/PaymentConcurrencyException.java
+++ b/src/main/java/com/dnd/moddo/domain/groupMember/exception/PaymentConcurrencyException.java
@@ -1,0 +1,11 @@
+package com.dnd.moddo.domain.groupMember.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.dnd.moddo.global.exception.ModdoException;
+
+public class PaymentConcurrencyException extends ModdoException {
+	public PaymentConcurrencyException() {
+		super(HttpStatus.BAD_REQUEST, "다른 사용자가 상태를 갱신했습니다");
+	}
+}

--- a/src/test/java/com/dnd/moddo/domain/groupMember/service/PaymentConcurrencyTest.java
+++ b/src/test/java/com/dnd/moddo/domain/groupMember/service/PaymentConcurrencyTest.java
@@ -1,0 +1,99 @@
+package com.dnd.moddo.domain.groupMember.service;
+
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+
+import java.time.LocalDateTime;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import com.dnd.moddo.ModdoApplication;
+import com.dnd.moddo.domain.group.entity.Group;
+import com.dnd.moddo.domain.group.repository.GroupRepository;
+import com.dnd.moddo.domain.group.service.implementation.GroupReader;
+import com.dnd.moddo.domain.groupMember.dto.request.PaymentStatusUpdateRequest;
+import com.dnd.moddo.domain.groupMember.entity.GroupMember;
+import com.dnd.moddo.domain.groupMember.entity.type.ExpenseRole;
+import com.dnd.moddo.domain.groupMember.repository.GroupMemberRepository;
+import com.dnd.moddo.domain.groupMember.service.implementation.GroupMemberReader;
+import com.dnd.moddo.domain.groupMember.service.implementation.GroupMemberUpdater;
+import com.dnd.moddo.domain.groupMember.service.implementation.GroupMemberValidator;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(classes = ModdoApplication.class) // 명시적으로 설정 클래스를 지정
+public class PaymentConcurrencyTest {
+	@Autowired
+	private GroupMemberUpdater groupMemberUpdater;
+	@Autowired
+	private GroupMemberRepository groupMemberRepository;
+	@Autowired
+	private GroupRepository groupRepository;
+	@Autowired
+	private GroupMemberValidator groupMemberValidator;
+	@Autowired
+	private GroupMemberReader groupMemberReader;
+	@Autowired
+	private GroupReader groupReader;
+
+	private GroupMember groupMember;
+
+	@BeforeEach
+	void setUp() {
+		Group mockGroup = new Group("group 1", 1L, "1234", LocalDateTime.now().plusMinutes(1),
+			"은행", "계좌", LocalDateTime.now().plusDays(1));
+
+		groupRepository.save(mockGroup);
+
+		groupMember = groupMemberRepository.save(
+			GroupMember.builder()
+				.name("김반숙")
+				.group(mockGroup)
+				.profileId(1)
+				.role(ExpenseRole.PARTICIPANT)
+				.build());
+	}
+
+	@DisplayName("낙관적 락을 적용했을 때 업데이트 충돌로 일부 요청에서 예외가 발생한다.")
+	@Test
+	void optimisticLock_shouldThrowExceptionOnConflict() throws InterruptedException {
+		//given
+		Long groupMemberId = groupMember.getId();
+		int threadCount = 10;
+		CountDownLatch latch = new CountDownLatch(threadCount);
+
+		AtomicInteger successCount = new AtomicInteger();
+		AtomicInteger failureCount = new AtomicInteger();
+		//when
+
+		for (int i = 0; i < threadCount; i++) {
+			new Thread(() -> {
+				try {
+					groupMemberUpdater.updatePaymentStatus(groupMemberId, new PaymentStatusUpdateRequest(true));
+					successCount.incrementAndGet();
+				} catch (OptimisticLockingFailureException e) {
+					failureCount.incrementAndGet(); // 동시 수정 충돌 발생
+				} finally {
+					latch.countDown();
+				}
+			}).start();
+		}
+
+		latch.await();
+
+		//then
+
+		GroupMember result = groupMemberRepository.getById(groupMemberId);
+
+		assertThat(result.isPaid()).isTrue();
+		assertThat(successCount.get()).isGreaterThan(0);
+		assertThat(failureCount.get()).isGreaterThan(0);
+	}
+}


### PR DESCRIPTION
### #️⃣연관된 이슈
[MOD-32](https://moddo-kr.atlassian.net/browse/MOD-32)

### 🔀반영 브랜치
feat/MOD-32-concurrency-payment-status -> develop

### 🔧변경 사항
- 입금 내역 업데이트에 낙관적 락을 적용하였습니다.
  - 입금 내역에서 발생할 확률은 높지 않지만 동시성 문제가 발생할 수 있는 상황이 존재한다고 판단했습니다. 예를 들어 두 명의 사용자가 동시에 입금 상태를 변경하려 할 때 데이터가 덮어씌워지거나 업데이트가 누락되는 문제가 발생할 수 있습니다. 이때 입금 내역의 시간은 랭킹 등에 중요한 영향을 미치기 때문에 일관된 데이터 처리가 필요하다고 생각하였습니다. 이러한 이유로 낙관적 락을 적용하여 동시성 문제를 해결하고 입금 상태 변경에 대한 정확한 처리를 보장하기 위해 락을 도입했습니다.

### 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요


[MOD-32]: https://moddo-kr.atlassian.net/browse/MOD-32?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ