### PR TITLE
feat: 카카오 소셜 로그인 기능 추가

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -70,7 +70,7 @@ jobs:
           envs: GITHUB_SHA
           script: |
             cd dnd-12th-7-backend
-            sudo docker compose down
-            sudo docker compose rm -f
+            sudo docker compose stop app
+            sudo docker compose rm -f app
             sudo docker rmi ${{env.DOCKER_IMAGE_NAME}}:latest
-            sudo docker compose up -d
+            sudo docker compose up -d app

--- a/src/docs/asciidoc/auth.adoc
+++ b/src/docs/asciidoc/auth.adoc
@@ -51,3 +51,28 @@ include::{snippets}/auth-controller-test/reissue-access-token/http-response.adoc
 ==== 응답
 
 include::{snippets}/auth-controller-test/reissue-access-token/response-body.adoc[]
+
+== 카카오톡 소셜 로그인
+
+사용자가 카카오 소셜 로그인을 완료하면, 인가 코드를 통해 카카오 Access Token을 발급받고, 이를 이용해 카카오 사용자 정보를 조회합니다.
+조회된 사용자 정보로 서비스의 Access Token을 생성한 후, 해당 토큰은 쿠키를 통해 클라이언트에 전달됩니다.
+
+=== Example
+
+include::{snippets}/auth-controller-test/kakao-login-callback/curl-request.adoc[]
+
+=== HTTP
+
+==== 요청
+
+include::{snippets}/auth-controller-test/kakao-login-callback/http-request.adoc[]
+
+==== 응답
+
+include::{snippets}/auth-controller-test/kakao-login-callback/http-response.adoc[]
+
+=== Body
+
+==== 응답
+
+include::{snippets}/auth-controller-test/kakao-login-callback/response-body.adoc[]

--- a/src/main/java/com/dnd/moddo/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/dnd/moddo/domain/auth/controller/AuthController.java
@@ -35,7 +35,13 @@ public class AuthController {
 
 	@GetMapping("/user/guest/token")
 	public ResponseEntity<TokenResponse> getGuestToken() {
-		return ResponseEntity.ok(authService.createGuestUser());
+		TokenResponse tokenResponse = authService.createGuestUser();
+
+		String cookie = createCookie("accessToken", tokenResponse.accessToken()).toString();
+
+		return ResponseEntity.ok()
+			.header(HttpHeaders.SET_COOKIE, cookie)
+			.body(tokenResponse);
 	}
 
 	@PutMapping("/user/reissue/token")

--- a/src/main/java/com/dnd/moddo/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/dnd/moddo/domain/auth/controller/AuthController.java
@@ -1,29 +1,90 @@
 package com.dnd.moddo.domain.auth.controller;
 
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.dnd.moddo.domain.auth.dto.KakaoTokenResponse;
 import com.dnd.moddo.domain.auth.service.AuthService;
+import com.dnd.moddo.domain.auth.service.KakaoClient;
 import com.dnd.moddo.domain.auth.service.RefreshTokenService;
 import com.dnd.moddo.global.jwt.dto.RefreshResponse;
 import com.dnd.moddo.global.jwt.dto.TokenResponse;
+import com.dnd.moddo.global.jwt.properties.CookieProperties;
+
 import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/api/v1/user")
+@EnableConfigurationProperties(CookieProperties.class)
+@RequestMapping("/api/v1")
 public class AuthController {
 
-    private final AuthService authService;
-    private final RefreshTokenService refreshTokenService;
+	private final AuthService authService;
+	private final RefreshTokenService refreshTokenService;
+	private final KakaoClient kakaoClient;
+	private final CookieProperties cookieProperties;
 
-    @GetMapping("/guest/token")
-    public ResponseEntity<TokenResponse> getGuestToken() {
-        return ResponseEntity.ok(authService.createGuestUser());
-    }
+	@GetMapping("/user/guest/token")
+	public ResponseEntity<TokenResponse> getGuestToken() {
+		return ResponseEntity.ok(authService.createGuestUser());
+	}
 
-    @PutMapping("/reissue/token")
-    public RefreshResponse reissueAccessToken(@RequestHeader(value = "Authorization") @NotBlank String refreshToken) {
-        return refreshTokenService.execute(refreshToken);
-    }
+	@PutMapping("/user/reissue/token")
+	public RefreshResponse reissueAccessToken(@RequestHeader(value = "Authorization") @NotBlank String refreshToken) {
+		return refreshTokenService.execute(refreshToken);
+	}
+
+	@GetMapping("/login/oauth2/callback")
+	public ResponseEntity<Void> kakaoLoginCallback(@RequestParam String code) {
+		KakaoTokenResponse kakaoTokenResponse = kakaoClient.join(code);
+
+		TokenResponse tokenResponse = authService.getOrCreateKakaoUserToken(kakaoTokenResponse.access_token());
+
+		String cookie = createCookie("accessToken", tokenResponse.accessToken()).toString();
+
+		return ResponseEntity.ok()
+			.header(HttpHeaders.SET_COOKIE, cookie)
+			.build();
+	}
+
+	@GetMapping("/logout")
+	public ResponseEntity<Void> kakaoLogout() {
+		String cookie = expireCookie("accessToken").toString();
+
+		return ResponseEntity.ok()
+			.header(HttpHeaders.SET_COOKIE, cookie)
+			.build();
+	}
+
+	private ResponseCookie createCookie(String name, String key) {
+		return ResponseCookie.from(name, key)
+			.httpOnly(cookieProperties.httpOnly())
+			.secure(cookieProperties.secure())
+			.path(cookieProperties.path())
+			.domain(cookieProperties.domain())
+			.sameSite(cookieProperties.sameSite())
+			.maxAge(cookieProperties.maxAge())
+			.build();
+
+	}
+
+	private ResponseCookie expireCookie(String name) {
+		return ResponseCookie.from(name, null)
+			.httpOnly(cookieProperties.httpOnly())
+			.secure(cookieProperties.secure())
+			.path(cookieProperties.path())
+			.domain(cookieProperties.domain())
+			.sameSite(cookieProperties.sameSite())
+			.maxAge(0L)
+			.build();
+	}
 }

--- a/src/main/java/com/dnd/moddo/domain/auth/dto/KakaoProfile.java
+++ b/src/main/java/com/dnd/moddo/domain/auth/dto/KakaoProfile.java
@@ -1,0 +1,36 @@
+package com.dnd.moddo.domain.auth.dto;
+
+public record KakaoProfile(
+	Long id,
+	String connected_at,
+	Properties properties,
+	KakaoAccount kakao_account
+) {
+	public record Properties(
+		String nickname,
+		String profile_image,
+		String thumbnail_image
+	) {
+	}
+
+	public record KakaoAccount(
+		Boolean profile_nickname_needs_agreement,
+		Boolean profile_image_needs_agreement,
+		Profile profile,
+		Boolean has_email,
+		Boolean email_needs_agreement,
+		Boolean is_email_valid,
+		Boolean is_email_verified,
+		String email
+	) {
+	}
+
+	public record Profile(
+		String nickname,
+		String thumbnail_image_url,
+		String profile_image_url,
+		Boolean is_default_image,
+		Boolean is_default_nickname
+	) {
+	}
+}

--- a/src/main/java/com/dnd/moddo/domain/auth/dto/KakaoTokenResponse.java
+++ b/src/main/java/com/dnd/moddo/domain/auth/dto/KakaoTokenResponse.java
@@ -1,0 +1,11 @@
+package com.dnd.moddo.domain.auth.dto;
+
+public record KakaoTokenResponse(
+	String access_token,
+	String token_type,
+	String refresh_token,
+	int expires_in,
+	String scope,
+	int refresh_token_expires_in
+) {
+}

--- a/src/main/java/com/dnd/moddo/domain/auth/service/AuthService.java
+++ b/src/main/java/com/dnd/moddo/domain/auth/service/AuthService.java
@@ -3,9 +3,11 @@ package com.dnd.moddo.domain.auth.service;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.dnd.moddo.domain.auth.dto.KakaoProfile;
 import com.dnd.moddo.domain.user.entity.User;
 import com.dnd.moddo.domain.user.entity.type.Authority;
 import com.dnd.moddo.domain.user.repository.UserRepository;
@@ -13,31 +15,61 @@ import com.dnd.moddo.global.jwt.dto.TokenResponse;
 import com.dnd.moddo.global.jwt.utill.JwtProvider;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @RequiredArgsConstructor
 @Service
+@Slf4j
 public class AuthService {
 
 	private final UserRepository userRepository;
 	private final JwtProvider jwtProvider;
+	private final KakaoClient kakaoClient;
+
+	@Value("${kakao.auth.client_id}")
+	String client_id;
+
+	@Value("${kakao.auth.redirect_uri}")
+	String redirect_uri;
 
 	@Transactional
 	public TokenResponse createGuestUser() {
 		String guestEmail = "guest-" + UUID.randomUUID() + "@guest.com";
 
-		User guestUser = User.builder()
-			.email(guestEmail)
-			.name("Guest")
-			.profile(null)
-			.createdAt(LocalDateTime.now())
-			.expiredAt(LocalDateTime.now().plusMonths(1))
-			.authority(Authority.USER)
-			.isMember(false)
-			.build();
-
-		userRepository.save(guestUser);
+		User guestUser = createUser(guestEmail, "Guest", false);
 
 		return jwtProvider.generateToken(guestUser.getId(), guestUser.getEmail(), guestUser.getAuthority().toString(),
 			guestUser.getIsMember());
 	}
+
+	private User createUser(String email, String name, boolean isMember) {
+		User user = User.builder()
+			.email(email)
+			.name(name)
+			.profile(null)
+			.createdAt(LocalDateTime.now())
+			.expiredAt(LocalDateTime.now().plusMonths(1))
+			.authority(Authority.USER)
+			.isMember(isMember)
+			.build();
+
+		return userRepository.save(user);
+	}
+
+	@Transactional
+	public TokenResponse getOrCreateKakaoUserToken(String token) {
+		KakaoProfile kakaoProfile = kakaoClient.getKakaoProfile(token);
+
+		String email = kakaoProfile.kakao_account().email();
+		String nickname = kakaoProfile.properties().nickname();
+
+		User kakaoUser = userRepository.findByEmail(email)
+			.orElseGet(() -> createUser(email, nickname, true));
+
+		log.info("[USER_LOGIN] 로그인 성공 : email={}, name={}", kakaoUser.getEmail(), kakaoUser.getName());
+
+		return jwtProvider.generateToken(kakaoUser.getId(), kakaoUser.getEmail(), kakaoUser.getAuthority().toString(),
+			kakaoUser.getIsMember());
+	}
+
 }

--- a/src/main/java/com/dnd/moddo/domain/auth/service/KakaoClient.java
+++ b/src/main/java/com/dnd/moddo/domain/auth/service/KakaoClient.java
@@ -1,0 +1,84 @@
+package com.dnd.moddo.domain.auth.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientResponseException;
+
+import com.dnd.moddo.domain.auth.dto.KakaoProfile;
+import com.dnd.moddo.domain.auth.dto.KakaoTokenResponse;
+import com.dnd.moddo.global.exception.ModdoException;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RequiredArgsConstructor
+@Slf4j
+@Component
+public class KakaoClient {
+
+	@Value("${kakao.auth.client_id}")
+	String client_id;
+
+	@Value("${kakao.auth.redirect_uri}")
+	String redirect_uri;
+
+	private final RestClient.Builder builder;
+
+	public KakaoTokenResponse join(String code) {
+		RestClient restClient = builder.build();
+
+		String uri = "https://kauth.kakao.com/oauth/token";
+
+		MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+		params.add("grant_type", "authorization_code");
+		params.add("client_id", client_id);
+		params.add("redirect_uri", redirect_uri);
+		params.add("code", code);
+
+		try {
+			return restClient.post()
+				.uri(uri)
+				.header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+				.body(params)
+				.retrieve()
+				.body(KakaoTokenResponse.class);
+
+		} catch (RestClientResponseException e) {
+			log.error("[KAKAO_API][GET_TOKEN][HTTP_ERROR] HTTP 에러 발생: status={}, body={}", e.getStatusCode(),
+				e.getResponseBodyAsString());
+			throw new ModdoException(HttpStatus.INTERNAL_SERVER_ERROR, "카카오 API HTTP 에러");
+		} catch (Exception e) {
+			log.info("[USER_LOGIN_FAIL] 로그인 실패 : code = {}", code);
+			throw new IllegalArgumentException(e.getMessage());
+		}
+	}
+
+	public KakaoProfile getKakaoProfile(String token) {
+		RestClient restClient = builder.build();
+
+		String uri = "https://kapi.kakao.com/v2/user/me";
+
+		try {
+			return restClient.get()
+				.uri(uri)
+				.header("Authorization", "Bearer " + token)
+				.header("Content-Type", "application/x-www-form-urlencoded;charset=UTF-8")
+				.retrieve()
+				.body(KakaoProfile.class);
+
+		} catch (RestClientResponseException e) {
+			log.error("[KAKAO_API][GET_PROFILE][HTTP_ERROR] HTTP 에러 발생: status={}, body={}", e.getStatusCode(),
+				e.getResponseBodyAsString());
+			throw new ModdoException(HttpStatus.INTERNAL_SERVER_ERROR, "카카오 API HTTP 에러");
+		} catch (Exception e) {
+			log.error("[KAKAO_CALLBACK_ERROR] 카카오 콜백 처리 실패", e);
+			throw new ModdoException(HttpStatus.INTERNAL_SERVER_ERROR, "카카오 콜백 처리 실패");
+		}
+	}
+}

--- a/src/main/java/com/dnd/moddo/global/jwt/properties/CookieProperties.java
+++ b/src/main/java/com/dnd/moddo/global/jwt/properties/CookieProperties.java
@@ -1,0 +1,16 @@
+package com.dnd.moddo.global.jwt.properties;
+
+import java.time.Duration;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "cookie")
+public record CookieProperties(
+	boolean httpOnly,
+	boolean secure,
+	String domain,
+	String path,
+	String sameSite,
+	Duration maxAge
+) {
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,10 +25,12 @@ management:
       exposure:
         include: health,info,prometheus
 
-#logging:
-#  level:
-#    org.springframework.web: DEBUG
-#    org.springframework.web.servlet.DispatcherServlet: DEBUG
+cookie:
+  http-only: false
+  path: /
+  same-site: none
+  max-age: 7D
+
 ---
 
 spring:

--- a/src/test/java/com/dnd/moddo/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/dnd/moddo/domain/auth/controller/AuthControllerTest.java
@@ -39,6 +39,9 @@ class AuthControllerTest extends RestDocsTestSupport {
 			.andExpect(jsonPath("$.refreshToken").value("refresh-token"))
 			.andExpect(jsonPath("$.isMember").value(false))
 			.andDo(restDocs.document(
+				responseHeaders(
+					headerWithName("Set-Cookie").description("엑세스 토큰")
+				),
 				responseFields(
 					fieldWithPath("accessToken").type(JsonFieldType.STRING).description("액세스 토큰"),
 					fieldWithPath("refreshToken").type(JsonFieldType.STRING).description("리프레시 토큰"),

--- a/src/test/java/com/dnd/moddo/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/auth/service/AuthServiceTest.java
@@ -1,0 +1,130 @@
+package com.dnd.moddo.domain.auth.service;
+
+import static com.dnd.moddo.global.support.UserTestFactory.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.dnd.moddo.domain.auth.dto.KakaoProfile;
+import com.dnd.moddo.domain.user.entity.User;
+import com.dnd.moddo.domain.user.repository.UserRepository;
+import com.dnd.moddo.global.jwt.dto.TokenResponse;
+import com.dnd.moddo.global.jwt.utill.JwtProvider;
+
+@ExtendWith(MockitoExtension.class)
+public class AuthServiceTest {
+	@Mock
+	private UserRepository userRepository;
+	@Mock
+	private JwtProvider jwtProvider;
+	@Mock
+	private KakaoClient kakaoClient;
+	@InjectMocks
+	private AuthService authService;
+
+	@DisplayName("게스트 회원을 생성하면 저장되고 토큰이 발급된다")
+	@Test
+	void whenCreateGuestUser_thenSaveAndIssueToken() {
+		//given
+		User user = createGuestDefault();
+		when(userRepository.save(any(User.class))).thenReturn(user);
+		//when
+		TokenResponse response = authService.createGuestUser();
+		//then
+		verify(userRepository, times(1)).save(any(User.class));
+	}
+
+	@DisplayName("기존 카카오 사용자가 로그인하면 토큰을 발급한다")
+	@Test
+	void whenKakaoUserExists_thenTokenIsIssued() {
+		//given
+		String token = "test_token";
+		KakaoProfile kakaoProfile = new KakaoProfile(
+			12345L,
+			"2025.06.29T00:00:00",
+			new KakaoProfile.Properties(
+				"테스트유저",
+				"profile_image",
+				"thumbnail_image"
+			),
+			new KakaoProfile.KakaoAccount(
+				true,
+				true,
+				new KakaoProfile.Profile(
+					"테스트 유저",
+					"thumbnail_image_url",
+					"profile_image_url",
+					true,
+					true
+				),
+				true,
+				true,
+				true,
+				true,
+				"test@example.com"
+			)
+		);
+		String email = kakaoProfile.kakao_account().email();
+		User user = createWithEmail(email);
+		when(kakaoClient.getKakaoProfile(anyString())).thenReturn(kakaoProfile);
+		when(userRepository.findByEmail(anyString())).thenReturn(Optional.of(user));
+
+		//when
+		TokenResponse response = authService.getOrCreateKakaoUserToken(token);
+
+		//then
+		verify(jwtProvider, times(1)).generateToken(any(), anyString(), anyString(), anyBoolean());
+	}
+
+	@DisplayName("신규 카카오 사용자가 로그인하면 회원가입 후 토큰을 발급한다")
+	@Test
+	void whenNewKakaoUser_thenRegisterAndIssueToken() {
+		//given
+		String token = "test_token";
+		KakaoProfile kakaoProfile = new KakaoProfile(
+			12345L,
+			"2025.06.29T00:00:00",
+			new KakaoProfile.Properties(
+				"테스트유저",
+				"profile_image",
+				"thumbnail_image"
+			),
+			new KakaoProfile.KakaoAccount(
+				true,
+				true,
+				new KakaoProfile.Profile(
+					"테스트 유저",
+					"thumbnail_image_url",
+					"profile_image_url",
+					true,
+					true
+				),
+				true,
+				true,
+				true,
+				true,
+				"test@example.com"
+			)
+		);
+		String email = kakaoProfile.kakao_account().email();
+		User user = createWithEmail(email);
+
+		when(kakaoClient.getKakaoProfile(anyString())).thenReturn(kakaoProfile);
+		when(userRepository.findByEmail(anyString())).thenReturn(Optional.empty());
+		when(userRepository.save(any(User.class))).thenReturn(user);
+
+		//when
+		TokenResponse response = authService.getOrCreateKakaoUserToken(token);
+
+		//then
+		verify(userRepository, times(1)).save(any(User.class));
+		verify(jwtProvider, times(1)).generateToken(any(), anyString(), anyString(), anyBoolean());
+	}
+}

--- a/src/test/java/com/dnd/moddo/domain/auth/service/KakaoClientTest.java
+++ b/src/test/java/com/dnd/moddo/domain/auth/service/KakaoClientTest.java
@@ -1,0 +1,171 @@
+package com.dnd.moddo.domain.auth.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.*;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.*;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+import com.dnd.moddo.domain.auth.dto.KakaoProfile;
+import com.dnd.moddo.domain.auth.dto.KakaoTokenResponse;
+
+@ExtendWith(SpringExtension.class)
+@RestClientTest(value = KakaoClient.class)
+public class KakaoClientTest {
+	@Autowired
+	private KakaoClient kakaoClient;
+
+	@Autowired
+	private MockRestServiceServer mockServer;
+
+	@Value("${kakao.auth.client_id}")
+	private String clientId;
+
+	@Value("${kakao.auth.redirect_uri}")
+	private String redirectUri;
+
+	@AfterEach
+	void tearDown() {
+		mockServer.reset();
+	}
+
+	@DisplayName("카카오 인가 코드로 토큰 요청하면 OauthToken을 반환한다")
+	@Test
+	void whenRequestKakaoAccessToken_thenReturnOauthToken() throws Exception {
+		// given
+		String code = "test-code";
+
+		MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+		params.add("code", "test-code");
+		params.add("grant_type", "authorization-code");
+		params.add("client_id", clientId);
+		params.add("redirect_uri", redirectUri);
+
+		String expectResponse = """
+			{
+			  "access_token": "test-token",
+			  "token_type": "bearer",
+			  "refresh_token": "refresh-token",
+			  "expires_in": 3600,
+			  "scope": "profile",
+			  "refresh_token_expires_in": 7200
+			}
+			""";
+
+		mockServer.expect(requestTo("https://kauth.kakao.com/oauth/token"))
+			.andExpect(method(HttpMethod.POST))
+			.andExpect(header("Content-Type", "application/x-www-form-urlencoded;charset=UTF-8"))
+			.andExpect(content().formData(params))
+			.andRespond(withSuccess(expectResponse, MediaType.APPLICATION_JSON));
+		// when
+		KakaoTokenResponse result = kakaoClient.join("test-code");
+
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result.access_token()).isEqualTo("test-token");
+	}
+
+	@DisplayName("잘못된 인가 코드로 토큰 요청 시 IllegalArgumentException이 발생한다")
+	@Test
+	void whenRequestKakaoAccessTokenWithInvalidCode_thenThrowException() {
+		//given
+		String code = "invalid_code";
+
+		MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+		params.add("code", "invalid-code");
+		params.add("grant_type", "authorization-code");
+		params.add("client_id", clientId);
+		params.add("redirect_uri", redirectUri);
+
+		mockServer.expect(requestTo("https://kauth.kakao.com/oauth/token"))
+			.andExpect(method(HttpMethod.POST))
+			.andExpect(header("Content-Type", "application/x-www-form-urlencoded;charset=UTF-8"))
+			.andExpect(content().formData(params))
+			.andRespond(withStatus(HttpStatus.BAD_REQUEST));
+
+		//when & then
+		assertThatThrownBy(() -> kakaoClient.join(code))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("400");
+	}
+
+	@DisplayName("정상 토큰으로 카카오 프로필 요청 시 KakaoProfile이 반환된다")
+	@Test
+	void whenGetKakaoProfile_thenReturnKakaoProfile() {
+		// given
+		String token = "test_token";
+
+		String expectResponse = """
+			{
+			  "id": 12345,
+			  "connected_at": "2025.06.29T00:00:00",
+			  "properties": {
+				"nickname": "테스트유저",
+				"profile_image": "profile_image",
+				"thumbnail_image": "thumbnail_image"
+			  },
+			  "kakao_account": {
+				"profile_nickname_needs_agreement": true,
+				"profile_image_needs_agreement": true,
+				"profile": {
+				  "nickname": "테스트 유저",
+				  "thumbnail_image_url": "thumbnail_image_url",
+				  "profile_image_url": "profile_image_url",
+				  "is_default_image": true,
+				  "is_default_nickname": true
+				},
+				"has_email": true,
+				"email_needs_agreement": true,
+				"is_email_valid": true,
+				"is_email_verified": true,
+				"email": "test@example.com"
+			  }
+			}
+			""";
+
+		mockServer.expect(requestTo("https://kapi.kakao.com/v2/user/me"))
+			.andExpect(method(HttpMethod.GET))
+			.andExpect(header("Content-Type", "application/x-www-form-urlencoded;charset=UTF-8"))
+			.andExpect(header("Authorization", "Bearer " + token))
+			.andRespond(withSuccess(expectResponse, MediaType.APPLICATION_JSON));
+
+		// when
+		KakaoProfile profile = kakaoClient.getKakaoProfile(token);
+
+		// then
+		assertThat(profile).isNotNull();
+		assertThat(profile.id()).isEqualTo(12345L);
+		assertThat(profile.kakao_account().email()).isEqualTo("test@example.com");
+		assertThat(profile.properties().nickname()).isEqualTo("테스트유저");
+	}
+
+	@DisplayName("카카오 API에서 에러가 발생하면 IllegalArgumentException이 발생한다")
+	@Test
+	void whenGetKakaoProfileWithHttpError_thenThrowException() {
+		// given
+		String token = "test_token";
+
+		mockServer.expect(requestTo("https://kapi.kakao.com/v2/user/me"))
+			.andExpect(method(HttpMethod.GET))
+			.andExpect(header("Content-Type", "application/x-www-form-urlencoded;charset=UTF-8"))
+			.andExpect(header("Authorization", "Bearer " + token))
+			.andRespond(withServerError());
+
+		// when & then
+		assertThatThrownBy(() -> kakaoClient.getKakaoProfile(token))
+			.isInstanceOf(IllegalArgumentException.class);
+	}
+}

--- a/src/test/java/com/dnd/moddo/domain/auth/service/RefreshTokenServiceTest.java
+++ b/src/test/java/com/dnd/moddo/domain/auth/service/RefreshTokenServiceTest.java
@@ -1,7 +1,6 @@
 package com.dnd.moddo.domain.auth.service;
 
-import static org.assertj.core.api.BDDAssertions.then;
-import static org.assertj.core.api.BDDAssertions.thenThrownBy;
+import static org.assertj.core.api.BDDAssertions.*;
 import static org.mockito.Mockito.*;
 
 import java.time.LocalDateTime;
@@ -29,61 +28,62 @@ import io.jsonwebtoken.JwtException;
 
 @ExtendWith(MockitoExtension.class)
 public class RefreshTokenServiceTest {
-    @Mock
-    private JwtUtil jwtUtil;
+	@Mock
+	private JwtUtil jwtUtil;
 
-    @Mock
-    private UserRepository userRepository;
+	@Mock
+	private UserRepository userRepository;
 
-    @Mock
-    private JwtProvider jwtProvider;
+	@Mock
+	private JwtProvider jwtProvider;
 
-    @InjectMocks
-    private RefreshTokenService refreshTokenService;
+	@InjectMocks
+	private RefreshTokenService refreshTokenService;
 
-    @BeforeEach
-    void setUp() {
-    }
+	@BeforeEach
+	void setUp() {
+	}
 
-    @Test
-    public void reissueAccessToken() {
-        // given
-        String validToken = "validToken";
-        String email = "test@example.com";
-        Long userId = 1L;
-        String role = "USER";
-        String newAccessToken = "newAccessToken";
+	@Test
+	public void reissueAccessToken() {
+		// given
+		String validToken = "validToken";
+		String email = "test@example.com";
+		Long userId = 1L;
+		String role = "USER";
+		String newAccessToken = "newAccessToken";
 
-        Jws<Claims> mockJws = mock(Jws.class);
-        Claims mockClaims = mock(Claims.class);
+		Jws<Claims> mockJws = mock(Jws.class);
+		Claims mockClaims = mock(Claims.class);
 
-        when(jwtUtil.getJwt(any())).thenReturn(mockJws);
-        when(mockJws.getBody()).thenReturn(mockClaims);
-        when(mockClaims.get(JwtConstants.EMAIL.message)).thenReturn(email);
+		when(jwtUtil.getJwt(any())).thenReturn(mockJws);
+		when(mockJws.getBody()).thenReturn(mockClaims);
+		when(mockClaims.get(JwtConstants.EMAIL.message)).thenReturn(email);
 
-        User user = new User("name", email, role, true, Authority.USER, LocalDateTime.now(), LocalDateTime.now().plusDays(1));
-        ReflectionTestUtils.setField(user, "id", userId);
+		User user = new User("name", email, role, true, Authority.USER, LocalDateTime.now(),
+			LocalDateTime.now().plusDays(1));
+		ReflectionTestUtils.setField(user, "id", userId);
 
-        when(userRepository.getByEmail(email)).thenReturn(user);
-        when(jwtProvider.generateAccessToken(userId, email, role)).thenReturn(newAccessToken);
+		when(userRepository.getByEmail(email)).thenReturn(user);
+		when(jwtProvider.generateAccessToken(userId, email, role)).thenReturn(newAccessToken);
 
-        // when
-        RefreshResponse response = refreshTokenService.execute(validToken);
+		// when
+		RefreshResponse response = refreshTokenService.execute(validToken);
 
-        // then
-        then(response.getAccessToken()).isEqualTo(newAccessToken);
-        verify(userRepository, times(1)).getByEmail(email);
-        verify(jwtProvider, times(1)).generateAccessToken(userId, email, role);
-    }
+		// then
+		then(response.getAccessToken()).isEqualTo(newAccessToken);
+		verify(userRepository, times(1)).getByEmail(email);
+		verify(jwtProvider, times(1)).generateAccessToken(userId, email, role);
+	}
 
-    @Test
-    public void shouldThrowOnInvalidToken() {
-        // given
-        String invalidToken = "invalidToken";
-        when(jwtUtil.getJwt(any())).thenThrow(new JwtException("Invalid token"));
+	@Test
+	public void shouldThrowOnInvalidToken() {
+		// given
+		String invalidToken = "invalidToken";
+		when(jwtUtil.getJwt(any())).thenThrow(new JwtException("Invalid token"));
 
-        // when & then
-        thenThrownBy(() -> refreshTokenService.execute(invalidToken))
-                .isInstanceOf(TokenInvalidException.class);
-    }
+		// when & then
+		thenThrownBy(() -> refreshTokenService.execute(invalidToken))
+			.isInstanceOf(TokenInvalidException.class);
+	}
 }

--- a/src/test/java/com/dnd/moddo/global/support/UserTestFactory.java
+++ b/src/test/java/com/dnd/moddo/global/support/UserTestFactory.java
@@ -1,0 +1,4 @@
+package com.dnd.moddo.global.support;
+
+public class UserTestFactory {
+}

--- a/src/test/java/com/dnd/moddo/global/support/UserTestFactory.java
+++ b/src/test/java/com/dnd/moddo/global/support/UserTestFactory.java
@@ -1,4 +1,35 @@
 package com.dnd.moddo.global.support;
 
+import static com.dnd.moddo.domain.user.entity.type.Authority.*;
+
+import java.time.LocalDateTime;
+
+import com.dnd.moddo.domain.user.entity.User;
+
 public class UserTestFactory {
+	public static User createGuestDefault() {
+		LocalDateTime time = LocalDateTime.now();
+
+		return new User(
+			"연노른자",
+			"guest-UUID1@guest.com",
+			"profile.png",
+			false,
+			USER,
+			time,
+			time.plusDays(7));
+	}
+
+	public static User createWithEmail(String email) {
+		LocalDateTime time = LocalDateTime.now();
+
+		return new User(
+			"연노른자",
+			email,
+			"profile.png",
+			true,
+			USER,
+			time,
+			time.plusDays(7));
+	}
 }

--- a/src/test/java/com/dnd/moddo/global/util/ControllerTest.java
+++ b/src/test/java/com/dnd/moddo/global/util/ControllerTest.java
@@ -8,6 +8,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import com.dnd.moddo.domain.auth.controller.AuthController;
 import com.dnd.moddo.domain.auth.service.AuthService;
+import com.dnd.moddo.domain.auth.service.KakaoClient;
 import com.dnd.moddo.domain.auth.service.RefreshTokenService;
 import com.dnd.moddo.domain.character.controller.CharacterController;
 import com.dnd.moddo.domain.character.service.QueryCharacterService;
@@ -54,6 +55,9 @@ public abstract class ControllerTest {
 
 	@MockBean
 	protected AuthService authService;
+
+	@MockBean
+	protected KakaoClient kakaoClient;
 
 	@MockBean
 	protected RefreshTokenService refreshTokenService;

--- a/src/test/java/com/dnd/moddo/integration/CacheIntegrationTest.java
+++ b/src/test/java/com/dnd/moddo/integration/CacheIntegrationTest.java
@@ -3,6 +3,7 @@ package com.dnd.moddo.integration;
 import static org.assertj.core.api.AssertionsForClassTypes.*;
 import static org.mockito.Mockito.*;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -61,6 +62,11 @@ public class CacheIntegrationTest {
 	@BeforeEach
 	void setUp() {
 		groupRepository.save(GroupTestFactory.createDefault());
+	}
+
+	@AfterEach
+	void tearDown() {
+		redis.close();
 	}
 
 	@DisplayName("groupCode로 groupId를 조회하면 Redis에 캐싱되고, 같은 코드로 재조회 시 캐시에서 반환한다")

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -38,7 +38,6 @@ aws:
     static: ap-northeast-2
 
 cookie:
-  domain: moddo.kro.kr
   secure: true
   http-only: false
   path: /

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -36,3 +36,8 @@ aws:
     secret-key: secretKeysecretKeysecretKeysecretKeysecretKeysecretKey
   region:
     static: ap-northeast-2
+
+kakao:
+  auth:
+    client_id: clientidclientidclientidclientidclientidclientidclientid
+    redirect_uri: http://localhost:8080/api/v1/login/kakao/callback

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -37,6 +37,15 @@ aws:
   region:
     static: ap-northeast-2
 
+cookie:
+  domain: moddo.kro.kr
+  secure: true
+  http-only: false
+  path: /
+  same-site: none
+  max-age: 7D
+
+
 kakao:
   auth:
     client_id: clientidclientidclientidclientidclientidclientidclientid


### PR DESCRIPTION
### #️⃣연관된 이슈
#140 

### 🔀반영 브랜치
feat/#140-kakao-login -> develop

### 🔧변경 사항
- CI/CD 워크플로우를 수정하였습니다.
  - 기존에는 `docker compose down` 명령어로 Redis와 서비스 컨테이너를 모두 중지시켰으나
  - 이제는 서비스 컨테이너만 중지, 삭제, 재실행하여 Redis 등 인프라 환경은 그대로 유지되도록 개선하였습니다.
- 카카오 소셜 로그인 기능을 추가하였습니다.
  - 카카오 인가 코드를 발급받아 백엔드의 redirect URI로 전달되도록 구현하였습니다.
  - 기존에는 Access Token을 Response Body에 담아 전달했지만 카카오 로그인은 redirect 방식이기 때문에 Response Body를 활용할 수 없었습니다.
  - 이에 따라 Access Token을 쿠키에 담아 클라이언트에 전달하는 방식으로 변경하였습니다.

### 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요
